### PR TITLE
Add 'show expired certificates' toggle to View menu

### DIFF
--- a/gconf/org.gnome.gnomint.gschema.xml
+++ b/gconf/org.gnome.gnomint.gschema.xml
@@ -18,7 +18,18 @@
         Whether the revoked certificates should be visible.
       </description>
     </key>
-    
+
+    <key name="expired-visible" type="b">
+      <default>true</default>
+      <summary>Expired certificates visibility</summary>
+      <description>
+        Whether already-expired certificates should be visible in the
+        certificates tree. CAs are always visible regardless of this
+        setting so that any still-valid certificates they signed remain
+        reachable.
+      </description>
+    </key>
+
     <key name="crq-visible" type="b">
       <default>true</default>
       <summary>Certificate requests visibility</summary>

--- a/gui/main_window.ui
+++ b/gui/main_window.ui
@@ -395,6 +395,18 @@
                         <signal name="toggled" handler="ca_rcrt_view_toggled" swapped="no"/>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="expired_view_menuitem">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">E_xpired Certificates</property>
+                        <property name="has_tooltip">True</property>
+                        <property name="tooltip_text" translatable="yes">When unchecked, certificates whose validity has already ended are hidden from the tree. A certificate is also considered expired if any of its issuing CAs has expired, so an expired CA's whole subtree is hidden alongside it.</property>
+                        <property name="use_underline">True</property>
+                        <property name="active">True</property>
+                        <signal name="toggled" handler="ca_expired_view_toggled" swapped="no"/>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -81,15 +81,15 @@ msgstr "_Obre una base de dades de certificats"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Sol·licituds de signatura de certificats</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,86 +106,86 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Núm. de sèrie"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Activació"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Venciment"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Revocació"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Exporta certificat"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Exporta sol·licitud de signatura de certificat"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Hi ha hagut un error al exportar el certificat."
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 "Ha hagut un error al exportar la sol·licitud de signatura de certificat "
 "(CSR),"
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Certificat exportat amb èxit."
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr "Sol·licitud de signatura de certificat exportada amb èxit."
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr "Exporta la clau privada xifrada"
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Clau privada exportada amb èxit."
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporta la clau privada sense xifrar"
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporta tot el certificat en un paquet PKCS#12"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Exporta sol·licitud de signatura de certificat (CSR) - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -193,7 +193,7 @@ msgstr ""
 "Seleccioneu quina part de la sol·licitud de signatura de certificat (CSR) "
 "voleu exportar:"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -201,7 +201,7 @@ msgstr ""
 "<i>Exporta la sol·licitud de signatura de certificat a un fitxer públic en "
 "format PEM</i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -211,27 +211,27 @@ msgstr ""
 "contrasenya. Aquest fitxer només ha de ser accessible pel titular de la "
 "sol·licitud de signatura del certificat.</i>"
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -242,17 +242,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr "Canvia la contrasenya de la CA - gnoMint"
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -260,60 +260,60 @@ msgstr ""
 "La contrasenya introduïda no es correspon amb la contrasenya real de la base "
 "de dades."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al establir la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr "La contrasenya s'ha establert amb èxit"
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al eliminar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "La contrasenya s'ha eliminat amb èxit"
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Desa paràmetres Diffie-Hellman"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Paràmetres Diffie-Hellman desats correctament"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "Seleccioneu el fitxer PEM a importar"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "S'han produït problemes al importar el fitxer '%s'"
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr "Seleccioneu el directori a importar"
 
@@ -1770,7 +1770,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2443,7 +2443,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2579,46 +2579,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3649,77 +3649,90 @@ msgid "_Revoked Certificates"
 msgstr "Certificats _revocats"
 
 #: gui/main_window.ui.h:27
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Exporta certificat"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr "A_juda"
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 msgid "Create a new database"
 msgstr "Crea una base de dades nova"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Obrir una base de dades existent"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Afegir una entitat certificadora (CA) auto-signada"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 #, fuzzy
 msgid "Add autosigned CA certificate"
 msgstr "Afegir una entitat certificadora (CA) auto-signada"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 #, fuzzy
 msgid "Add a new Certificate Signing Request"
 msgstr "Sol·licitud de signatura de certificat:\n"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Afegir CSR"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr "Extreu la clau privada de l'element sel·leccionat a un fitxer extern"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Extreure clau privada"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Revoca el certificat seleccionat"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Revoca"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Signa la sol·licitud de certificació seleccionada"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr "Signa"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Esborra la sol·licitud de signatura de certificat sel·leccionada"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 msgid "Quick certificate generation for web server"
 msgstr ""
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 #, fuzzy
 msgid "Web Server Wizard"
 msgstr "Servidor web TLS"
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 msgid "Quick certificate generation for email server"
 msgstr ""
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 #, fuzzy
 msgid "Email Server Wizard"
 msgstr "Servidor web TLS"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -93,7 +93,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -101,121 +101,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:993
+#: src/ca.c:1070
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -226,68 +226,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2434,46 +2434,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3401,74 +3401,86 @@ msgid "_Revoked Certificates"
 msgstr ""
 
 #: gui/main_window.ui.h:27
-msgid "_Help"
+msgid "E_xpired Certificates"
 msgstr ""
 
 #: gui/main_window.ui.h:28
-msgid "Create a new database"
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
 msgstr ""
 
 #: gui/main_window.ui.h:29
-msgid "Open an existing database"
+msgid "_Help"
 msgstr ""
 
 #: gui/main_window.ui.h:30
-msgid "Add an autosigned CA"
+msgid "Create a new database"
 msgstr ""
 
 #: gui/main_window.ui.h:31
-msgid "Add autosigned CA certificate"
+msgid "Open an existing database"
 msgstr ""
 
 #: gui/main_window.ui.h:32
-msgid "Add a new Certificate Signing Request"
+msgid "Add an autosigned CA"
 msgstr ""
 
 #: gui/main_window.ui.h:33
-msgid "Add CSR"
-msgstr "Přidat CSR"
+msgid "Add autosigned CA certificate"
+msgstr ""
 
 #: gui/main_window.ui.h:34
-msgid "Extract the private key of the selected item into a external file"
+msgid "Add a new Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:35
-msgid "Extract Private Key"
-msgstr ""
+msgid "Add CSR"
+msgstr "Přidat CSR"
 
 #: gui/main_window.ui.h:36
-msgid "Revoke the selected certificate"
+msgid "Extract the private key of the selected item into a external file"
 msgstr ""
 
 #: gui/main_window.ui.h:37
-msgid "Revoke"
+msgid "Extract Private Key"
 msgstr ""
 
 #: gui/main_window.ui.h:38
-msgid "Sign the selected Certificate Signing Request"
+msgid "Revoke the selected certificate"
 msgstr ""
 
 #: gui/main_window.ui.h:39
-msgid "Sign"
+msgid "Revoke"
 msgstr ""
 
 #: gui/main_window.ui.h:40
-msgid "Delete the selected Certificate Signing Request"
+msgid "Sign the selected Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:41
-msgid "Quick certificate generation for web server"
+msgid "Sign"
 msgstr ""
 
 #: gui/main_window.ui.h:42
-msgid "Web Server Wizard"
+msgid "Delete the selected Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:43
-msgid "Quick certificate generation for email server"
+msgid "Quick certificate generation for web server"
 msgstr ""
 
 #: gui/main_window.ui.h:44
+msgid "Web Server Wizard"
+msgstr ""
+
+#: gui/main_window.ui.h:45
+msgid "Quick certificate generation for email server"
+msgstr ""
+
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -80,15 +80,15 @@ msgstr "Zertifikat-Datenbank ö_ffnen"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Zertifikate</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -96,7 +96,7 @@ msgstr "<b>Signaturanfragen für Zertifikate</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -105,84 +105,84 @@ msgstr "%d.%m.%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Seriell"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Widerruf"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Zertifikat exportieren"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Signaturanfrage für Zertifikat exportieren"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Beim Export des Zertifikats ist ein Fehler aufgetreten."
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr "Signaturanfrage für Zertifikat wurde erfolgreich exportiert"
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Geheimer Schlüssel wurde erfolgreich exportiert"
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Geheimen Schlüssel en_tpacken"
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Gesamtes Zertifikat in einem PKCS#12-Paket exportieren"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Signaturanfrage exportieren - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -190,7 +190,7 @@ msgstr ""
 "Bitte wählen Sie den Teil der gespeicherten Siganturanfrage aus, den Sie "
 "exportieren wollen:"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -198,34 +198,34 @@ msgstr ""
 "<i>Signaturanfrage für Zertifikat in eine öffentliche Datei im PEM-Format "
 "exportieren.</i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -236,17 +236,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr "Zertifizierungsstellen-Passwort ändern - gnoMint"
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -254,60 +254,60 @@ msgstr ""
 "Das von Ihnen eingegebene Passwort stimmt nicht mit dem derzeit für die "
 "Datenbank geltenden Passwort überein."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ändern des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ermitteln des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr "Passwort wurde erfolgreich ermittelt"
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Löschen des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "Passwort wurde erfolgreich gelöscht"
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Diffie-Hellman-Parameter speichern"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-Parameter wurden erfolgreich gespeichert"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "PEM-Datei zum Importieren auswählen"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problem beim Importieren der Datei »%s«"
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr "Ordner zum Importieren auswählen"
 
@@ -1707,7 +1707,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2399,7 +2399,7 @@ msgstr "Beim Exportieren des Zertifikats ist ein Fehler aufgetreten."
 msgid "- A Certification Authority manager"
 msgstr "- Ein Zertifizierungsstellen-Verwalter"
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
@@ -2549,15 +2549,15 @@ msgstr ""
 "Dateien im Ordner entsprechen keinem unterstützten Zertifizierungsstellen-"
 "Format."
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr "- Eine grafische Verwaltung für Zertifizierungsstellen"
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr "Neue Zertifizierungsstellen-Datenbank erzeugen"
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
@@ -2566,25 +2566,25 @@ msgstr ""
 "Problem beim Erzeugen der Zertifizierungsstellen-Datenbank »%s«:\n"
 "%s"
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr "Problem beim Öffnen der neuen Zertifizierungsstellen-Datenbank »%s«"
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr "Zertifizierungsstellen-Datenbank öffnen"
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr "Problem beim Öffnen der Zertifizierungsstellen-Datenbank »%s«"
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr "Zertifizierungsstellen-Datenbank speichern unter …"
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
@@ -2592,7 +2592,7 @@ msgstr ""
 "gnoMint ist ein Programm zum Erzeugen und Verwalten von "
 "Zertifizierungsstellen und deren Zertifikaten"
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3606,82 +3606,95 @@ msgid "_Revoked Certificates"
 msgstr "Wider_rufene Zertifikate"
 
 #: gui/main_window.ui.h:27
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Zertifikat exportieren"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 msgid "Create a new database"
 msgstr "Eine neue Datenbank erstellen"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Eine existierende Datenbank öffnen"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr ""
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 #, fuzzy
 msgid "Add autosigned CA certificate"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 #, fuzzy
 msgid "Add a new Certificate Signing Request"
 msgstr "Signaturanfrage für Zertifikat:\n"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Zertifizierungsanfrage hinzufügen"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr ""
 "Geheimen Schlüssel des gewählten Objekts in eine externe Datei entpacken"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Geheimen Schlüssel entpacken"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Das ausgewählte Zertifikat widerrufen"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Widerrufen"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 #, fuzzy
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Signaturanfrage für Zertifikat:\n"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr "Signieren"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 #, fuzzy
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Signaturanfrage für Zertifikat:\n"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 #, fuzzy
 msgid "Quick certificate generation for web server"
 msgstr "Erzeugung des Zertifikats ist fehlgeschlagen"
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 #, fuzzy
 msgid "Web Server Wizard"
 msgstr "TLS-Webserver"
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 #, fuzzy
 msgid "Quick certificate generation for email server"
 msgstr "Erzeugung des Zertifikats ist fehlgeschlagen"
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 #, fuzzy
 msgid "Email Server Wizard"
 msgstr "TLS-Webserver"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -82,15 +82,15 @@ msgstr "Abrir base de datos de certificados"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificados</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -98,7 +98,7 @@ msgstr "<b>Solicitudes de certificación</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,85 +106,85 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Nº serie"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Activación"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Caducidad"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Revocación"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Exportar certificado"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 #, fuzzy
 msgid "_Cancel"
 msgstr "Francia"
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Exportar solicitud de certificación"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Ocurrió un error al exportar el certificado"
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr "Ocurrió un error al exportar la solicitud de certificación."
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Certificado exportado con éxito"
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr "Solicitud de certificación exportada correctamente"
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr "Exportar clave privada cifrada."
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Clave privada exportada con éxito"
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportar clave privada sin cifrar."
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportar todo el certificado en un paquete PKCS#12"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Exportar solicitud de certificación - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -192,7 +192,7 @@ msgstr ""
 "Seleccione qué parte almacenada de la solicitud de certificación desea "
 "exportar:"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -200,7 +200,7 @@ msgstr ""
 "<i>Exporta la solicitud de certificación a un fichero público en formato "
 "PEM</i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -210,15 +210,15 @@ msgstr ""
 "clave. Este fichero sólo debería ser accesible para el titular de la "
 "soliticud de certificación.</i>"
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -228,11 +228,11 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado de AC?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -250,15 +250,15 @@ msgstr ""
 "certificados generados con él, por lo que todos deberían regenerarse con un "
 "nuevo certificado de AC."
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr "Cambiando contraseña de AC - gnoMint"
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -266,60 +266,60 @@ msgstr ""
 "La contraseña actual que ha introducido no coincide con la contraseña real "
 "de la base de datos."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. Se canceló la "
 "operación."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al establecer la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr "Contraseña establecida con éxito"
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "Contraseña eliminada con éxito"
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Guardar parámetros Diffie-Hellman"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parámetros Diffie-Hellman guardados correctamente"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "Seleccione fichero PEM a importar"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Hubo problemas al importar el fichero '%s'"
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr "Seleccione directorio a importar"
 
@@ -1785,7 +1785,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "David Marín Carreño <davefx@gmail.com>\n"
@@ -2518,7 +2518,7 @@ msgstr "Ocurrió un error al exportar el certificado."
 msgid "- A Certification Authority manager"
 msgstr "-Un gestor de Autoridades de Certificación"
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr "Fallo al inicializar: %s\n"
@@ -2673,15 +2673,15 @@ msgstr ""
 "Los ficheros existentes en el directorio no pertenecen a ningún formato "
 "soportado de Autoridad de Certificación."
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr "- Un gestor gráfico de Autoridades de Certificación"
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr "Crear nueva base de datos de AC"
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
@@ -2690,25 +2690,25 @@ msgstr ""
 "Hubo problemas al crear la base de datos de la AC '%s':\n"
 "%s"
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr "Hubo problemas al abrir la nueva base de datos de la AC '%s'"
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr "Abrir base de datos de AC"
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr "Hubo problemas al abrir la base de datos de la AC '%s'"
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr "Guardar base de datos de AC como..."
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
@@ -2716,7 +2716,7 @@ msgstr ""
 "gnoMint es un programa diseñado para crear y gestionar Autoridades de "
 "Certificación, así como sus certificados"
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3063,7 +3063,9 @@ msgstr "¡Certificado generado con éxito!"
 
 #: src/wizard_window.c:412
 msgid "No Certificate Authority found. Please create a CA first."
-msgstr "No se encontró ninguna Autoridad de Certificación. Por favor, cree primero una AC."
+msgstr ""
+"No se encontró ninguna Autoridad de Certificación. Por favor, cree primero "
+"una AC."
 
 #: gui/certificate_popup_menu.ui.h:1
 msgid "Shows the certificate properties window"
@@ -3110,7 +3112,8 @@ msgstr "Añadir certificado de servidor _web (asistente)"
 
 #: gui/certificate_popup_menu.ui.h:12
 msgid "Quick certificate generation for a web server, signed by this CA"
-msgstr "Generación rápida de un certificado para un servidor web, firmado por esta AC"
+msgstr ""
+"Generación rápida de un certificado para un servidor web, firmado por esta AC"
 
 #: gui/certificate_popup_menu.ui.h:13 gui/main_window.ui.h:11
 msgid "Add _Email Server Certificate (wizard)"
@@ -3118,7 +3121,9 @@ msgstr "Añadir certificado de servidor de _correo (asistente)"
 
 #: gui/certificate_popup_menu.ui.h:14
 msgid "Quick certificate generation for an email server, signed by this CA"
-msgstr "Generación rápida de un certificado para un servidor de correo, firmado por esta AC"
+msgstr ""
+"Generación rápida de un certificado para un servidor de correo, firmado por "
+"esta AC"
 
 #: gui/certificate_properties_dialog.ui.h:1
 msgid "Certificate properties - gnoMint"
@@ -3740,7 +3745,9 @@ msgstr "Añadir _solicitud de certificación"
 
 #: gui/main_window.ui.h:10
 msgid "Quick certificate generation for a web server, signed by an existing CA"
-msgstr "Generación rápida de un certificado para un servidor web, firmado por una AC existente"
+msgstr ""
+"Generación rápida de un certificado para un servidor web, firmado por una AC "
+"existente"
 
 #: gui/main_window.ui.h:12
 msgid ""
@@ -3789,74 +3796,90 @@ msgid "_Revoked Certificates"
 msgstr "Certificados _revocados"
 
 #: gui/main_window.ui.h:27
+msgid "E_xpired Certificates"
+msgstr "Certificados ca_ducados"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+"Si se desmarca, los certificados cuya validez ya ha terminado se ocultan "
+"del árbol. Un certificado también se considera caducado si lo está alguna "
+"de sus autoridades emisoras, de modo que un AC caducado oculta también "
+"todo su subárbol."
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr "Ay_uda"
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 msgid "Create a new database"
 msgstr "Crear nueva base de datos"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Abrir base de datos existente"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Añadir autoridad de certificación auto-firmada"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 msgid "Add autosigned CA certificate"
 msgstr "Añadir certificado de AC autofirmado"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 msgid "Add a new Certificate Signing Request"
 msgstr "Añadir nueva solicitud de certificación"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Añadir CSR"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr "Extrae la clave privada del elemento seleccionado a un fichero externo"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Extraer clave privada"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Revocar el certificado seleccionado"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Revocar"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Firmar la solicitud de certificación seleccionada"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr "Firmar"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Borrar la solicitud de certificación seleccionada"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 msgid "Quick certificate generation for web server"
 msgstr "Generación rápida de un certificado para un servidor web"
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 msgid "Web Server Wizard"
 msgstr "Asistente de servidor web"
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 msgid "Quick certificate generation for email server"
 msgstr "Generación rápida de un certificado para un servidor de correo"
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr "Asistente de servidor de correo"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -78,15 +78,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -94,7 +94,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -102,121 +102,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:993
+#: src/ca.c:1070
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -227,68 +227,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2433,46 +2433,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3419,76 +3419,89 @@ msgid "_Revoked Certificates"
 msgstr "Peruttujen varmenteiden näkyvyys"
 
 #: gui/main_window.ui.h:27
-msgid "_Help"
-msgstr ""
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Peruttujen varmenteiden näkyvyys"
 
 #: gui/main_window.ui.h:28
-msgid "Create a new database"
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
 msgstr ""
 
 #: gui/main_window.ui.h:29
-msgid "Open an existing database"
+msgid "_Help"
 msgstr ""
 
 #: gui/main_window.ui.h:30
-msgid "Add an autosigned CA"
+msgid "Create a new database"
 msgstr ""
 
 #: gui/main_window.ui.h:31
+msgid "Open an existing database"
+msgstr ""
+
+#: gui/main_window.ui.h:32
+msgid "Add an autosigned CA"
+msgstr ""
+
+#: gui/main_window.ui.h:33
 #, fuzzy
 msgid "Add autosigned CA certificate"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 msgid "Add a new Certificate Signing Request"
 msgstr ""
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr ""
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr ""
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr ""
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 #, fuzzy
 msgid "Revoke the selected certificate"
 msgstr "Peruttujen varmenteiden näkyvyys"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr ""
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr ""
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr ""
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr ""
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 msgid "Quick certificate generation for web server"
 msgstr ""
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 msgid "Web Server Wizard"
 msgstr ""
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 msgid "Quick certificate generation for email server"
 msgstr ""
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -81,15 +81,15 @@ msgstr "_Ouvrir une base de données de certificats"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Demandes en signature de certificat</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,84 +106,84 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Numéro"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Activation"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Expiration"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Révocation"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Exporter un certificat"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Exporter une CSR"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Erreur pendant l'exportation du certificat."
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr "Erreur pendant l'exportation de la Requête de Signature de Certificat."
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Certificat exporté avec succès."
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr "CSR exporté avec succès."
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr "Exporter la clé privée chiffrée"
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Clé privée exportée avec succès"
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporter la clé privée non chiffrée"
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporter l'intégralité du certificat vers un paquet au format PKCS#12"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Exportation de Requête de Signature de Certificat - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -191,13 +191,13 @@ msgstr ""
 "Veuillez choisir la partie de la Requête de Signature de Certificat "
 "sauvegardée que vous souhaitez exporter :"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr "<i>Exporter la CSR vers un fichier public, au format PEM.</i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -207,27 +207,27 @@ msgstr ""
 "passe, au format PKCS#8. Ce fichier ne devrait être accessible que par le "
 "titulaire de la CSR.</i>"
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -238,16 +238,16 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr "Modifier le mot de passe de l'Autorité de Certification - gnoMint"
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -255,60 +255,60 @@ msgstr ""
 "Le mot de passe que vous venez d'entrer ne correspond pas au mot de passe "
 "actuel de la base de données."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant l'affectationdu mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr "Mot de passe mis en place avec succès."
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "Mot de passe supprimé avec succès."
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Sauvegarder les paramètres Diffie-Hellman"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Les paramètres Diffie-Hellman ont été sauvegardés avec succès"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "Choisir le fichier PEM à importer"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problème pendant l'importation du fichier '%s'"
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr "Sélectionner le répertoire à importer"
 
@@ -1738,7 +1738,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2424,7 +2424,7 @@ msgstr "Erreur pendant l'exportation du certificat."
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr "L'initialisation a échoué : %s\n"
@@ -2564,42 +2564,42 @@ msgstr "Erreur pendant l'ouverture du répertoire keys/."
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr "- Un gestionnaire graphique d'Autorité de Certification"
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr "Créer une nouvelle base de données d'Autorité de Certification"
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr "Ouvrir une base de données d'Autorité de Certification"
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 "Problème pendant l'ouverture de la base de données de l'Autorité de "
 "Certification '%s'"
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr "Sauvegarder la base de données de l'Autorité de Certification sous..."
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
@@ -2607,7 +2607,7 @@ msgstr ""
 "gnoMint est un programme permettant de créer et de gérer des Autorités de "
 "Certification, et leurs certificats."
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3657,78 +3657,91 @@ msgid "_Revoked Certificates"
 msgstr "Certificats _révoqués"
 
 #: gui/main_window.ui.h:27
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Exporter un certificat"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr "_Aide"
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 msgid "Create a new database"
 msgstr "Création d'une nouvelle base de données"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Ouvrir une base de données existante"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Ajouter une Autorité de Certification auto-signée"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 msgid "Add autosigned CA certificate"
 msgstr "Ajouter un certificat d'Autorité de Certification auto-signée"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 msgid "Add a new Certificate Signing Request"
 msgstr "Ajouter une nouvelle Requête de Signature de Certificat"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Ajouter une CSR"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr ""
 "Extraire la clé privée de l'élément sélectionné dans un fichier externe"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Extraire la clé privée"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Révoquer le certificat sélectionné"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Révoquer"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Signer la CSR sélectionnée"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr "Signer"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Supprimer le CSR sélectionné"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 #, fuzzy
 msgid "Quick certificate generation for web server"
 msgstr "La génération du certificat a échoué"
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 #, fuzzy
 msgid "Web Server Wizard"
 msgstr "Serveur Web TLS"
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 #, fuzzy
 msgid "Quick certificate generation for email server"
 msgstr "La génération du certificat a échoué"
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 #, fuzzy
 msgid "Email Server Wizard"
 msgstr "Serveur Web TLS"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -81,15 +81,15 @@ msgstr "_Apri il database di certificato"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificati</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -105,84 +105,84 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Revoca"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Esporta certificato"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Esporta la richiesta di firma di certificato (CSR)"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Errore durante l'esportazione del certificato."
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr "Errore durante l'esportazione del CSR."
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Certificato esportato correttamente"
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr "Richiesta di firma di certificato (CSR) esportata correttamente"
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr "Esporta la chiave privata criptata"
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Chiave privata esportata correttamente"
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Esporta chiave privata non criptata"
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Esporta l'intero certificato nel pacchetto PKCS#12"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Esporta CSR - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -190,7 +190,7 @@ msgstr ""
 "Si prega di scegliere quale parte della richiesta di firma di certificato "
 "(CSR) salvata si vuole esportare:"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -198,7 +198,7 @@ msgstr ""
 "<i>Esporta la richiesta di firma di certificato (CSR) in un file pubblico, "
 "in formato PEM.</i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -208,27 +208,27 @@ msgstr ""
 "Questo file deve essere accessibile solamente da parte del soggetto della "
 "richiesta di firma di certificato (CSR).</i>"
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -239,17 +239,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -257,60 +257,60 @@ msgstr ""
 "La password attualmente inserita non corrisponde con la reale e corrente "
 "password del database."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la modifica della password del database. L'operazione è stata "
 "annullata."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Errore nello stabilire la password del database. L'operazione è stata "
 "annullata."
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr "Password stabilita correttamente"
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la rimozione della password del database. L'operazione è "
 "stata annullata."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "Password rimossa correttamente"
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Salva i parametri Diffie-Hellman"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parametri Diffie-Hellman salvati correttamente"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "Selezionare il file PEM da importare"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr ""
 
@@ -1691,7 +1691,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2368,7 +2368,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2514,46 +2514,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3588,81 +3588,94 @@ msgid "_Revoked Certificates"
 msgstr "_Certificati revocati"
 
 #: gui/main_window.ui.h:27
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Esporta certificato"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr ""
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 #, fuzzy
 msgid "Create a new database"
 msgstr "Creazione del database di CA"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Apri un database esistente"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Aggiungi un CA autofirmato"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 #, fuzzy
 msgid "Add autosigned CA certificate"
 msgstr "Aggiungi un CA autofirmato"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 #, fuzzy
 msgid "Add a new Certificate Signing Request"
 msgstr "Richiesta di firma di certificato (CSR):\n"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Aggiungi CSR"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr "Estrai la chiave privata dell'oggetto selezionato in un file esterno"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Estrai la chiave privata"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Revoca il certificato selezionato"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Revoca"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Firma la richiesta di firma del certificato selezionato"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 #, fuzzy
 msgid "Sign"
 msgstr "Firma"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Cancellazione della richiesta di firma certificato (CSR) selezionata"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 #, fuzzy
 msgid "Quick certificate generation for web server"
 msgstr "Generazione del certificato fallita"
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 #, fuzzy
 msgid "Web Server Wizard"
 msgstr "Server web TLS"
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 #, fuzzy
 msgid "Quick certificate generation for email server"
 msgstr "Generazione del certificato fallita"
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 #, fuzzy
 msgid "Email Server Wizard"
 msgstr "Server web TLS"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -93,7 +93,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -101,121 +101,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Periodic"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Activacion"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Expiracion"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Revocacion"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:993
+#: src/ca.c:1070
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Error inesperada"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -226,68 +226,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2306,7 +2306,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2437,46 +2437,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3418,74 +3418,87 @@ msgid "_Revoked Certificates"
 msgstr "<b>Certificats</b>"
 
 #: gui/main_window.ui.h:27
-msgid "_Help"
-msgstr "_Ajuda"
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "<b>Certificats</b>"
 
 #: gui/main_window.ui.h:28
-msgid "Create a new database"
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
 msgstr ""
 
 #: gui/main_window.ui.h:29
-msgid "Open an existing database"
-msgstr ""
+msgid "_Help"
+msgstr "_Ajuda"
 
 #: gui/main_window.ui.h:30
-msgid "Add an autosigned CA"
+msgid "Create a new database"
 msgstr ""
 
 #: gui/main_window.ui.h:31
-msgid "Add autosigned CA certificate"
+msgid "Open an existing database"
 msgstr ""
 
 #: gui/main_window.ui.h:32
-msgid "Add a new Certificate Signing Request"
+msgid "Add an autosigned CA"
 msgstr ""
 
 #: gui/main_window.ui.h:33
-msgid "Add CSR"
+msgid "Add autosigned CA certificate"
 msgstr ""
 
 #: gui/main_window.ui.h:34
-msgid "Extract the private key of the selected item into a external file"
+msgid "Add a new Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:35
-msgid "Extract Private Key"
+msgid "Add CSR"
 msgstr ""
 
 #: gui/main_window.ui.h:36
-msgid "Revoke the selected certificate"
+msgid "Extract the private key of the selected item into a external file"
 msgstr ""
 
 #: gui/main_window.ui.h:37
-msgid "Revoke"
-msgstr "Revocar"
+msgid "Extract Private Key"
+msgstr ""
 
 #: gui/main_window.ui.h:38
-msgid "Sign the selected Certificate Signing Request"
+msgid "Revoke the selected certificate"
 msgstr ""
 
 #: gui/main_window.ui.h:39
-msgid "Sign"
-msgstr "Signar"
+msgid "Revoke"
+msgstr "Revocar"
 
 #: gui/main_window.ui.h:40
-msgid "Delete the selected Certificate Signing Request"
+msgid "Sign the selected Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:41
-msgid "Quick certificate generation for web server"
-msgstr ""
+msgid "Sign"
+msgstr "Signar"
 
 #: gui/main_window.ui.h:42
-msgid "Web Server Wizard"
+msgid "Delete the selected Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:43
-msgid "Quick certificate generation for email server"
+msgid "Quick certificate generation for web server"
 msgstr ""
 
 #: gui/main_window.ui.h:44
+msgid "Web Server Wizard"
+msgstr ""
+
+#: gui/main_window.ui.h:45
+msgid "Quick certificate generation for email server"
+msgstr ""
+
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -93,7 +93,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -101,121 +101,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:993
+#: src/ca.c:1070
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -226,68 +226,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2432,46 +2432,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3416,75 +3416,88 @@ msgid "_Revoked Certificates"
 msgstr "Visibilidade de certificados revogados"
 
 #: gui/main_window.ui.h:27
-msgid "_Help"
-msgstr ""
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Visibilidade de certificados revogados"
 
 #: gui/main_window.ui.h:28
-msgid "Create a new database"
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
 msgstr ""
 
 #: gui/main_window.ui.h:29
-msgid "Open an existing database"
+msgid "_Help"
 msgstr ""
 
 #: gui/main_window.ui.h:30
-msgid "Add an autosigned CA"
+msgid "Create a new database"
 msgstr ""
 
 #: gui/main_window.ui.h:31
-msgid "Add autosigned CA certificate"
+msgid "Open an existing database"
 msgstr ""
 
 #: gui/main_window.ui.h:32
-msgid "Add a new Certificate Signing Request"
+msgid "Add an autosigned CA"
 msgstr ""
 
 #: gui/main_window.ui.h:33
-msgid "Add CSR"
+msgid "Add autosigned CA certificate"
 msgstr ""
 
 #: gui/main_window.ui.h:34
-msgid "Extract the private key of the selected item into a external file"
+msgid "Add a new Certificate Signing Request"
 msgstr ""
 
 #: gui/main_window.ui.h:35
-msgid "Extract Private Key"
+msgid "Add CSR"
 msgstr ""
 
 #: gui/main_window.ui.h:36
+msgid "Extract the private key of the selected item into a external file"
+msgstr ""
+
+#: gui/main_window.ui.h:37
+msgid "Extract Private Key"
+msgstr ""
+
+#: gui/main_window.ui.h:38
 #, fuzzy
 msgid "Revoke the selected certificate"
 msgstr "Visibilidade de certificados revogados"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr ""
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr ""
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr ""
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr ""
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 msgid "Quick certificate generation for web server"
 msgstr ""
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 msgid "Web Server Wizard"
 msgstr ""
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 msgid "Quick certificate generation for email server"
 msgstr ""
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -81,15 +81,15 @@ msgstr "_Открыть базу сертификатов"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Сертификат</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Запрос на Подпись Сертификата</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,84 +106,84 @@ msgstr "%m/%d/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Серийный номер"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Активация"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Срок истечения"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Отзыв"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Экспорт сертификата"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Экспорт запроса на подпись сертификата"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Произошла ошибка во время экспорта сертификата."
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr "Произошла ошибка во время экспорта CSR."
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Сертификат успешно экспортирован"
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr "Запрос на подпись сертификата успешно экспортирован"
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr "Экспорт зашифрованного закрытого ключ"
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Закрытый ключ успешно экспортирован"
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Экспорт незашифрованного закрытого ключа"
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Экспорт всего сертификата в PKCS#12 пакет"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Экспорт CSR - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -191,7 +191,7 @@ msgstr ""
 "Пожалуйста, выберите какую часть сохранённого Запроса на Подпись Сертификата "
 "вы хотите экспортировать:"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -199,7 +199,7 @@ msgstr ""
 "<i>Экспорт Запроса на Подпись Сертификата в незашифрованный файл PEM формата."
 "</i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -208,27 +208,27 @@ msgstr ""
 "<i>Экспрорт сохранённого закрытого ключа в PKCS#8 файл защищённый паролем. "
 "Этот файл должен быть доступен владельцу Запроса на Подпись Сертификата.</i>"
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Неожиданная ошибка"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -239,15 +239,15 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr "Изменить CA пароль - gnoMint"
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -255,54 +255,54 @@ msgstr ""
 "Текущий пароль, который вы ввели, не совпадает с текущим актуальным паролем "
 "базы."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr "Произошла  ошибка при смене пароля базы. Операция отменена."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr "Пароль установлен успешно"
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr "Произошла ошибка при удалении пароля базы. Операция отменена."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "Пароль удалён успешно."
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Сохранить Diffie-Hellman параметры"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Параметры Diffie-Hellman сохранены успешно"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "Выберите PEM файл для импорта"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Проблема при импорте файла '%s'"
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr "Выберите каталог для импорта"
 
@@ -1761,7 +1761,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2491,7 +2491,7 @@ msgstr "Произошла ошибка во время экспорта сер�
 msgid "- A Certification Authority manager"
 msgstr "- управление Центром Авторизации"
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr "Не удалось инициализировать: %s\n"
@@ -2644,15 +2644,15 @@ msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 "Файлы в каталоге не принадлежат какому-либо поддерживаемому формату CA."
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr "- графический менеджер Центра Авторизации"
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr "Создать новую базу CA"
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
@@ -2661,25 +2661,25 @@ msgstr ""
 "Проблема при создании базы CA '%s':\n"
 "%s"
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr "Проблема при открытии новой '%s' базы CA"
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr "Открыть базу CA"
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr "Проблема при открытии базы CA '%s'"
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr "Сохранить базу CA как..."
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
@@ -2687,7 +2687,7 @@ msgstr ""
 "gnoMint это программа для создания и управления Центром Сертификации и его "
 "сертификатами"
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3758,77 +3758,90 @@ msgid "_Revoked Certificates"
 msgstr "_Отозванные Сертификаты"
 
 #: gui/main_window.ui.h:27
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Экспорт сертификата"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr "_Справка"
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 msgid "Create a new database"
 msgstr "Создать новую базу"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Открыть существующую базу"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Добавить самоподписанный CA"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 msgid "Add autosigned CA certificate"
 msgstr "Добавить самоподписанный CA сертификат"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 msgid "Add a new Certificate Signing Request"
 msgstr "Добавить новый Запрос на Подпись Сертификата"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Добавить CSR"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr "Извлечь закрытый ключ выбранного объекта во внешний файл"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Извлечь Закрытый Ключ"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Отозвать выбранные сертификаты"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Отозвать"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Подписать выбранный Запрос на Подпись Сертификата"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr "Подписать"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Удалить выбранный Запрос на Подпись Сертификата"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 #, fuzzy
 msgid "Quick certificate generation for web server"
 msgstr "Создание сертификата не удалось"
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 #, fuzzy
 msgid "Web Server Wizard"
 msgstr "TLS Веб сервер"
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 #, fuzzy
 msgid "Quick certificate generation for email server"
 msgstr "Создание сертификата не удалось"
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 #, fuzzy
 msgid "Email Server Wizard"
 msgstr "TLS Веб сервер"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -78,15 +78,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -94,7 +94,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -102,121 +102,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:993
+#: src/ca.c:1070
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -227,68 +227,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2434,46 +2434,46 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr ""
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr ""
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr ""
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr ""
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
 msgstr ""
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3465,79 +3465,92 @@ msgid "_Revoked Certificates"
 msgstr "Viditeľnosť zrušených certifikátov"
 
 #: gui/main_window.ui.h:27
-msgid "_Help"
-msgstr ""
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Pridať _žiadosť o vydanie certifikátu"
 
 #: gui/main_window.ui.h:28
-msgid "Create a new database"
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
 msgstr ""
 
 #: gui/main_window.ui.h:29
-msgid "Open an existing database"
+msgid "_Help"
 msgstr ""
 
 #: gui/main_window.ui.h:30
+msgid "Create a new database"
+msgstr ""
+
+#: gui/main_window.ui.h:31
+msgid "Open an existing database"
+msgstr ""
+
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Pridať self-signed CA"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 #, fuzzy
 msgid "Add autosigned CA certificate"
 msgstr "Pridať self-signed CA"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 #, fuzzy
 msgid "Add a new Certificate Signing Request"
 msgstr "Pridať novú žiadosť o vydanie certifikátu"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr "Pridať žiadosť o vydanie certifikátu"
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr ""
 
-#: gui/main_window.ui.h:35
-msgid "Extract Private Key"
-msgstr ""
-
-#: gui/main_window.ui.h:36
-#, fuzzy
-msgid "Revoke the selected certificate"
-msgstr "Viditeľnosť zrušených certifikátov"
-
 #: gui/main_window.ui.h:37
-msgid "Revoke"
+msgid "Extract Private Key"
 msgstr ""
 
 #: gui/main_window.ui.h:38
 #, fuzzy
-msgid "Sign the selected Certificate Signing Request"
-msgstr "Pridať novú žiadosť o vydanie certifikátu"
+msgid "Revoke the selected certificate"
+msgstr "Viditeľnosť zrušených certifikátov"
 
 #: gui/main_window.ui.h:39
-msgid "Sign"
+msgid "Revoke"
 msgstr ""
 
 #: gui/main_window.ui.h:40
 #, fuzzy
-msgid "Delete the selected Certificate Signing Request"
+msgid "Sign the selected Certificate Signing Request"
 msgstr "Pridať novú žiadosť o vydanie certifikátu"
 
 #: gui/main_window.ui.h:41
-msgid "Quick certificate generation for web server"
+msgid "Sign"
 msgstr ""
 
 #: gui/main_window.ui.h:42
-msgid "Web Server Wizard"
-msgstr ""
+#, fuzzy
+msgid "Delete the selected Certificate Signing Request"
+msgstr "Pridať novú žiadosť o vydanie certifikátu"
 
 #: gui/main_window.ui.h:43
-msgid "Quick certificate generation for email server"
+msgid "Quick certificate generation for web server"
 msgstr ""
 
 #: gui/main_window.ui.h:44
+msgid "Web Server Wizard"
+msgstr ""
+
+#: gui/main_window.ui.h:45
+msgid "Quick certificate generation for email server"
+msgstr ""
+
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 06:28+0200\n"
+"POT-Creation-Date: 2026-05-21 11:12+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -80,15 +80,15 @@ msgstr "_Öppna certifikatdatabas"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:150
+#: src/ca.c:223
 msgid "<b>Certificates</b>"
 msgstr "<b>Certifikat</b>"
 
-#: src/ca.c:288
+#: src/ca.c:361
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
-#: src/ca.c:331 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -96,7 +96,7 @@ msgstr "<b>Certifikatsigneringsbegäran</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: src/ca.c:334 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -105,84 +105,84 @@ msgstr "%Y/%m/%d %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: src/ca.c:479 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
-#: src/ca.c:514
+#: src/ca.c:591
 msgid "Serial"
 msgstr "Serienummer"
 
-#: src/ca.c:521
+#: src/ca.c:598
 msgid "Activation"
 msgstr "Aktivering"
 
-#: src/ca.c:528
+#: src/ca.c:605
 msgid "Expiration"
 msgstr "Utgång"
 
-#: src/ca.c:535
+#: src/ca.c:612
 msgid "Revocation"
 msgstr "Spärrning"
 
-#: src/ca.c:833
+#: src/ca.c:910
 msgid "Export certificate"
 msgstr "Exportera certifikat"
 
-#: src/ca.c:836 src/ca.c:843 src/ca.c:945 src/ca.c:996 src/ca.c:1047
-#: src/ca.c:1876 src/ca.c:1982 src/ca.c:2016 src/crl.c:257 src/main.c:328
-#: src/main.c:400 src/main.c:488 gui/san_editor_dialog.ui.h:9
+#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
+#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:837 src/ca.c:844 src/ca.c:946 src/ca.c:997 src/ca.c:1048
-#: src/ca.c:1877 src/crl.c:258
+#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
+#: src/ca.c:1971 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:840
+#: src/ca.c:917
 msgid "Export certificate signing request"
 msgstr "Exportera certificate signing request"
 
-#: src/ca.c:855 src/ca.c:891 src/ca.c:901 src/export.c:278
+#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Det inträffade ett fel då certifikatet skulle exporteras."
 
-#: src/ca.c:857 src/ca.c:893 src/ca.c:903
+#: src/ca.c:934 src/ca.c:970 src/ca.c:980
 msgid "There was an error while exporting CSR."
 msgstr "Det inträffade ett fel då CSR skulle exporteras."
 
-#: src/ca.c:916 src/ca.c:1082
+#: src/ca.c:993 src/ca.c:1159
 msgid "Certificate exported successfully"
 msgstr "Certifikatet exporterades"
 
-#: src/ca.c:923
+#: src/ca.c:1000
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:942
+#: src/ca.c:1019
 msgid "Export crypted private key"
 msgstr "Exportera krypterad privat nyckel"
 
-#: src/ca.c:971 src/ca.c:1023
+#: src/ca.c:1048 src/ca.c:1100
 msgid "Private key exported successfully"
 msgstr "Privat nyckel exporterades"
 
-#: src/ca.c:993
+#: src/ca.c:1070
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportera okrypterad privat nyckel"
 
-#: src/ca.c:1044
+#: src/ca.c:1121
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportera helt certifikat i PKCS#12-paket"
 
-#: src/ca.c:1115
+#: src/ca.c:1192
 msgid "Export CSR - gnoMint"
 msgstr "Exportera CSR - gnoMint"
 
-#: src/ca.c:1120
+#: src/ca.c:1197
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -190,7 +190,7 @@ msgstr ""
 "Vänligen välj vilken del av den sparade Certificate Signing Request du vill "
 "exportera:"
 
-#: src/ca.c:1125
+#: src/ca.c:1202
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -198,7 +198,7 @@ msgstr ""
 "<i>Exportera Certificate Signing Request till en publik fil, i PEM-format.</"
 "i>"
 
-#: src/ca.c:1130
+#: src/ca.c:1207
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -208,27 +208,27 @@ msgstr ""
 "fil. Filen bör endast kunna kommas åt av den till vilken Certificate Signing "
 "Request är utfärdat.</i>"
 
-#: src/ca.c:1194
+#: src/ca.c:1271
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: src/ca.c:1254
+#: src/ca.c:1331
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: src/ca.c:1255
+#: src/ca.c:1332
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1263
+#: src/ca.c:1340
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: src/ca.c:1264
+#: src/ca.c:1341
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -239,72 +239,72 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1307
+#: src/ca.c:1384
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: src/ca.c:1654
+#: src/ca.c:1748
 msgid "Change CA password - gnoMint"
 msgstr "Ändra CA-lösenord - gnoMint"
 
-#: src/ca.c:1672
+#: src/ca.c:1766
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 "Det lösenord Du skrivit in är inte det som behövs för den valda databasen."
 
-#: src/ca.c:1687
+#: src/ca.c:1781
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle bytas. Operationen avbröts."
 
-#: src/ca.c:1696
+#: src/ca.c:1790
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: src/ca.c:1706 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1716
+#: src/ca.c:1810
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1726
+#: src/ca.c:1820
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle tas bort. Operationen "
 "avbröts."
 
-#: src/ca.c:1735
+#: src/ca.c:1829
 msgid "Password removed successfully"
 msgstr "Lösenordet togs bort"
 
-#: src/ca.c:1873
+#: src/ca.c:1967
 msgid "Save Diffie-Hellman parameters"
 msgstr "Spara Diffie-Hellman-parametrar"
 
-#: src/ca.c:1899
+#: src/ca.c:1993
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-parametrar sparades"
 
 #. Import single file
-#: src/ca.c:1979
+#: src/ca.c:2073
 msgid "Select PEM file to import"
 msgstr "Välj PEM-fil att importera"
 
-#: src/ca.c:1983 src/ca.c:2017 src/main.c:329 src/main.c:401 src/main.c:489
+#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2000
+#: src/ca.c:2094
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Ett problem inträffade vid importerandet av filen '%s'"
 
-#: src/ca.c:2013
+#: src/ca.c:2107
 msgid "Select directory to import"
 msgstr "Välj katalog att importera"
 
@@ -1670,7 +1670,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:542
+#: src/ca-cli-callbacks.c:1535 src/ca-cli-callbacks.c:1536 src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
@@ -2338,7 +2338,7 @@ msgstr ""
 msgid "- A Certification Authority manager"
 msgstr ""
 
-#: src/gnomint-cli.c:60 src/main.c:129
+#: src/gnomint-cli.c:60 src/main.c:130
 #, c-format
 msgid "Failed to initialize: %s\n"
 msgstr ""
@@ -2469,40 +2469,40 @@ msgstr ""
 msgid "Files in the directory don't belong to any supported CA format."
 msgstr ""
 
-#: src/main.c:126
+#: src/main.c:127
 msgid "- A graphical Certification Authority manager"
 msgstr "- En grafisk hanterare för certifikatutfärdare"
 
-#: src/main.c:325
+#: src/main.c:327
 msgid "Create new CA database"
 msgstr "Skapa ny CA-databas"
 
-#: src/main.c:363
+#: src/main.c:365
 #, c-format
 msgid ""
 "Problem when creating '%s' CA database:\n"
 "%s"
 msgstr ""
 
-#: src/main.c:376
+#: src/main.c:378
 #, c-format
 msgid "Problem when opening new '%s' CA database"
 msgstr ""
 
-#: src/main.c:397
+#: src/main.c:399
 msgid "Open CA database"
 msgstr "Öppna CA-databas"
 
-#: src/main.c:420 src/main.c:460
+#: src/main.c:422 src/main.c:462
 #, c-format
 msgid "Problem when opening '%s' CA database"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:487
 msgid "Save CA database as..."
 msgstr "Spara CA-databas som..."
 
-#: src/main.c:537
+#: src/main.c:539
 msgid ""
 "gnoMint is a program for creating and managing Certification Authorities, "
 "and their certificates"
@@ -2510,7 +2510,7 @@ msgstr ""
 "gnoMint är ett program för att skapa och hantera certifikatutfärdare och "
 "deras certifikat"
 
-#: src/main.c:538
+#: src/main.c:540
 msgid ""
 "This program is free software; you can redistribute it and/or modify it "
 "under the terms of the GNU General Public License as published by the Free "
@@ -3536,79 +3536,92 @@ msgid "_Revoked Certificates"
 msgstr "Spä_rrade certifikat"
 
 #: gui/main_window.ui.h:27
+#, fuzzy
+msgid "E_xpired Certificates"
+msgstr "Exportera certifikat"
+
+#: gui/main_window.ui.h:28
+msgid ""
+"When unchecked, certificates whose validity has already ended are hidden "
+"from the tree. A certificate is also considered expired if any of its "
+"issuing CAs has expired, so an expired CA's whole subtree is hidden "
+"alongside it."
+msgstr ""
+
+#: gui/main_window.ui.h:29
 msgid "_Help"
 msgstr "_Hjälp"
 
-#: gui/main_window.ui.h:28
+#: gui/main_window.ui.h:30
 msgid "Create a new database"
 msgstr "Skapa en ny databas"
 
-#: gui/main_window.ui.h:29
+#: gui/main_window.ui.h:31
 msgid "Open an existing database"
 msgstr "Öppna en existerande databas"
 
-#: gui/main_window.ui.h:30
+#: gui/main_window.ui.h:32
 msgid "Add an autosigned CA"
 msgstr "Lägg till en autosignerad CA"
 
-#: gui/main_window.ui.h:31
+#: gui/main_window.ui.h:33
 #, fuzzy
 msgid "Add autosigned CA certificate"
 msgstr "Lägg till en autosignerad CA"
 
-#: gui/main_window.ui.h:32
+#: gui/main_window.ui.h:34
 #, fuzzy
 msgid "Add a new Certificate Signing Request"
 msgstr "Signera vald Certificate Signing Request"
 
-#: gui/main_window.ui.h:33
+#: gui/main_window.ui.h:35
 msgid "Add CSR"
 msgstr ""
 
-#: gui/main_window.ui.h:34
+#: gui/main_window.ui.h:36
 msgid "Extract the private key of the selected item into a external file"
 msgstr "Extrahera den privata nyckeln från valt objekt till en extern fil"
 
-#: gui/main_window.ui.h:35
+#: gui/main_window.ui.h:37
 msgid "Extract Private Key"
 msgstr "Extrahera privat nyckel"
 
-#: gui/main_window.ui.h:36
+#: gui/main_window.ui.h:38
 msgid "Revoke the selected certificate"
 msgstr "Återkalla det valda certifikatet"
 
-#: gui/main_window.ui.h:37
+#: gui/main_window.ui.h:39
 msgid "Revoke"
 msgstr "Återkalla"
 
-#: gui/main_window.ui.h:38
+#: gui/main_window.ui.h:40
 msgid "Sign the selected Certificate Signing Request"
 msgstr "Signera vald Certificate Signing Request"
 
-#: gui/main_window.ui.h:39
+#: gui/main_window.ui.h:41
 msgid "Sign"
 msgstr "Signera"
 
-#: gui/main_window.ui.h:40
+#: gui/main_window.ui.h:42
 #, fuzzy
 msgid "Delete the selected Certificate Signing Request"
 msgstr "Signera vald Certificate Signing Request"
 
-#: gui/main_window.ui.h:41
+#: gui/main_window.ui.h:43
 #, fuzzy
 msgid "Quick certificate generation for web server"
 msgstr "Certifikatgenerering misslyckades"
 
-#: gui/main_window.ui.h:42
+#: gui/main_window.ui.h:44
 msgid "Web Server Wizard"
 msgstr ""
 
-#: gui/main_window.ui.h:43
+#: gui/main_window.ui.h:45
 #, fuzzy
 msgid "Quick certificate generation for email server"
 msgstr "Certifikatgenerering misslyckades"
 
-#: gui/main_window.ui.h:44
+#: gui/main_window.ui.h:46
 msgid "Email Server Wizard"
 msgstr ""
 

--- a/src/ca.c
+++ b/src/ca.c
@@ -65,7 +65,11 @@ enum {CA_MODEL_COLUMN_ID=0,
       CA_MODEL_COLUMN_PARENT_ROUTE=11,
       CA_MODEL_COLUMN_ITEM_TYPE=12,
       CA_MODEL_COLUMN_PARENT_ID=13, /* Only for CSRs */
-      CA_MODEL_COLUMN_NUMBER=14}
+      CA_MODEL_COLUMN_FOREGROUND=14, /* GdkRGBA-style color name, or NULL
+                                      * for default. "gray" for certs
+                                      * with effective_expiration past
+                                      * the current time. */
+      CA_MODEL_COLUMN_NUMBER=15}
         CaModelColumns;
 
 enum {CSR_MODEL_COLUMN_ID=0,
@@ -94,6 +98,16 @@ static GtkTreeIter * csr_parent_iter = NULL;
 
 static gboolean view_csr = TRUE;
 static gboolean view_rcrt = TRUE;
+static gboolean view_expired = TRUE;
+
+/* Map ca_id (guint64 boxed as a pointer) → effective_expiration (time_t
+ * boxed as a pointer). Used by the hide-expired filter to enforce the
+ * RFC 5280 rule that a certificate's effective validity ends with its
+ * issuing CA. Populated as ca_file_foreach_crt iterates: CAs come before
+ * their descendants in hierarchical order, so by the time a descendant
+ * is processed its CA's effective_expiration is already cached. Reset
+ * each ca_refresh_model_callback. */
+static GHashTable *ca_effective_expiration = NULL;
 
 
 int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char **columnNames);
@@ -143,7 +157,70 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
         guint64 uint64_value;
 	const gchar * string_value;
 	gchar * last_node_route = NULL;
-	
+
+	/* Compute this cert's *effective* expiration: the earliest of its
+	 * own notAfter and every ancestor CA's notAfter, per RFC 5280.
+	 *
+	 * Parent lookup uses parent_route, which is colon-delimited like
+	 * ":3:5:" (this cert's parent is id 5, grandparent is id 3). For
+	 * top-level certs parent_route is ":" — no parent, so effective
+	 * expiration is just self_expiration.
+	 *
+	 * Because ca_file_foreach_crt yields certs in hierarchical order,
+	 * by the time we see a leaf cert the entire CA chain is already
+	 * cached in ca_effective_expiration. We also cache CAs we process
+	 * so that any cert further down can look us up. */
+	time_t self_expiration = (argv[CA_FILE_CERT_COLUMN_EXPIRATION] &&
+				  argv[CA_FILE_CERT_COLUMN_EXPIRATION][0])
+		? (time_t) g_ascii_strtoll (
+		    argv[CA_FILE_CERT_COLUMN_EXPIRATION], NULL, 10)
+		: 0;
+	time_t effective_expiration = self_expiration;
+
+	if (argv[CA_FILE_CERT_COLUMN_PARENT_ROUTE]) {
+		const gchar *route = argv[CA_FILE_CERT_COLUMN_PARENT_ROUTE];
+		const gchar *trailing = strrchr (route, ':');
+		/* route looks like ":3:5:" — the immediate parent id sits
+		 * between the second-to-last and the last ':'. */
+		if (trailing && trailing != route) {
+			const gchar *p = trailing - 1;
+			while (p > route && *p != ':')
+				p--;
+			if (*p == ':' && p + 1 < trailing) {
+				guint64 parent_id = g_ascii_strtoull (p + 1, NULL, 10);
+				gpointer key = GUINT_TO_POINTER ((guint) parent_id);
+				if (ca_effective_expiration &&
+				    g_hash_table_contains (ca_effective_expiration, key)) {
+					time_t parent_eff = (time_t) GPOINTER_TO_INT (
+					    g_hash_table_lookup (ca_effective_expiration, key));
+					if (parent_eff > 0 &&
+					    (effective_expiration == 0 ||
+					     parent_eff < effective_expiration))
+						effective_expiration = parent_eff;
+				}
+			}
+		}
+	}
+
+	/* Cache this CA's effective expiration so descendants pick it up. */
+	if (argv[CA_FILE_CERT_COLUMN_IS_CA] &&
+	    atoi (argv[CA_FILE_CERT_COLUMN_IS_CA]) == 1 &&
+	    argv[CA_FILE_CERT_COLUMN_ID] && ca_effective_expiration) {
+		guint64 self_id = g_ascii_strtoull (
+		    argv[CA_FILE_CERT_COLUMN_ID], NULL, 10);
+		g_hash_table_insert (ca_effective_expiration,
+		                     GUINT_TO_POINTER ((guint) self_id),
+		                     GINT_TO_POINTER ((gint) effective_expiration));
+	}
+
+	/* Skip if hiding expired and this cert (or its CA chain) is past. */
+	if (! view_expired && effective_expiration > 0 &&
+	    effective_expiration < time (NULL)) {
+		g_free (last_id_value);
+		g_free (last_parent_route_value);
+		return 0;
+	}
+
 	if (cert_title_inserted == FALSE) {
 		gtk_tree_store_append (new_model, &iter, NULL);
 		gtk_tree_store_set (new_model, &iter,
@@ -225,7 +302,14 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 	
 	gtk_tree_store_append (new_model, &iter, (last_parent_iter ? last_parent_iter: cert_parent_iter));
 
-        if (! argv[CA_FILE_CERT_COLUMN_REVOCATION])        
+	/* Grey out the row if the certificate's effective validity has
+	 * ended. effective_expiration was computed above with cascade
+	 * through any parent CAs. */
+	const gchar *row_foreground =
+	    (effective_expiration > 0 && effective_expiration < time (NULL))
+	        ? "gray" : NULL;
+
+        if (! argv[CA_FILE_CERT_COLUMN_REVOCATION])
                 gtk_tree_store_set (new_model, &iter,
                                     CA_MODEL_COLUMN_ID, atoll(argv[CA_FILE_CERT_COLUMN_ID]),
                                     CA_MODEL_COLUMN_IS_CA, atoi(argv[CA_FILE_CERT_COLUMN_IS_CA]),
@@ -240,9 +324,10 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 				    CA_MODEL_COLUMN_PARENT_DN, argv[CA_FILE_CERT_COLUMN_PARENT_DN],
 				    CA_MODEL_COLUMN_PARENT_ROUTE, argv[CA_FILE_CERT_COLUMN_PARENT_ROUTE],
                                     CA_MODEL_COLUMN_ITEM_TYPE, 0,
+                                    CA_MODEL_COLUMN_FOREGROUND, row_foreground,
                                     -1);
         else {
-                gchar * revoked_subject = g_markup_printf_escaped ("<s>%s</s>", 
+                gchar * revoked_subject = g_markup_printf_escaped ("<s>%s</s>",
                                                                    argv[CA_FILE_CERT_COLUMN_SUBJECT]);
 
                 gtk_tree_store_set (new_model, &iter,
@@ -259,6 +344,7 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 				    CA_MODEL_COLUMN_PARENT_DN, argv[CA_FILE_CERT_COLUMN_PARENT_DN],
 				    CA_MODEL_COLUMN_PARENT_ROUTE, argv[CA_FILE_CERT_COLUMN_PARENT_ROUTE],
                                     CA_MODEL_COLUMN_ITEM_TYPE, 0,
+                                    CA_MODEL_COLUMN_FOREGROUND, row_foreground,
                                     -1);
 
                 g_free (revoked_subject);
@@ -440,14 +526,19 @@ gboolean ca_refresh_model_callback ()
            - Parent ID (only for CSR)
 	*/
 
-	new_model = gtk_tree_store_new (CA_MODEL_COLUMN_NUMBER, G_TYPE_UINT64, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_STRING, 
-					G_TYPE_INT, G_TYPE_INT, G_TYPE_INT, G_TYPE_BOOLEAN, G_TYPE_STRING, 
-					G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_INT, G_TYPE_STRING);
+	new_model = gtk_tree_store_new (CA_MODEL_COLUMN_NUMBER, G_TYPE_UINT64, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_STRING,
+					G_TYPE_INT, G_TYPE_INT, G_TYPE_INT, G_TYPE_BOOLEAN, G_TYPE_STRING,
+					G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_INT, G_TYPE_STRING,
+					G_TYPE_STRING /* FOREGROUND */);
 
 	cert_title_inserted = FALSE;
 	cert_parent_iter = NULL;
 	last_parent_iter = NULL;
 	last_cert_iter = NULL;
+
+	if (ca_effective_expiration)
+		g_hash_table_destroy (ca_effective_expiration);
+	ca_effective_expiration = g_hash_table_new (g_direct_hash, g_direct_equal);
 	csr_title_inserted=FALSE;
 	csr_parent_iter = NULL;
 
@@ -478,8 +569,9 @@ gboolean ca_refresh_model_callback ()
 		gtk_tree_view_insert_column_with_attributes (treeview,
 							     -1, _("Subject"), renderer,
 							     "markup", CA_MODEL_COLUMN_SUBJECT,
+							     "foreground", CA_MODEL_COLUMN_FOREGROUND,
 							     NULL);
-		
+
 /*                 gtk_tooltips_set_tip (table_tooltips, GTK_WIDGET(gtk_tree_view_get_column(treeview, column_number - 1)),  */
 /*                                       _("Subject of the certificate or request"),  */
 /*                                       _("This is the distinguished name (DN) of the certificate or request")); */
@@ -512,7 +604,8 @@ gboolean ca_refresh_model_callback ()
 
 		gtk_tree_view_insert_column_with_attributes (treeview,
                                                              -1, _("Serial"), renderer,
-                                                             "markup", CA_MODEL_COLUMN_SERIAL, 
+                                                             "markup", CA_MODEL_COLUMN_SERIAL,
+                                                             "foreground", CA_MODEL_COLUMN_FOREGROUND,
                                                              NULL);
 		
 		renderer = GTK_CELL_RENDERER(gtk_cell_renderer_text_new ());
@@ -521,6 +614,9 @@ gboolean ca_refresh_model_callback ()
 							    -1, _("Activation"), renderer,
 							    __ca_tree_view_date_datafunc,
 							    GINT_TO_POINTER(CA_MODEL_COLUMN_ACTIVATION), g_free);
+		gtk_tree_view_column_add_attribute (
+		    gtk_tree_view_get_column (treeview, -1 + (gint)gtk_tree_view_get_n_columns (treeview)),
+		    renderer, "foreground", CA_MODEL_COLUMN_FOREGROUND);
 
 		renderer = GTK_CELL_RENDERER(gtk_cell_renderer_text_new ());
 
@@ -528,14 +624,20 @@ gboolean ca_refresh_model_callback ()
 							    -1, _("Expiration"), renderer,
 							    __ca_tree_view_date_datafunc,
 							    GINT_TO_POINTER(CA_MODEL_COLUMN_EXPIRATION), g_free);
+		gtk_tree_view_column_add_attribute (
+		    gtk_tree_view_get_column (treeview, -1 + (gint)gtk_tree_view_get_n_columns (treeview)),
+		    renderer, "foreground", CA_MODEL_COLUMN_FOREGROUND);
 
                 renderer = GTK_CELL_RENDERER(gtk_cell_renderer_text_new ());
-                
+
                 columns_number = gtk_tree_view_insert_column_with_data_func (treeview,
                                                                              -1, _("Revocation"), renderer,
                                                                              __ca_tree_view_date_datafunc,
-                                                                             GINT_TO_POINTER(CA_MODEL_COLUMN_REVOCATION), 
+                                                                             GINT_TO_POINTER(CA_MODEL_COLUMN_REVOCATION),
                                                                              g_free);
+                gtk_tree_view_column_add_attribute (
+                    gtk_tree_view_get_column (treeview, columns_number - 1),
+                    renderer, "foreground", CA_MODEL_COLUMN_FOREGROUND);
                 
 
 	}
@@ -1419,6 +1521,23 @@ G_MODULE_EXPORT gboolean ca_rcrt_view_toggled (GtkCheckMenuItem *button, gpointe
         ca_update_revoked_view (gtk_check_menu_item_get_active (button), TRUE);
         if (view_rcrt != preferences_get_revoked_visible())
                 preferences_set_revoked_visible (view_rcrt);
+
+        return TRUE;
+}
+
+void ca_update_expired_view (gboolean new_value, gboolean refresh)
+{
+        view_expired = new_value;
+        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM(gtk_builder_get_object(main_window_gtkb, "expired_view_menuitem")), new_value);
+        if (refresh)
+                dialog_refresh_list();
+}
+
+G_MODULE_EXPORT gboolean ca_expired_view_toggled (GtkCheckMenuItem *button, gpointer user_data)
+{
+        ca_update_expired_view (gtk_check_menu_item_get_active (button), TRUE);
+        if (view_expired != preferences_get_expired_visible())
+                preferences_set_expired_visible (view_expired);
 
         return TRUE;
 }

--- a/src/ca.h
+++ b/src/ca.h
@@ -45,6 +45,8 @@ void ca_update_csr_view (gboolean new_value, gboolean refresh);
 gboolean ca_csr_view_toggled (GtkCheckMenuItem *button, gpointer user_data);
 void ca_update_revoked_view (gboolean new_value, gboolean refresh);
 gboolean ca_rcrt_view_toggled (GtkCheckMenuItem *button, gpointer user_data);
+void ca_update_expired_view (gboolean new_value, gboolean refresh);
+gboolean ca_expired_view_toggled (GtkCheckMenuItem *button, gpointer user_data);
 void ca_generate_crl (GtkCheckMenuItem *button, gpointer user_data);
 gboolean ca_treeview_popup_timeout_program_cb (gpointer data);
 void ca_treeview_popup_timeout_program (GdkEventButton *event);

--- a/src/main.c
+++ b/src/main.c
@@ -120,6 +120,7 @@ int main (int   argc,
 	
 	preferences_gui_set_csr_visible_callback (ca_update_csr_view);
 	preferences_gui_set_revoked_visible_callback (ca_update_revoked_view);
+	preferences_gui_set_expired_visible_callback (ca_update_expired_view);
 
         preferences_init (argc, argv);
 
@@ -168,6 +169,7 @@ int main (int   argc,
         }
         ca_update_revoked_view (preferences_get_revoked_visible(), FALSE);
         ca_update_csr_view (preferences_get_crq_visible(), FALSE);
+        ca_update_expired_view (preferences_get_expired_visible(), FALSE);
         
 
 	gtk_builder_connect_signals (main_window_gtkb, NULL);	       	

--- a/src/preferences-gui.c
+++ b/src/preferences-gui.c
@@ -30,6 +30,7 @@ static GSettings * preferences_settings;
 
 PreferencesGuiChangeCallback csr_visible_callback = NULL;
 PreferencesGuiChangeCallback revoked_visible_callback = NULL;
+PreferencesGuiChangeCallback expired_visible_callback = NULL;
 
 void preferences_gui_set_csr_visible_callback (PreferencesGuiChangeCallback callback)
 {
@@ -39,6 +40,11 @@ void preferences_gui_set_csr_visible_callback (PreferencesGuiChangeCallback call
 void preferences_gui_set_revoked_visible_callback (PreferencesGuiChangeCallback callback)
 {
 	revoked_visible_callback = callback;
+}
+
+void preferences_gui_set_expired_visible_callback (PreferencesGuiChangeCallback callback)
+{
+	expired_visible_callback = callback;
 }
 
 
@@ -57,6 +63,11 @@ void preferences_changed_callback(GSettings* settings,
                 revoked_visible_callback (value, TRUE);
         }
 
+        if (! strcmp (key, "expired-visible") && expired_visible_callback) {
+                gboolean value = g_settings_get_boolean (settings, key);
+                expired_visible_callback (value, TRUE);
+        }
+
 }
 
 
@@ -70,6 +81,10 @@ void preferences_init (int argc, char ** argv)
                           NULL);
 
         g_signal_connect (preferences_settings, "changed::crq-visible",
+                          G_CALLBACK (preferences_changed_callback),
+                          NULL);
+
+        g_signal_connect (preferences_settings, "changed::expired-visible",
                           G_CALLBACK (preferences_changed_callback),
                           NULL);
 
@@ -95,6 +110,16 @@ gboolean preferences_get_revoked_visible ()
 void preferences_set_revoked_visible (gboolean new_value)
 {
         g_settings_set_boolean (preferences_settings, "revoked-visible", new_value);
+}
+
+gboolean preferences_get_expired_visible ()
+{
+        return g_settings_get_boolean (preferences_settings, "expired-visible");
+}
+
+void preferences_set_expired_visible (gboolean new_value)
+{
+        g_settings_set_boolean (preferences_settings, "expired-visible", new_value);
 }
 
 gboolean preferences_get_crq_visible ()

--- a/src/preferences-gui.h
+++ b/src/preferences-gui.h
@@ -26,6 +26,8 @@ void preferences_gui_set_csr_visible_callback (PreferencesGuiChangeCallback call
 
 void preferences_gui_set_revoked_visible_callback (PreferencesGuiChangeCallback callback);
 
+void preferences_gui_set_expired_visible_callback (PreferencesGuiChangeCallback callback);
+
 void preferences_init (int, char**);
 
 gchar *preferences_get_size(void);
@@ -33,6 +35,9 @@ void preferences_set_size (const gchar *new_value);
 
 gboolean preferences_get_revoked_visible(void);
 void preferences_set_revoked_visible (gboolean new_value);
+
+gboolean preferences_get_expired_visible(void);
+void preferences_set_expired_visible (gboolean new_value);
 
 gboolean preferences_get_crq_visible(void);
 void preferences_set_crq_visible (gboolean new_value);


### PR DESCRIPTION
Adds an "E_xpired Certificates" (Spanish: "Certificados ca_ducados") toggle to the View menu, sitting next to the existing "Revoked Certificates" toggle.

## Behavior

| Toggle | Tree view |
|---|---|
| **On** (default) | All certificates shown. Effectively-expired ones render in **grey** across Subject / Serial / Activation / Expiration / Revocation columns so they read as disabled at a glance. |
| **Off** | Expired certificates are hidden from the tree entirely. |

## Cascade rule, per RFC 5280

A certificate is considered expired not only when its own \`notAfter\` is past, but also when **any ancestor CA in its chain has expired**. An expired CA's entire subtree is therefore greyed out (and hidden when the toggle is off) even if some descendants' own \`notAfter\` dates are still in the future. The new tooltip on the menu item documents this so users don't get surprised.

## Implementation notes

- **GSettings**: new \`expired-visible\` key (default \`true\`); \`preferences_get_expired_visible\` / \`preferences_set_expired_visible\` mirror the revoked-visible pair, and the change callback is registered against \`ca_update_expired_view\` exactly like \`ca_update_revoked_view\`.
- **Cascade computation**: \`ca.c\` gets a static \`GHashTable<ca_id, effective_expiration>\` repopulated each \`ca_refresh_model_callback\`. \`ca_file_foreach_crt\` yields rows in hierarchical order, so every CA's \`effective_expiration = min(self.expiration, parent_effective_expiration)\` is cached before any descendant arrives. The filter and the row foreground both consult this cache — no per-row recursive SQL.
- **Greyed rows**: a new \`CA_MODEL_COLUMN_FOREGROUND\` on the \`GtkTreeStore\` holds \`\"gray\"\` for effectively-expired rows, \`NULL\` otherwise. The five text renderers bind their \`foreground\` attribute to this column, so the disabled look applies uniformly across columns and travels with the model.
- **Toggle plumbing**: \`ca_expired_view_toggled\` (signal handler) → \`ca_update_expired_view\` (sets the static, syncs the menu item, calls \`dialog_refresh_list\`) → \`ca_refresh_model_callback\` (which now also rebuilds the foreground column). Same path the revoked toggle takes.

## Tests + dist

All 5 tests pass (\`check_y2k38\`, \`check_ui_consistency\`, \`check_workflows\`, \`check_cli_email.sh\`, \`check_cli_wizard.sh\`). \`make distcheck\` is clean.

## Translations

Spanish translations done for both new strings (menu label and tooltip). The 11 other .po files have the new entries listed but \`msgstr ""\` — ready for the existing translation workflow to pick up.

## Manual sanity check on the example fixture

\`certs/example-ca.gnomint\` contains a "Signing software CA" expiring 2013-08-23 with a leaf cert ("gnoMint program") under it. With this PR:

- Toggle on: both the CA and its leaf cert show in grey (the leaf's own notAfter is irrelevant because the CA expired in 2013).
- Toggle off: both disappear from the tree.
- Other still-valid CAs and their descendants remain in normal black text.