### PR TITLE
Update for Glib > 2.32

### DIFF
--- a/src/ca_creation.c
+++ b/src/ca_creation.c
@@ -29,7 +29,7 @@
 
 gint ca_creation_is_launched = -1;
 
-static GMutex ca_creation_thread_status_mutex = G_STATIC_MUTEX_INIT;
+static GMutex ca_creation_thread_status_mutex;
 gint ca_creation_thread_status = 0;
 gchar * ca_creation_message = "";
 

--- a/src/ca_file.h
+++ b/src/ca_file.h
@@ -69,16 +69,17 @@ gchar * ca_file_revoke_crt_with_date (guint64 id, time_t date);
 
 GList * ca_file_get_revoked_certs (guint64 ca_id, gchar **error);
 
-enum {CA_FILE_CA_COLUMN_ID=0,
+// CaFileCAColumns
+enum CaFileCAColumns {CA_FILE_CA_COLUMN_ID=0,
       CA_FILE_CA_COLUMN_SERIAL=1,
       CA_FILE_CA_COLUMN_SUBJECT=2,
       CA_FILE_CA_COLUMN_DN=3,
       CA_FILE_CA_COLUMN_PARENT_DN=4,
       CA_FILE_CA_COLUMN_PEM=5,
-      CA_FILE_CA_COLUMN_NUMBER=6}
-        CaFileCAColumns;
+      CA_FILE_CA_COLUMN_NUMBER=6};
 
-enum {CA_FILE_CERT_COLUMN_ID=0,
+// CaFileCertColumns
+enum CaFileCertColumns {CA_FILE_CERT_COLUMN_ID=0,
       CA_FILE_CERT_COLUMN_IS_CA=1,
       CA_FILE_CERT_COLUMN_SERIAL=2,
       CA_FILE_CERT_COLUMN_SUBJECT=3,
@@ -90,16 +91,15 @@ enum {CA_FILE_CERT_COLUMN_ID=0,
       CA_FILE_CERT_COLUMN_DN=9,
       CA_FILE_CERT_COLUMN_PARENT_DN=10,
       CA_FILE_CERT_COLUMN_PARENT_ROUTE=11,
-      CA_FILE_CERT_COLUMN_NUMBER=12}
-        CaFileCertColumns;
+      CA_FILE_CERT_COLUMN_NUMBER=12};
 
-enum {CA_FILE_CSR_COLUMN_ID=0,
+// CaFileCSRColumns
+enum CaFileCSRColumns {CA_FILE_CSR_COLUMN_ID=0,
       CA_FILE_CSR_COLUMN_SUBJECT=1,
       CA_FILE_CSR_COLUMN_PRIVATE_KEY_IN_DB=2,
       CA_FILE_CSR_COLUMN_PEM=3,
       CA_FILE_CSR_COLUMN_PARENT_ID=4,
-      CA_FILE_CSR_COLUMN_NUMBER=5}
-        CaFileCSRColumns;
+      CA_FILE_CSR_COLUMN_NUMBER=5};
 
 
 gboolean ca_file_foreach_ca (CaFileCallbackFunc func, gpointer userdata);

--- a/src/csr_creation.c
+++ b/src/csr_creation.c
@@ -29,7 +29,7 @@
 
 gint csr_creation_is_launched = -1;
 
-static GMutex csr_creation_thread_status_mutex = G_STATIC_MUTEX_INIT;
+static GMutex csr_creation_thread_status_mutex;
 gint csr_creation_thread_status = 0;
 gchar * csr_creation_message = "";
 


### PR DESCRIPTION
Updated GMutex initialization to be compatible with Glib > 2.32. Also removed variable definitions for some enums in ca_file.h so ld would quit complaining about multiple definitions.