### PR TITLE
Add emailAddress field to certificates and CSRs (closes #19)

### DIFF
--- a/gui/certificate_properties_dialog.ui
+++ b/gui/certificate_properties_dialog.ui
@@ -96,7 +96,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">15</property>
+                        <property name="top_attach">17</property>
                       </packing>
                     </child>
                     <child>
@@ -109,7 +109,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">14</property>
+                        <property name="top_attach">16</property>
                       </packing>
                     </child>
                     <child>
@@ -122,7 +122,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">13</property>
+                        <property name="top_attach">15</property>
                       </packing>
                     </child>
                     <child>
@@ -135,7 +135,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">12</property>
+                        <property name="top_attach">14</property>
                       </packing>
                     </child>
                     <child>
@@ -148,7 +148,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">11</property>
+                        <property name="top_attach">13</property>
                       </packing>
                     </child>
                     <child>
@@ -161,7 +161,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">10</property>
+                        <property name="top_attach">12</property>
                       </packing>
                     </child>
                     <child>
@@ -174,7 +174,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">9</property>
+                        <property name="top_attach">10</property>
                       </packing>
                     </child>
                     <child>
@@ -187,7 +187,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -200,7 +200,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -213,7 +213,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -226,7 +226,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -291,7 +291,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">15</property>
+                        <property name="top_attach">17</property>
                       </packing>
                     </child>
                     <child>
@@ -304,7 +304,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">14</property>
+                        <property name="top_attach">16</property>
                       </packing>
                     </child>
                     <child>
@@ -318,7 +318,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">13</property>
+                        <property name="top_attach">15</property>
                       </packing>
                     </child>
                     <child>
@@ -331,7 +331,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">12</property>
+                        <property name="top_attach">14</property>
                       </packing>
                     </child>
                     <child>
@@ -344,7 +344,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">11</property>
+                        <property name="top_attach">13</property>
                       </packing>
                     </child>
                     <child>
@@ -358,7 +358,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">10</property>
+                        <property name="top_attach">12</property>
                       </packing>
                     </child>
                     <child>
@@ -371,7 +371,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">9</property>
+                        <property name="top_attach">10</property>
                       </packing>
                     </child>
                     <child>
@@ -384,7 +384,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -397,7 +397,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -411,7 +411,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -424,7 +424,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -438,7 +438,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -451,7 +451,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -521,7 +521,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">16</property>
+                        <property name="top_attach">18</property>
                       </packing>
                     </child>
                     <child>
@@ -534,7 +534,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">16</property>
+                        <property name="top_attach">18</property>
                       </packing>
                     </child>
                     <child>
@@ -551,7 +551,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">17</property>
+                        <property name="top_attach">19</property>
                       </packing>
                     </child>
                     <child>
@@ -564,10 +564,64 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">17</property>
+                        <property name="top_attach">19</property>
                       </packing>
                     </child>
-                  </object>
+                                      <child>
+                      <object class="GtkLabel" id="label_email_subject">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Email address</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="certSubjectEmailLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes"></property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_email_issuer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Email address</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">11</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="certIssuerEmailLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes"></property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">11</property>
+                      </packing>
+                    </child>
+</object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>

--- a/gui/csr_properties_dialog.ui
+++ b/gui/csr_properties_dialog.ui
@@ -103,7 +103,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -168,7 +168,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -211,7 +211,34 @@
                         <property name="top_attach">0</property>
                       </packing>
                     </child>
-                  </object>
+                                      <child>
+                      <object class="GtkLabel" id="label_email_subject_csr">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Email address</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="certSubjectEmailLabel1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes"></property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+</object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>

--- a/gui/new_ca_window.ui
+++ b/gui/new_ca_window.ui
@@ -224,6 +224,30 @@ Common Name (CN):</property>
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="label_email_ca">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Email address:</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="email_entry">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">•</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkComboBox" id="country_combobox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>

--- a/gui/new_cert_window.ui
+++ b/gui/new_cert_window.ui
@@ -241,7 +241,7 @@ Common Name (CN):</property>
                     </object>
                     <packing>
                       <property name="left_attach">0</property>
-                      <property name="top_attach">6</property>
+                      <property name="top_attach">7</property>
                     </packing>
                   </child>
                   <child>
@@ -256,10 +256,37 @@ Common Name (CN):</property>
                     </object>
                     <packing>
                       <property name="left_attach">1</property>
+                      <property name="top_attach">7</property>
+                    </packing>
+                  </child>
+                                <child>
+                    <object class="GtkLabel" id="label_email_cert">
+                      <property name="visible">True</property>
+                      <property name="can_focus">False</property>
+                      <property name="label" translatable="yes">Email address:</property>
+                      <property name="xalign">0</property>
+                      <property name="yalign">0</property>
+                    </object>
+                    <packing>
+                      <property name="left_attach">0</property>
                       <property name="top_attach">6</property>
                     </packing>
                   </child>
-              </object>
+                  <child>
+                    <object class="GtkLabel" id="email_label">
+                      <property name="visible">True</property>
+                      <property name="can_focus">False</property>
+                      <property name="label" translatable="yes">None</property>
+                      <property name="selectable">True</property>
+                      <property name="xalign">0</property>
+                      <property name="yalign">0</property>
+                    </object>
+                    <packing>
+                      <property name="left_attach">1</property>
+                      <property name="top_attach">6</property>
+                    </packing>
+                  </child>
+</object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>

--- a/gui/new_req_window.ui
+++ b/gui/new_req_window.ui
@@ -299,7 +299,7 @@ subject.&lt;/small&gt;</property>
                   <object class="GtkLabel" id="label94">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Certificate 
+                    <property name="label" translatable="yes">Certificate
  Common Name (CN):</property>
                     <property name="xalign">0</property>
                     <property name="yalign">0</property>
@@ -307,6 +307,30 @@ subject.&lt;/small&gt;</property>
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_email_csr">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Email address:</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="email_entry1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">•</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>

--- a/src/ca-cli-callbacks.c
+++ b/src/ca-cli-callbacks.c
@@ -392,6 +392,17 @@ int ca_cli_callback_addcsr (int argc, char **argv)
 		csr_creation_data->cn = aux;
 		aux = NULL;
 
+		aux = dialog_ask_for_string (_("Enter email address (leave blank for none)"), csr_creation_data->emailAddress);
+		if (csr_creation_data->emailAddress)
+			g_free (csr_creation_data->emailAddress);
+		if (aux && aux[0])
+			csr_creation_data->emailAddress = aux;
+		else {
+			g_free (aux);
+			csr_creation_data->emailAddress = NULL;
+		}
+		aux = NULL;
+
 		aux = dialog_ask_for_string (_("Enter Subject Alternative Names (SAN) [format: DNS:example.com,IP:192.168.1.1]"), csr_creation_data->subject_alt_name);
 		if (csr_creation_data->subject_alt_name)
 			g_free (csr_creation_data->subject_alt_name);
@@ -528,6 +539,17 @@ int ca_cli_callback_addca (int argc, char **argv)
 		if (ca_creation_data->cn)
 			g_free (ca_creation_data->cn);
 		ca_creation_data->cn = aux;
+		aux = NULL;
+
+		aux = dialog_ask_for_string (_("Enter email address (leave blank for none)"), ca_creation_data->emailAddress);
+		if (ca_creation_data->emailAddress)
+			g_free (ca_creation_data->emailAddress);
+		if (aux && aux[0])
+			ca_creation_data->emailAddress = aux;
+		else {
+			g_free (aux);
+			ca_creation_data->emailAddress = NULL;
+		}
 		aux = NULL;
 
 		aux = dialog_ask_for_string (_("Enter Subject Alternative Names (SAN) [format: DNS:example.com,IP:192.168.1.1]"), ca_creation_data->subject_alt_name);

--- a/src/certificate_properties.c
+++ b/src/certificate_properties.c
@@ -203,8 +203,11 @@ void __certificate_properties_populate (const char *certificate_pem)
 	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certSubjectOLabel");	
 	gtk_label_set_text (GTK_LABEL(widget), cert->o);
 
-	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certSubjectOULabel");	
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certSubjectOULabel");
 	gtk_label_set_text (GTK_LABEL(widget), cert->ou);
+
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certSubjectEmailLabel");
+	gtk_label_set_text (GTK_LABEL(widget), cert->emailAddress ? cert->emailAddress : "");
 
 	// Display Subject Alternative Names if present
 	if (cert->subject_alt_name && cert->subject_alt_name[0]) {
@@ -212,16 +215,19 @@ void __certificate_properties_populate (const char *certificate_pem)
 		gtk_label_set_text (GTK_LABEL(widget), cert->subject_alt_name);
 	}
 
-	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerCNLabel");	
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerCNLabel");
 	gtk_label_set_text (GTK_LABEL(widget), cert->i_cn);
 
-	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerOLabel");	
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerOLabel");
 	gtk_label_set_text (GTK_LABEL(widget), cert->i_o);
 
-	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerOULabel");	
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerOULabel");
 	gtk_label_set_text (GTK_LABEL(widget), cert->i_ou);
 
-	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "sha1Label");	
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "certIssuerEmailLabel");
+	gtk_label_set_text (GTK_LABEL(widget), cert->i_emailAddress ? cert->i_emailAddress : "");
+
+	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "sha1Label");
 	gtk_label_set_text (GTK_LABEL(widget), cert->sha1);
 
 	widget = gtk_builder_get_object (certificate_properties_window_gtkb, "md5Label");	

--- a/src/csr_properties.c
+++ b/src/csr_properties.c
@@ -64,10 +64,13 @@ void __csr_properties_populate (const char *csr_pem, gboolean privkey_in_db)
 	widget = gtk_builder_get_object (csr_properties_window_gtkb, "certSubjectOLabel1");	
 	gtk_label_set_text (GTK_LABEL(widget), csr->o);
 
-	widget = gtk_builder_get_object (csr_properties_window_gtkb, "certSubjectOULabel1");	
+	widget = gtk_builder_get_object (csr_properties_window_gtkb, "certSubjectOULabel1");
 	gtk_label_set_text (GTK_LABEL(widget), csr->ou);
 
-	widget = gtk_builder_get_object (csr_properties_window_gtkb, "certSubjectSANLabel1");	
+	widget = gtk_builder_get_object (csr_properties_window_gtkb, "certSubjectEmailLabel1");
+	gtk_label_set_text (GTK_LABEL(widget), csr->emailAddress ? csr->emailAddress : "");
+
+	widget = gtk_builder_get_object (csr_properties_window_gtkb, "certSubjectSANLabel1");
 	if (csr->subject_alt_name && csr->subject_alt_name[0]) {
 		gtk_label_set_text (GTK_LABEL(widget), csr->subject_alt_name);
 	} else {

--- a/src/new_ca_window.c
+++ b/src/new_ca_window.c
@@ -266,6 +266,13 @@ G_MODULE_EXPORT void on_new_ca_commit_clicked (GtkButton *widg,
 	else
 		ca_creation_data->cn = NULL;
 
+	widget = GTK_WIDGET(gtk_builder_get_object (new_ca_window_gtkb, "email_entry"));
+	text = (gchar *) gtk_entry_get_text (GTK_ENTRY(widget));
+	if (strlen (text))
+		ca_creation_data->emailAddress = g_strdup (text);
+	else
+		ca_creation_data->emailAddress = NULL;
+
 	// Get SANs from SAN manager widget
 	if (san_manager_widget) {
 		gchar *san_string = san_manager_get_string(san_manager_widget);

--- a/src/new_cert.c
+++ b/src/new_cert.c
@@ -265,7 +265,14 @@ void new_cert_window_display(const guint64 csr_id, const gchar *csr_pem, const g
 
 	object = gtk_builder_get_object (new_cert_window_gtkb, "cn_label");
 	gtk_label_set_text (GTK_LABEL(object), csr_info->cn);
-	
+
+	object = gtk_builder_get_object (new_cert_window_gtkb, "email_label");
+	if (csr_info->emailAddress && csr_info->emailAddress[0]) {
+		gtk_label_set_text (GTK_LABEL(object), csr_info->emailAddress);
+	} else {
+		gtk_label_set_text (GTK_LABEL(object), _("None"));
+	}
+
 	object = gtk_builder_get_object (new_cert_window_gtkb, "san_label");
 	if (csr_info->subject_alt_name && csr_info->subject_alt_name[0]) {
 		gtk_label_set_text (GTK_LABEL(object), csr_info->subject_alt_name);

--- a/src/new_req_window.c
+++ b/src/new_req_window.c
@@ -519,6 +519,13 @@ G_MODULE_EXPORT void on_new_req_commit_clicked (GtkButton *widg,
 	else
 		csr_creation_data->cn = NULL;
 
+	widget = GTK_WIDGET(gtk_builder_get_object (new_req_window_gtkb, "email_entry1"));
+	text = (gchar *) gtk_entry_get_text (GTK_ENTRY(widget));
+	if (strlen (text))
+		csr_creation_data->emailAddress = g_strdup (text);
+	else
+		csr_creation_data->emailAddress = NULL;
+
 	// Get SANs from SAN manager widget
 	if (san_manager_widget1) {
 		gchar *san_string = san_manager_get_string(san_manager_widget1);

--- a/src/tls.c
+++ b/src/tls.c
@@ -643,12 +643,20 @@ gchar * tls_generate_self_signed_certificate (TlsCreationData * creation_data,
 	}
 	if (creation_data->cn) {
 		gnutls_x509_crt_set_dn_by_oid (crt, GNUTLS_OID_X520_COMMON_NAME,
-					       0, creation_data->cn, strlen(creation_data->cn));	
+					       0, creation_data->cn, strlen(creation_data->cn));
 		gnutls_x509_crt_set_issuer_dn_by_oid (crt, GNUTLS_OID_X520_COMMON_NAME,
-						      0, creation_data->cn, strlen(creation_data->cn));	
+						      0, creation_data->cn, strlen(creation_data->cn));
+	}
+	if (creation_data->emailAddress) {
+		gnutls_x509_crt_set_dn_by_oid (crt, GNUTLS_OID_PKCS9_EMAIL,
+					       0, creation_data->emailAddress,
+					       strlen (creation_data->emailAddress));
+		gnutls_x509_crt_set_issuer_dn_by_oid (crt, GNUTLS_OID_PKCS9_EMAIL,
+						      0, creation_data->emailAddress,
+						      strlen (creation_data->emailAddress));
 	}
 
-	
+
 	if (gnutls_x509_crt_set_ca_status (crt, 1) != 0) {
 		gnutls_x509_crt_deinit (crt);
 		return g_strdup_printf(_("Error when setting basicConstraint extension"));
@@ -764,9 +772,14 @@ gchar * tls_generate_csr (TlsCreationData * creation_data,
 	}
 	if (creation_data->cn) {
 		gnutls_x509_crq_set_dn_by_oid (crq, GNUTLS_OID_X520_COMMON_NAME,
-					       0, creation_data->cn, strlen(creation_data->cn));	
+					       0, creation_data->cn, strlen(creation_data->cn));
 	}
-	
+	if (creation_data->emailAddress) {
+		gnutls_x509_crq_set_dn_by_oid (crq, GNUTLS_OID_PKCS9_EMAIL,
+					       0, creation_data->emailAddress,
+					       strlen (creation_data->emailAddress));
+	}
+
 	// Add Subject Alternative Names if provided
 	if (creation_data->subject_alt_name && creation_data->subject_alt_name[0]) {
 		if (tls_add_san_to_crq(crq, creation_data->subject_alt_name) < 0) {
@@ -911,10 +924,15 @@ gchar * tls_generate_certificate (TlsCertCreationData * creation_data,
 
 	if (ca_cert_data->cn)
 		gnutls_x509_crt_set_issuer_dn_by_oid (crt, GNUTLS_OID_X520_COMMON_NAME,
-						      0, ca_cert_data->cn, strlen(ca_cert_data->cn));	
+						      0, ca_cert_data->cn, strlen(ca_cert_data->cn));
 
-	
-        ca_keyid = g_new0 (guchar,1);	
+	if (ca_cert_data->emailAddress)
+		gnutls_x509_crt_set_issuer_dn_by_oid (crt, GNUTLS_OID_PKCS9_EMAIL,
+						      0, ca_cert_data->emailAddress,
+						      strlen (ca_cert_data->emailAddress));
+
+
+        ca_keyid = g_new0 (guchar,1);
         gnutls_x509_crt_get_subject_key_id(ca_crt, ca_keyid, &ca_keyidsize, NULL);
         g_free (ca_keyid);        
         if (ca_keyidsize) {
@@ -1157,6 +1175,16 @@ TlsCert * tls_parse_cert_pem (const char * pem_certificate)
 		aux = NULL;
 	}
 
+	size = 0;
+	gnutls_x509_crt_get_dn_by_oid (*cert, GNUTLS_OID_PKCS9_EMAIL, 0, 0, aux, &size);
+	if (size) {
+		aux = g_new0 (gchar, size);
+		gnutls_x509_crt_get_dn_by_oid (*cert, GNUTLS_OID_PKCS9_EMAIL, 0, 0, aux, &size);
+		res->emailAddress = g_strdup (aux);
+		g_free (aux);
+		aux = NULL;
+	}
+
 
 	size = 0;
 	gnutls_x509_crt_get_dn (*cert, aux, &size);
@@ -1194,6 +1222,16 @@ TlsCert * tls_parse_cert_pem (const char * pem_certificate)
 		aux = g_new0(gchar, size);
 		gnutls_x509_crt_get_issuer_dn_by_oid (*cert, GNUTLS_OID_X520_ORGANIZATIONAL_UNIT_NAME, 0, 0, aux, &size);
 		res->i_ou = g_strdup (aux);
+		g_free (aux);
+		aux = NULL;
+	}
+
+	size = 0;
+	gnutls_x509_crt_get_issuer_dn_by_oid (*cert, GNUTLS_OID_PKCS9_EMAIL, 0, 0, aux, &size);
+	if (size) {
+		aux = g_new0 (gchar, size);
+		gnutls_x509_crt_get_issuer_dn_by_oid (*cert, GNUTLS_OID_PKCS9_EMAIL, 0, 0, aux, &size);
+		res->i_emailAddress = g_strdup (aux);
 		g_free (aux);
 		aux = NULL;
 	}
@@ -1513,6 +1551,7 @@ void tls_cert_free (TlsCert *tlscert)
 	g_free (tlscert->st);
 	g_free (tlscert->l);
 	g_free (tlscert->dn);
+	g_free (tlscert->emailAddress);
 	g_free (tlscert->i_cn);
 	g_free (tlscert->i_o);
 	g_free (tlscert->i_ou);
@@ -1520,6 +1559,7 @@ void tls_cert_free (TlsCert *tlscert)
 	g_free (tlscert->i_st);
 	g_free (tlscert->i_l);
 	g_free (tlscert->i_dn);
+	g_free (tlscert->i_emailAddress);
 	g_free (tlscert->sha1);
 	g_free (tlscert->sha256);
 	g_free (tlscert->sha512);
@@ -1577,6 +1617,16 @@ TlsCsr * tls_parse_csr_pem (const char * pem_csr)
 		aux = g_new0(gchar, size);
 		gnutls_x509_crq_get_dn_by_oid (*csr, GNUTLS_OID_X520_ORGANIZATIONAL_UNIT_NAME, 0, 0, aux, &size);
 		res->ou = g_strdup (aux);
+		g_free (aux);
+		aux = NULL;
+	}
+
+	size = 0;
+	gnutls_x509_crq_get_dn_by_oid (*csr, GNUTLS_OID_PKCS9_EMAIL, 0, 0, aux, &size);
+	if (size) {
+		aux = g_new0 (gchar, size);
+		gnutls_x509_crq_get_dn_by_oid (*csr, GNUTLS_OID_PKCS9_EMAIL, 0, 0, aux, &size);
+		res->emailAddress = g_strdup (aux);
 		g_free (aux);
 		aux = NULL;
 	}
@@ -1736,7 +1786,11 @@ void tls_csr_free (TlsCsr *tlscsr)
 
 	if (tlscsr->dn) {
 		g_free (tlscsr->dn);
-	}	
+	}
+
+	if (tlscsr->emailAddress) {
+		g_free (tlscsr->emailAddress);
+	}
 
 	if (tlscsr->key_id) {
 		g_free (tlscsr->key_id);

--- a/src/tls.h
+++ b/src/tls.h
@@ -97,6 +97,7 @@ typedef struct __TlsCert {
 	gchar * st;
 	gchar * l;
 	gchar * dn;
+	gchar * emailAddress;
 
 	gchar * i_cn;
 	gchar * i_o;
@@ -105,6 +106,7 @@ typedef struct __TlsCert {
 	gchar * i_st;
 	gchar * i_l;
 	gchar * i_dn;
+	gchar * i_emailAddress;
 
 	gchar * sha1;
 	gchar * md5;
@@ -126,7 +128,7 @@ typedef struct __TlsCert {
 	time_t activation_time;
 } TlsCert;
 
-typedef struct __TlsCsr {	
+typedef struct __TlsCsr {
 	gchar * cn;
 	gchar * o;
 	gchar * ou;
@@ -134,6 +136,7 @@ typedef struct __TlsCsr {
 	gchar * st;
 	gchar * l;
 	gchar * dn;
+	gchar * emailAddress;
 
 	gchar * key_id;
 	

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,14 +10,15 @@
 ##                           the headless backend. Gnomint's primary
 ##                           user environment is Wayland.
 
-TESTS = check_y2k38 check_ui_consistency check_workflows
-check_PROGRAMS = $(TESTS)
+TESTS = check_y2k38 check_ui_consistency check_workflows check_cli_email.sh
+check_PROGRAMS = check_y2k38 check_ui_consistency check_workflows
 
 # Per-test wrapper: only check_workflows runs under a headless Wayland
-# compositor. The static tests stay display-free.
+# compositor. The static tests stay display-free. check_cli_email.sh
+# spawns gnomint-cli directly so it needs no display either.
 check_workflows_LOG_COMPILER = $(srcdir)/run-headless.sh
 
-EXTRA_DIST = run-headless.sh
+EXTRA_DIST = run-headless.sh check_cli_email.sh
 
 # ---------------------------------------------------------------
 # Y2K38 verification — no GUI dependencies, just stdio + time.h.

--- a/tests/check_cli_email.sh
+++ b/tests/check_cli_email.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# check_cli_email.sh — verify the gnomint-cli accepts an emailAddress when
+# adding a CA and surfaces it in the certificate's Distinguished Name.
+#
+# Companion test to the email-address round-trip in tests/check_workflows.c
+# (which covers the GTK side). Together they exercise the feature added in
+# response to issue #19 on both interfaces gnoMint ships.
+#
+# Strategy:
+#   - Spawn gnomint-cli pointing at a fresh tempfile DB.
+#   - Pipe an addca conversation (RSA, 1024-bit, 12 months — small so the
+#     test stays fast) including a known email address.
+#   - Follow up with `showcert 1` in the same session.
+#   - Grep the captured output for the email.
+#
+# Failure modes the test catches:
+#   - addca skips or misorders the new email prompt.
+#   - tls_generate_self_signed_certificate doesn't actually embed
+#     GNUTLS_OID_PKCS9_EMAIL in the subject DN.
+#   - tls_parse_cert_pem doesn't read the email back into the DN string
+#     surfaced by `showcert`.
+
+set -eu
+
+# Allow override for distcheck etc.; default to in-tree build location.
+GNOMINT_CLI=${GNOMINT_CLI:-../src/gnomint-cli}
+
+if [ ! -x "$GNOMINT_CLI" ]; then
+    echo "SKIP: $GNOMINT_CLI not built or not executable" >&2
+    exit 77         # GNU autotest convention for SKIP.
+fi
+
+TMPDIR_HERE=$(mktemp -d /tmp/gnomint-cli-test-XXXXXX)
+trap 'rm -rf "$TMPDIR_HERE"' EXIT INT TERM
+TEST_DB="$TMPDIR_HERE/test.gnomint"
+EMAIL="ca-cli-test@example.com"
+CN="Test CLI CA"
+
+# Pipe the addca conversation. Empty lines accept the (NULL) default for
+# Country/State/Locality/Organization/OU. The email prompt is the new one
+# this test exercises. SAN is left empty. RSA 1024-bit, 12-month validity.
+OUTPUT=$(
+    "$GNOMINT_CLI" "$TEST_DB" <<EOF 2>&1 || true
+addca
+
+
+
+
+
+$CN
+$EMAIL
+
+RSA
+1024
+12
+no
+yes
+showcert 1
+exit
+EOF
+)
+
+if ! printf '%s\n' "$OUTPUT" | grep -q "$EMAIL"; then
+    echo "FAIL: email '$EMAIL' not found in gnomint-cli output" >&2
+    echo "--- captured output ---" >&2
+    printf '%s\n' "$OUTPUT" >&2
+    echo "--- end captured output ---" >&2
+    exit 1
+fi
+
+echo "PASS: gnomint-cli addca embedded '$EMAIL' visible via showcert"

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -49,6 +49,9 @@
 #include <unistd.h>
 
 #include <gtk/gtk.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+#include "tls.h"
 
 #ifndef GNOMINT_UI_DIR
 # error "GNOMINT_UI_DIR must be set at compile time (path to gui/)"
@@ -90,6 +93,15 @@ extern void ca_on_sign1_activate (GtkMenuItem *, gpointer);
 extern void ca_on_revoke_activate (GtkMenuItem *, gpointer);
 extern gboolean ca_treeview_row_activated (GtkTreeView *, GtkTreePath *,
                                            GtkTreeViewColumn *, gpointer);
+
+/* TLS helpers exercised by the email scenario. */
+extern void    tls_init (void);
+extern gchar * tls_generate_rsa_keys (TlsCreationData *cd,
+                                      gchar **private_key,
+                                      gnutls_x509_privkey_t **key);
+extern gchar * tls_generate_self_signed_certificate (TlsCreationData *cd,
+                                                     gnutls_x509_privkey_t *key,
+                                                     gchar **certificate);
 
 /* ------------------------------------------------------------------ */
 /*  Failure tracking + critical-log capture                           */
@@ -804,6 +816,115 @@ out:
 }
 
 /* ------------------------------------------------------------------ */
+/*  Scenario 8 (issue #19): emailAddress round-trips through cert     */
+/*                          generation, parsing, and properties UI    */
+/* ------------------------------------------------------------------ */
+
+static int
+scenario_email_address (void)
+{
+    const char  *expected_email = "test@example.com";
+    int          rc = 1;
+    gchar       *private_key = NULL;
+    gchar       *cert_pem = NULL;
+    gchar       *err = NULL;
+    gchar       *ui_path = NULL;
+    TlsCreationData *cd = NULL;
+    gnutls_x509_privkey_t *key = NULL;
+
+    fprintf (stderr, "==> scenario: emailAddress round-trip (issue #19)\n");
+
+    tls_init ();
+
+    cd = g_new0 (TlsCreationData, 1);
+    cd->cn = g_strdup ("Email Address Test CA");
+    cd->emailAddress = g_strdup (expected_email);
+    cd->key_type = 0;             /* 0 = RSA, 1 = DSA */
+    cd->key_bitlength = 1024;     /* small for speed; never use in production */
+    cd->activation = time (NULL);
+    cd->expiration = cd->activation + 86400;
+
+    err = tls_generate_rsa_keys (cd, &private_key, &key);
+    if (err) {
+        fail_test ("email-address", "tls_generate_rsa_keys failed: %s", err);
+        g_free (err);
+        goto out;
+    }
+
+    err = tls_generate_self_signed_certificate (cd, key, &cert_pem);
+    if (err) {
+        fail_test ("email-address",
+                   "tls_generate_self_signed_certificate failed: %s", err);
+        g_free (err);
+        goto out;
+    }
+
+    /* The cert is self-signed so subject email == issuer email. Parse it
+     * through the production code path and assert both labels populate. */
+    certificate_properties_window_gtkb = gtk_builder_new ();
+    ui_path = g_build_filename (GNOMINT_UI_DIR,
+                                "certificate_properties_dialog.ui", NULL);
+    GError *gerr = NULL;
+    if (gtk_builder_add_from_file (certificate_properties_window_gtkb,
+                                   ui_path, &gerr) == 0) {
+        fail_test ("email-address", "cannot load %s: %s", ui_path,
+                   gerr ? gerr->message : "?");
+        g_clear_error (&gerr);
+        goto out;
+    }
+
+    __certificate_properties_populate (cert_pem);
+
+    GObject *subj = gtk_builder_get_object (certificate_properties_window_gtkb,
+                                            "certSubjectEmailLabel");
+    if (!subj || !GTK_IS_LABEL (subj)) {
+        fail_test ("email-address", "certSubjectEmailLabel missing");
+        goto out;
+    }
+    const gchar *subj_text = gtk_label_get_text (GTK_LABEL (subj));
+    if (!subj_text || g_strcmp0 (subj_text, expected_email) != 0) {
+        fail_test ("email-address",
+                   "certSubjectEmailLabel = \"%s\", expected \"%s\"",
+                   subj_text ? subj_text : "(null)", expected_email);
+        goto out;
+    }
+    fprintf (stderr, "    subject email = \"%s\" OK\n", subj_text);
+
+    GObject *iss = gtk_builder_get_object (certificate_properties_window_gtkb,
+                                           "certIssuerEmailLabel");
+    if (!iss || !GTK_IS_LABEL (iss)) {
+        fail_test ("email-address", "certIssuerEmailLabel missing");
+        goto out;
+    }
+    const gchar *iss_text = gtk_label_get_text (GTK_LABEL (iss));
+    if (!iss_text || g_strcmp0 (iss_text, expected_email) != 0) {
+        fail_test ("email-address",
+                   "certIssuerEmailLabel = \"%s\", expected \"%s\"",
+                   iss_text ? iss_text : "(null)", expected_email);
+        goto out;
+    }
+    fprintf (stderr, "    issuer  email = \"%s\" OK\n", iss_text);
+
+    rc = 0;
+
+out:;
+    int crits = critical_messages_check_and_reset ("email-address");
+    if (crits != 0)
+        rc = 1;
+
+    if (certificate_properties_window_gtkb) {
+        g_object_unref (certificate_properties_window_gtkb);
+        certificate_properties_window_gtkb = NULL;
+    }
+    g_free (ui_path);
+    g_free (cert_pem);
+    g_free (private_key);
+    if (cd)
+        tls_creation_data_free (cd);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Driver                                                            */
 /* ------------------------------------------------------------------ */
 
@@ -828,6 +949,7 @@ main (int argc, char **argv)
     /* Phase 2A scenarios — work without any install. */
     scenario_all_ui_files_load ();
     scenario_cert_properties_populate ();
+    scenario_email_address ();
 
     /* Phase 2B scenarios drive production code paths that load .ui
      * files from PACKAGE_DATA_DIR (new_ca_window.c et al). That path


### PR DESCRIPTION
Reimplementation of the design from the closed draft PR #20, redone against post-SAN master and without the noise files PR #20 carried. Closes issue #19.

## What this adds

Threads an `emailAddress` field through every gnoMint surface — struct definitions, GnuTLS-level generation/parsing, GUI input, GUI display, CLI prompts, and automated tests.

### Backend (`src/tls.c`, `src/tls.h`)

- `TlsCsr` gains `emailAddress`.
- `TlsCert` gains `emailAddress` and `i_emailAddress` (issuer email — relevant when the cert is signed by a CA whose own subject has an email).
- \`tls_generate_self_signed_certificate\` sets `GNUTLS_OID_PKCS9_EMAIL` in both subject DN and issuer DN.
- \`tls_generate_csr\` sets it in the request's subject DN.
- \`tls_generate_certificate\` (the CSR-signing path) copies the parent CA's `emailAddress` into the issuer DN. The requester's email rides into the issued cert's subject via GnuTLS's existing \`gnutls_x509_crt_set_crq\` copy of the full subject DN.
- \`tls_parse_cert_pem\` reads back both subject and issuer email; \`tls_parse_csr_pem\` reads it back from the request. Both freed in the corresponding \`*_free\` functions.

### GUI input

| Where | Widget id | File |
|---|---|---|
| New self-signed CA | \`email_entry\` | \`gui/new_ca_window.ui\` |
| New CSR | \`email_entry1\` | \`gui/new_req_window.ui\` |

Read into the creation data in \`on_new_ca_commit_clicked\` / \`on_new_req_commit_clicked\`.

### GUI display

| Where | Widget id(s) | File |
|---|---|---|
| Certificate Properties → Subject | \`certSubjectEmailLabel\` | \`gui/certificate_properties_dialog.ui\` |
| Certificate Properties → Issuer | \`certIssuerEmailLabel\` | (same) |
| CSR Properties → Subject | \`certSubjectEmailLabel1\` | \`gui/csr_properties_dialog.ui\` |
| Sign CSR dialog → subject summary | \`email_label\` | \`gui/new_cert_window.ui\` |

Each existing GtkGrid was carefully shifted to accommodate the new row without breaking the latent layout we fixed in #39. The static UI consistency checker from #42 catches any (left_attach, top_attach) collision the shift introduces — verified passing.

### CLI (`src/ca-cli-callbacks.c`)

The \`addca\` and \`addcsr\` interactive flows now prompt:

\`\`\`
Enter email address (leave blank for none) [...]
\`\`\`

between the CN and SAN prompts. Empty input keeps \`emailAddress\` NULL. The address propagates through to the generated cert/CSR DN where \`showcert\` / \`showcsr\` already surface it as part of the Distinguished Name.

## Tests

Two new tests, both green on this branch.

### UI: `scenario_email_address` in `tests/check_workflows.c`

Runs under the existing headless Wayland test infrastructure (PR #45). Generates a 1024-bit RSA self-signed CA whose subject and issuer carry `test@example.com` via the production \`tls_generate_rsa_keys\` + \`tls_generate_self_signed_certificate\` functions, then drives \`__certificate_properties_populate\` against the generated PEM and asserts both \`certSubjectEmailLabel\` and \`certIssuerEmailLabel\` equal the expected address. Catches any drop in the chain: struct field, OID embedding, parsing, populate.

### CLI: `tests/check_cli_email.sh`

Spawns \`gnomint-cli\` against a tempfile DB, pipes a full \`addca\` conversation including a known email, then runs \`showcert 1\` and greps for the email in the captured Distinguished Name. Wired into \`TESTS\` and \`EXTRA_DIST\` in \`tests/Makefile.am\`.

\`\`\`
PASS: check_y2k38
PASS: check_ui_consistency
PASS: check_workflows
PASS: check_cli_email.sh
# TOTAL: 4
# PASS:  4
\`\`\`

\`make distcheck\` also passes end-to-end.

## What's intentionally not in this PR

- No NEWS entry. This lands post-1.4.0 ("Lazarus"); whenever you decide to cut 1.4.1 or 1.5.0, the NEWS entry will mention this.
- No subjectAltName \`rfc822Name\` plumbing. The existing SAN editor (from #18) already handles \`rfc822Name\` SANs if you want the modern PKI placement of email — this PR adds the classic \`emailAddress\` attribute in the subject DN, which is what the Copilot draft #20 was building and is the immediately useful behavior. The two can coexist on a single cert.

## Relationship to closed PR #20

PR #20 was closed because its branch was 109 commits behind master, conflicted with #39's layout, and shipped three accidentally-committed files (\`_codeql_detected_source_root\`, \`gconf/gnomint.schemas.valid\`, \`po/.intltool-merge-cache.lock\`). The TLS-side design from that draft was sound and is reproduced here. The .ui shifts had to be redone because master had since added SAN rows. Credit to whoever originally drafted PR #20 — design was right.