### PR TITLE
Fix argument order for addcsr call.

### DIFF
--- a/src/ca-cli-callbacks.c
+++ b/src/ca-cli-callbacks.c
@@ -301,7 +301,7 @@ int ca_cli_callback_addcsr (int argc, char **argv)
 		TlsCert *tlscert = NULL;
 		gchar *pem = NULL;
 
-		pem = ca_file_get_public_pem_from_id (ca_id, CA_FILE_ELEMENT_TYPE_CERT);
+		pem = ca_file_get_public_pem_from_id (CA_FILE_ELEMENT_TYPE_CERT, ca_id);
 		g_assert (pem);
 
                 tlscert = tls_parse_cert_pem (pem);


### PR DESCRIPTION
Fix argument order in call to ca_file_get_public_pem_from_id . This is causing a segfault, and the bug described here: https://sourceforge.net/p/gnomint/mailman/message/24607412/