### PR TITLE
Allow setting of cflags and remove -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,9 +182,9 @@ dnl
 
 dnl
 if test "x$GCC" = "xyes"; then
-	CFLAGS="-Wall -Werror "
+	CFLAGS+="-Wall "
 	if test "x$use_debug" = "xYes"; then
-   	   CFLAGS="$CFLAGS -g -O0"
+   	   CFLAGS+="$CFLAGS -g -O0"
 	fi
 fi
 


### PR DESCRIPTION
The -Werror flag was removed as per the ChangeLog in February 2014 on commit: 29f551e01808928abf2f95f0b4d1dfd108225de8, this seems to have been re-added.
Adding additional CFLAGS compile options causes build failures as it errors out.