### PR TITLE
Add headless Wayland workflow tests (Phase 2A of #43)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,7 +35,8 @@ jobs:
             libgdk-pixbuf2.0-dev \
             gettext \
             intltool \
-            iso-codes
+            iso-codes \
+            weston
       
       - name: Verify dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ po/gnomint.pot
 src/test_y2k38
 test-driver
 tests/check_ui_consistency
+tests/check_workflows
 tests/check_y2k38
 tests/*.log
 tests/*.trs

--- a/gui/csr_properties_dialog.ui
+++ b/gui/csr_properties_dialog.ui
@@ -235,22 +235,6 @@
                 <property name="tab_fill">False</property>
               </packing>
             </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel" id="label139">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Details</property>
-                <property name="xalign">0</property>
-                <property name="yalign">0</property>
-              </object>
-              <packing>
-                <property name="position">1</property>
-                <property name="tab_fill">False</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,14 +1,23 @@
 ## tests/Makefile.am — make check harness
 ##
-## Two stages are planned; this file implements stage 1 (see issue #42).
-##
+## Stage 1 — static checks, no display needed (issue #42, landed):
 ##   check_y2k38             Standalone Y2K38 verification (was src/test_y2k38.c)
 ##   check_ui_consistency    Static .ui consistency checker
 ##
-## Stage 2 (issue #43) will add check_workflows running under Xvfb.
+## Stage 2A — runtime checks under headless Wayland (issue #43):
+##   check_workflows         GTK workflow regression tests, run via
+##                           run-headless.sh which spawns weston with
+##                           the headless backend. Gnomint's primary
+##                           user environment is Wayland.
 
-TESTS = check_y2k38 check_ui_consistency
+TESTS = check_y2k38 check_ui_consistency check_workflows
 check_PROGRAMS = $(TESTS)
+
+# Per-test wrapper: only check_workflows runs under a headless Wayland
+# compositor. The static tests stay display-free.
+check_workflows_LOG_COMPILER = $(srcdir)/run-headless.sh
+
+EXTRA_DIST = run-headless.sh
 
 # ---------------------------------------------------------------
 # Y2K38 verification — no GUI dependencies, just stdio + time.h.
@@ -85,4 +94,62 @@ check_ui_consistency_LDADD = \
 	-ldl
 
 check_ui_consistency_LDFLAGS = \
+	-export-dynamic
+
+# ---------------------------------------------------------------
+# check_workflows — runtime GTK workflow tests under headless Wayland.
+# Links the same GUI object files as check_ui_consistency so populate
+# functions and global builders are reachable. Run by run-headless.sh
+# which manages a weston subprocess.
+# ---------------------------------------------------------------
+
+check_workflows_SOURCES = \
+	check_workflows.c \
+	$(top_srcdir)/src/main.c \
+	$(top_srcdir)/src/country_table.c \
+	$(top_srcdir)/src/new_ca_window.c \
+	$(top_srcdir)/src/new_req_window.c \
+	$(top_srcdir)/src/new_cert.c \
+	$(top_srcdir)/src/creation_process_window.c \
+	$(top_srcdir)/src/dialog.c \
+	$(top_srcdir)/src/ca.c \
+	$(top_srcdir)/src/ca_creation.c \
+	$(top_srcdir)/src/tls.c \
+	$(top_srcdir)/src/ca_file.c \
+	$(top_srcdir)/src/certificate_properties.c \
+	$(top_srcdir)/src/ca_policy.c \
+	$(top_srcdir)/src/csr_creation.c \
+	$(top_srcdir)/src/csr_properties.c \
+	$(top_srcdir)/src/pkey_manage.c \
+	$(top_srcdir)/src/preferences-gui.c \
+	$(top_srcdir)/src/preferences-window.c \
+	$(top_srcdir)/src/crl.c \
+	$(top_srcdir)/src/uint160.c \
+	$(top_srcdir)/src/import.c \
+	$(top_srcdir)/src/export.c \
+	$(top_srcdir)/src/san_manager.c
+
+check_workflows_CFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_builddir) \
+	-I$(top_srcdir)/src \
+	$(GNOMINT_CFLAGS) \
+	$(LIBGNUTLS_CFLAGS) \
+	$(LIBGCRYPT_CFLAGS) \
+	$(SQLITE_CFLAGS) \
+	-DPACKAGE_DATA_DIR=\""$(datadir)"\" \
+	-DGNOMINT_UI_DIR=\""$(abs_top_srcdir)/gui"\" \
+	-DTEST_PEM_PATH=\""$(abs_top_srcdir)/certs/davefx.pem"\" \
+	-DCOMPILATION_DATE=`date +%s` \
+	-DHAVE_CONFIG_H \
+	-DGNOMINT_UI_TEST
+
+check_workflows_LDADD = \
+	$(GNOMINT_LIBS) \
+	$(LIBGCRYPT_LIBS) \
+	$(LIBGNUTLS_LIBS) \
+	$(SQLITE_LIBS) \
+	$(LTLIBINTL)
+
+check_workflows_LDFLAGS = \
 	-export-dynamic

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -1,0 +1,319 @@
+/*
+ * check_workflows.c — Phase 2A runtime workflow regression tests.
+ *
+ * Runs under a headless Wayland compositor (weston, started by
+ * tests/run-headless.sh) with GDK_BACKEND=wayland. Wayland is gnomint's
+ * primary user environment, so we exercise GTK's Wayland backend rather
+ * than X11.
+ *
+ * Scope (issue #43, Phase 2A):
+ *
+ *   1. Smoke: gtk_init succeeds under Wayland; every .ui file in gui/
+ *      loads via gtk_builder_add_from_file without any GTK CRITICAL
+ *      warnings. Complements check_ui_consistency (static XML scan)
+ *      by exercising GTK's actual parser and widget construction on
+ *      the Wayland code path.
+ *
+ *   2. Certificate properties populate: build certificate_properties_dialog.ui
+ *      via GtkBuilder, then call gnomint's __certificate_properties_populate
+ *      with a known cert PEM. Assert that key widgets received their text.
+ *      Catches widget-ID drift between certificate_properties.c and the .ui
+ *      that the static checker can't see — the static check only knows
+ *      about <signal handler="..."> references, not gtk_builder_get_object
+ *      lookups inside .c files.
+ *
+ * Phase 2B (dialog auto-dismiss + the five workflow scenarios in #43)
+ * is intentionally not implemented here; see the issue for the split.
+ *
+ * Any G_LOG_LEVEL_CRITICAL or G_LOG_LEVEL_WARNING from Gtk/Gdk/GLib
+ * fails the run. The handler counts hits and records them; tests check
+ * the counter before/after each scenario.
+ *
+ * Exit codes: 0 = all pass; 1 = at least one failure.
+ */
+
+#include <dirent.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <gtk/gtk.h>
+
+#ifndef GNOMINT_UI_DIR
+# error "GNOMINT_UI_DIR must be set at compile time (path to gui/)"
+#endif
+#ifndef TEST_PEM_PATH
+# error "TEST_PEM_PATH must be set at compile time (path to a sample cert PEM)"
+#endif
+
+/* External symbols from src/certificate_properties.c that we drive
+ * directly. Both are global (not static) — see the .c file. */
+extern GtkBuilder *certificate_properties_window_gtkb;
+extern void        __certificate_properties_populate (const char *pem);
+
+/* Globals from src/main.c that other linked GUI files reference. */
+extern GtkBuilder *main_window_gtkb;
+
+/* ------------------------------------------------------------------ */
+/*  Failure tracking + critical-log capture                           */
+/* ------------------------------------------------------------------ */
+
+static int g_failures = 0;
+static int g_critical_count = 0;
+static GPtrArray *g_critical_messages;    /* of gchar*, owning */
+
+static void
+fail_test (const char *test, const char *fmt, ...) G_GNUC_PRINTF (2, 3);
+
+static void
+fail_test (const char *test, const char *fmt, ...)
+{
+    va_list ap;
+    fprintf (stderr, "  FAIL [%s] ", test);
+    va_start (ap, fmt);
+    vfprintf (stderr, fmt, ap);
+    va_end (ap);
+    fputc ('\n', stderr);
+    g_failures++;
+}
+
+/* GLib ≥ 2.50 routes all g_log() output through g_log_writer_func, which
+ * bypasses g_log_set_handler(). We install a writer that captures the
+ * critical/warning levels we care about and tells GLib we handled the
+ * message (no fallthrough to the default writer / stderr). */
+static GLogWriterOutput
+critical_log_writer (GLogLevelFlags         log_level,
+                     const GLogField       *fields,
+                     gsize                  n_fields,
+                     gpointer               user_data G_GNUC_UNUSED)
+{
+    /* Anything below WARNING (info/debug/message) we let through unchanged. */
+    if (!(log_level & (G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING)))
+        return g_log_writer_default (log_level, fields, n_fields, NULL);
+
+    const char *domain = "(no-domain)";
+    const char *message = "(no message)";
+    for (gsize i = 0; i < n_fields; i++) {
+        if (g_strcmp0 (fields[i].key, "GLIB_DOMAIN") == 0 && fields[i].value)
+            domain = fields[i].value;
+        else if (g_strcmp0 (fields[i].key, "MESSAGE") == 0 && fields[i].value)
+            message = fields[i].value;
+    }
+
+    g_critical_count++;
+    g_ptr_array_add (g_critical_messages,
+                     g_strdup_printf ("%s: %s", domain, message));
+    return G_LOG_WRITER_HANDLED;
+}
+
+/* Returns the number of critical/warning messages logged since the last
+ * call to critical_messages_reset(). Snapshots so a scenario can capture
+ * messages it triggered without disturbing later scenarios. */
+static int
+critical_messages_check_and_reset (const char *scenario)
+{
+    int n = (int) g_critical_messages->len;
+    if (n > 0) {
+        guint i;
+        for (i = 0; i < g_critical_messages->len; i++) {
+            fail_test (scenario, "GTK/GLib critical: %s",
+                       (const char *) g_ptr_array_index (g_critical_messages, i));
+        }
+    }
+    g_ptr_array_set_size (g_critical_messages, 0);
+    g_critical_count = 0;
+    return n;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Scenario 1: every .ui file loads via GtkBuilder under Wayland     */
+/* ------------------------------------------------------------------ */
+
+static int
+scenario_all_ui_files_load (void)
+{
+    DIR           *d;
+    struct dirent *de;
+    int            scanned = 0;
+    int            failed_files = 0;
+
+    fprintf (stderr, "==> scenario: all .ui files load via GtkBuilder\n");
+
+    d = opendir (GNOMINT_UI_DIR);
+    if (!d) {
+        fail_test ("ui-files-load", "cannot opendir(%s)", GNOMINT_UI_DIR);
+        return 1;
+    }
+    while ((de = readdir (d))) {
+        size_t len = strlen (de->d_name);
+        if (len <= 3 || g_strcmp0 (de->d_name + len - 3, ".ui") != 0)
+            continue;
+
+        gchar      *path = g_build_filename (GNOMINT_UI_DIR, de->d_name, NULL);
+        GtkBuilder *b = gtk_builder_new ();
+        GError     *err = NULL;
+        guint       before = g_critical_messages->len;
+        scanned++;
+
+        if (gtk_builder_add_from_file (b, path, &err) == 0) {
+            fail_test ("ui-files-load", "%s: %s",
+                       de->d_name, err ? err->message : "unknown error");
+            g_clear_error (&err);
+            failed_files++;
+        }
+        /* Attribute any critical/warning logs emitted during this load
+         * to this specific file. Rewriting message text in place so the
+         * final reset() reports them with file context. */
+        for (guint k = before; k < g_critical_messages->len; k++) {
+            char *orig = g_ptr_array_index (g_critical_messages, k);
+            g_ptr_array_index (g_critical_messages, k) =
+                g_strdup_printf ("%s while loading %s", orig, de->d_name);
+            g_free (orig);
+        }
+
+        g_object_unref (b);
+        g_free (path);
+    }
+    closedir (d);
+
+    int crits = critical_messages_check_and_reset ("ui-files-load");
+    fprintf (stderr, "    %d .ui files loaded (%d failures, %d crit logs)\n",
+             scanned, failed_files, crits);
+    return (failed_files == 0 && crits == 0) ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Scenario 2: certificate properties populate                       */
+/* ------------------------------------------------------------------ */
+
+static int
+scenario_cert_properties_populate (void)
+{
+    GError *err = NULL;
+    gchar  *pem = NULL;
+    gsize   pem_len = 0;
+    int     ok = 0;
+
+    fprintf (stderr, "==> scenario: certificate_properties_populate\n");
+
+    if (!g_file_get_contents (TEST_PEM_PATH, &pem, &pem_len, &err)) {
+        fail_test ("cert-properties-populate",
+                   "cannot read test PEM at %s: %s",
+                   TEST_PEM_PATH, err ? err->message : "?");
+        g_clear_error (&err);
+        return 1;
+    }
+
+    /* Build the dialog the same way certificate_properties_display does,
+     * but stop before gtk_dialog_run. We assign to the global builder
+     * variable that the populate code reads from. */
+    certificate_properties_window_gtkb = gtk_builder_new ();
+    gchar *ui_path = g_build_filename (GNOMINT_UI_DIR,
+                                       "certificate_properties_dialog.ui",
+                                       NULL);
+    if (gtk_builder_add_from_file (certificate_properties_window_gtkb,
+                                   ui_path, &err) == 0) {
+        fail_test ("cert-properties-populate",
+                   "cannot load %s: %s", ui_path,
+                   err ? err->message : "?");
+        g_clear_error (&err);
+        goto out;
+    }
+
+    /* Drive gnomint's actual populate function. Any widget-ID drift between
+     * certificate_properties.c and the .ui will emit Gtk-CRITICAL warnings
+     * here, which our log handler captures. */
+    __certificate_properties_populate (pem);
+
+    /* Assert key widgets received non-empty text. Cert is davefx.pem
+     * (FNMT root CA), so we expect at least the subject CN field to be set. */
+    GObject *cn = gtk_builder_get_object (certificate_properties_window_gtkb,
+                                          "certSubjectCNLabel");
+    if (!cn || !GTK_IS_LABEL (cn)) {
+        fail_test ("cert-properties-populate",
+                   "certSubjectCNLabel missing or not a GtkLabel");
+        goto out;
+    }
+    const gchar *cn_text = gtk_label_get_text (GTK_LABEL (cn));
+    if (!cn_text || cn_text[0] == '\0') {
+        fail_test ("cert-properties-populate",
+                   "certSubjectCNLabel is empty after populate");
+        goto out;
+    }
+    fprintf (stderr, "    populated certSubjectCNLabel = \"%s\"\n", cn_text);
+
+    GObject *sn = gtk_builder_get_object (certificate_properties_window_gtkb,
+                                          "certSNLabel");
+    if (!sn || !GTK_IS_LABEL (sn) ||
+        gtk_label_get_text (GTK_LABEL (sn))[0] == '\0') {
+        fail_test ("cert-properties-populate",
+                   "certSNLabel empty or missing");
+        goto out;
+    }
+
+    GObject *sha1 = gtk_builder_get_object (certificate_properties_window_gtkb,
+                                            "sha1Label");
+    if (!sha1 || !GTK_IS_LABEL (sha1) ||
+        gtk_label_get_text (GTK_LABEL (sha1))[0] == '\0') {
+        fail_test ("cert-properties-populate",
+                   "sha1Label empty or missing");
+        goto out;
+    }
+
+    ok = 1;
+
+out:;
+    int crits = critical_messages_check_and_reset ("cert-properties-populate");
+    if (crits != 0)
+        ok = 0;
+
+    if (certificate_properties_window_gtkb) {
+        g_object_unref (certificate_properties_window_gtkb);
+        certificate_properties_window_gtkb = NULL;
+    }
+    g_free (ui_path);
+    g_free (pem);
+    return ok ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Driver                                                            */
+/* ------------------------------------------------------------------ */
+
+int
+main (int argc, char **argv)
+{
+    /* gtk_init_check is non-fatal; we want a clean failure path if the
+     * Wayland compositor isn't reachable. */
+    if (!gtk_init_check (&argc, &argv)) {
+        fprintf (stderr,
+                 "FAIL: gtk_init_check failed under GDK_BACKEND=%s "
+                 "(WAYLAND_DISPLAY=%s).\n"
+                 "This test must run under tests/run-headless.sh.\n",
+                 g_getenv ("GDK_BACKEND") ? g_getenv ("GDK_BACKEND") : "(unset)",
+                 g_getenv ("WAYLAND_DISPLAY") ?
+                     g_getenv ("WAYLAND_DISPLAY") : "(unset)");
+        return 1;
+    }
+
+    g_critical_messages = g_ptr_array_new_with_free_func (g_free);
+
+    /* g_log_writer_func intercepts every g_log emission across all
+     * domains. Set it AFTER gtk_init so anything GTK emits during the
+     * scenarios is captured. */
+    g_log_set_writer_func (critical_log_writer, NULL, NULL);
+    g_log_set_always_fatal (G_LOG_LEVEL_ERROR);
+
+    scenario_all_ui_files_load ();
+    scenario_cert_properties_populate ();
+
+    g_ptr_array_free (g_critical_messages, TRUE);
+
+    if (g_failures > 0) {
+        fprintf (stderr, "==> %d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    fprintf (stderr, "==> OK\n");
+    return 0;
+}

--- a/tests/run-headless.sh
+++ b/tests/run-headless.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# run-headless.sh — run a GTK test binary under a headless Wayland compositor.
+#
+# Used as automake's check_workflows_LOG_COMPILER. Spawns weston with the
+# headless backend on a unique socket, exports GDK_BACKEND=wayland +
+# WAYLAND_DISPLAY pointing at that socket, runs the supplied binary, and
+# tears weston down regardless of test outcome. The test's exit code is
+# propagated.
+#
+# Wayland is gnomint's primary user environment, so the workflow regression
+# tests exercise GTK's Wayland backend rather than X11.
+
+set -eu
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <test-binary> [args...]" >&2
+    exit 2
+fi
+
+# weston needs an XDG_RUNTIME_DIR with 0700 perms to put its socket in.
+if [ -z "${XDG_RUNTIME_DIR:-}" ]; then
+    XDG_RUNTIME_DIR="$(mktemp -d -t gnomint-test-runtime.XXXXXX)"
+    export XDG_RUNTIME_DIR
+    chmod 700 "$XDG_RUNTIME_DIR"
+    CLEAN_RUNTIME_DIR=1
+else
+    CLEAN_RUNTIME_DIR=0
+fi
+
+WAYLAND_DISPLAY="gnomint-test-$$"
+export WAYLAND_DISPLAY
+export GDK_BACKEND=wayland
+
+WESTON_LOG="$XDG_RUNTIME_DIR/weston-$$.log"
+
+# Start weston in headless mode. --shell=desktop-shell.so is the default;
+# --idle-time=0 prevents weston from quitting under inactivity (it is
+# headless so there are no input events at all).
+weston \
+    --backend=headless-backend.so \
+    --socket="$WAYLAND_DISPLAY" \
+    --idle-time=0 \
+    > "$WESTON_LOG" 2>&1 &
+WESTON_PID=$!
+
+cleanup() {
+    rc=$?
+    if kill -0 "$WESTON_PID" 2>/dev/null; then
+        kill "$WESTON_PID" 2>/dev/null || true
+        wait "$WESTON_PID" 2>/dev/null || true
+    fi
+    if [ "$CLEAN_RUNTIME_DIR" = 1 ]; then
+        rm -rf "$XDG_RUNTIME_DIR"
+    fi
+    # Surface weston's own log on test failure to help diagnose.
+    if [ "$rc" != 0 ] && [ -f "$WESTON_LOG" ]; then
+        echo "--- weston log ---" >&2
+        cat "$WESTON_LOG" >&2
+        echo "--- end weston log ---" >&2
+    fi
+    rm -f "$WESTON_LOG"
+    exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+# Wait for weston's socket to appear (it's async). The lock file is created
+# alongside the socket once weston is ready to accept connections.
+i=0
+while [ $i -lt 50 ] && [ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; do
+    sleep 0.1
+    i=$((i + 1))
+done
+if [ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
+    echo "run-headless.sh: weston socket never appeared at " \
+         "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" >&2
+    exit 1
+fi
+
+# Hand off to the actual test binary. Its exit code becomes ours.
+"$@"


### PR DESCRIPTION
Implements Phase 2A of issue #43. Phase 2B (dialog auto-dismiss + the five original workflow scenarios) is intentionally deferred — see #43's updated description for the split rationale.

## What this adds

A new test binary \`tests/check_workflows\` driven from automake's \`make check\`, run under a headless Wayland compositor via \`tests/run-headless.sh\`. Wayland is gnomint's primary user environment, so the runtime workflow tests exercise GTK's Wayland backend rather than X11.

The static checks from #42 (\`check_y2k38\`, \`check_ui_consistency\`) continue to run without any display.

## The two scenarios

1. **All .ui files load via real GtkBuilder under Wayland.** All 21 \`.ui\` files in \`gui/\` are loaded via \`gtk_builder_add_from_file\`, and the test fails if any Gtk/Gdk/GLib CRITICAL or WARNING is logged. This complements the static XML check in #42 by exercising GTK's actual parser and widget construction on the Wayland code path.

2. **Certificate properties populate.** Builds \`certificate_properties_dialog.ui\` via GtkBuilder, then calls gnomint's production \`__certificate_properties_populate\` with the cert PEM at \`certs/davefx.pem\`. Asserts \`certSubjectCNLabel\`, \`certSNLabel\`, and \`sha1Label\` received non-empty text. Catches widget-ID drift between \`certificate_properties.c\` and the \`.ui\` — something the static checker can't see because it only knows about \`<signal handler=\"...\">\` references, not \`gtk_builder_get_object\` callsites inside \`.c\` files.

## How critical/warning capture works

GLib ≥ 2.50 routes all \`g_log()\` output through \`g_log_writer_func\`, which bypasses \`g_log_set_handler()\`. The test installs a writer that captures \`G_LOG_LEVEL_CRITICAL\` and \`G_LOG_LEVEL_WARNING\` across every domain (Gtk, Gdk, GLib, GLib-GObject, default) and tells GLib the message is handled (no fallthrough to the default writer). Lower levels (info/debug/message) pass through unchanged.

## Verified against an injected regression

Renaming \`certSubjectCNLabel\` to \`certSubjectCNLabel_RENAMED\` in the \`.ui\` makes the populate scenario fail with **two** captured failures in one run:

\`\`\`
FAIL [cert-properties-populate] certSubjectCNLabel missing or not a GtkLabel
FAIL [cert-properties-populate] GTK/GLib critical: Gtk: gtk_label_set_text: assertion 'GTK_IS_LABEL (label)' failed
\`\`\`

The same regression on master would silently no-op the dialog field.

## Bonus: latent bug surfaced and fixed

While bringing the test up, it caught a real but cosmetic issue in \`csr_properties_dialog.ui\`:

\`\`\`
Gtk: Overriding tab label for notebook while loading csr_properties_dialog.ui
\`\`\`

Diagnosis: \`notebook4\` declared a \"Details\" tab whose content was a Glade \`<placeholder/>\` (a designer-only construct). GtkBuilder doesn't materialise placeholders as real pages, so when the \"Details\" tab label was attached it silently overrode the \"General\" tab label of page 0. Since \`notebook4\` has \`show_tabs=False\` and \`csr_properties.c\` only addresses widgets from the General page, the Details tab + placeholder were unused dead structure. They are removed in the same commit (16 lines of .ui).

## CI

\`weston\` added to the \`apt-get install\` list in \`.github/workflows/copilot-setup-steps.yml\`. \`make check\` continues to be invoked there (added in #42); the headless Wayland scenario runs automatically.

## How to run locally

\`\`\`
sudo apt-get install weston   # one-time, alongside the existing build deps
./autogen.sh
./configure
make
make check
\`\`\`

Output on this branch:

\`\`\`
PASS: check_y2k38
PASS: check_ui_consistency
PASS: check_workflows
============================================================================
# TOTAL: 3
# PASS:  3
\`\`\`

## What this doesn't catch (Phase 2B work)

- The five original workflow scenarios in #43 (extract private key, sign CSR, new CA, view properties full, revoke). All of those enter \`gtk_dialog_run\` and require an auto-dismiss mechanism that hasn't been built yet.
- Cell collisions where one widget spans multiple cells via \`width\`/\`height\` (still TODO for the static checker too).

Refs #43. Issue stays open until Phase 2B lands.