### PR TITLE
Highlight certificates expiring soon in amber

### DIFF
--- a/gconf/org.gnome.gnomint.gschema.xml
+++ b/gconf/org.gnome.gnomint.gschema.xml
@@ -30,6 +30,18 @@
       </description>
     </key>
 
+    <key name="expire-warning-days" type="i">
+      <default>30</default>
+      <summary>Days before expiration to highlight certificates in amber</summary>
+      <description>
+        Certificates whose effective validity ends within this many days
+        are shown in amber in the certificates tree, as a heads-up that
+        they should be renewed soon. Setting this to 0 disables the
+        amber highlight (certificates appear either normally or in gray
+        for already-expired).
+      </description>
+    </key>
+
     <key name="crq-visible" type="b">
       <default>true</default>
       <summary>Certificate requests visibility</summary>

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -81,15 +81,15 @@ msgstr "_Obre una base de dades de certificats"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Sol·licituds de signatura de certificats</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,86 +106,86 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Núm. de sèrie"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Activació"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Venciment"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Revocació"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Exporta certificat"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Exporta sol·licitud de signatura de certificat"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Hi ha hagut un error al exportar el certificat."
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 "Ha hagut un error al exportar la sol·licitud de signatura de certificat "
 "(CSR),"
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Certificat exportat amb èxit."
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr "Sol·licitud de signatura de certificat exportada amb èxit."
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr "Exporta la clau privada xifrada"
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Clau privada exportada amb èxit."
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporta la clau privada sense xifrar"
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporta tot el certificat en un paquet PKCS#12"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Exporta sol·licitud de signatura de certificat (CSR) - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -193,7 +193,7 @@ msgstr ""
 "Seleccioneu quina part de la sol·licitud de signatura de certificat (CSR) "
 "voleu exportar:"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -201,7 +201,7 @@ msgstr ""
 "<i>Exporta la sol·licitud de signatura de certificat a un fitxer públic en "
 "format PEM</i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -211,27 +211,27 @@ msgstr ""
 "contrasenya. Aquest fitxer només ha de ser accessible pel titular de la "
 "sol·licitud de signatura del certificat.</i>"
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -242,17 +242,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr "Canvia la contrasenya de la CA - gnoMint"
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -260,60 +260,60 @@ msgstr ""
 "La contrasenya introduïda no es correspon amb la contrasenya real de la base "
 "de dades."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al establir la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr "La contrasenya s'ha establert amb èxit"
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al eliminar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "La contrasenya s'ha eliminat amb èxit"
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Desa paràmetres Diffie-Hellman"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Paràmetres Diffie-Hellman desats correctament"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "Seleccioneu el fitxer PEM a importar"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "S'han produït problemes al importar el fitxer '%s'"
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr "Seleccioneu el directori a importar"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -93,7 +93,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -101,121 +101,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -226,68 +226,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -80,15 +80,15 @@ msgstr "Zertifikat-Datenbank ö_ffnen"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Zertifikate</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -96,7 +96,7 @@ msgstr "<b>Signaturanfragen für Zertifikate</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -105,84 +105,84 @@ msgstr "%d.%m.%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Seriell"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Widerruf"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Zertifikat exportieren"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Signaturanfrage für Zertifikat exportieren"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Beim Export des Zertifikats ist ein Fehler aufgetreten."
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr "Signaturanfrage für Zertifikat wurde erfolgreich exportiert"
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Geheimer Schlüssel wurde erfolgreich exportiert"
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Geheimen Schlüssel en_tpacken"
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Gesamtes Zertifikat in einem PKCS#12-Paket exportieren"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Signaturanfrage exportieren - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -190,7 +190,7 @@ msgstr ""
 "Bitte wählen Sie den Teil der gespeicherten Siganturanfrage aus, den Sie "
 "exportieren wollen:"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -198,34 +198,34 @@ msgstr ""
 "<i>Signaturanfrage für Zertifikat in eine öffentliche Datei im PEM-Format "
 "exportieren.</i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -236,17 +236,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr "Zertifizierungsstellen-Passwort ändern - gnoMint"
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -254,60 +254,60 @@ msgstr ""
 "Das von Ihnen eingegebene Passwort stimmt nicht mit dem derzeit für die "
 "Datenbank geltenden Passwort überein."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ändern des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ermitteln des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr "Passwort wurde erfolgreich ermittelt"
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Löschen des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "Passwort wurde erfolgreich gelöscht"
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Diffie-Hellman-Parameter speichern"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-Parameter wurden erfolgreich gespeichert"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "PEM-Datei zum Importieren auswählen"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problem beim Importieren der Datei »%s«"
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr "Ordner zum Importieren auswählen"
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -82,15 +82,15 @@ msgstr "Abrir base de datos de certificados"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificados</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -98,7 +98,7 @@ msgstr "<b>Solicitudes de certificación</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,85 +106,85 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Nº serie"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Activación"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Caducidad"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Revocación"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Exportar certificado"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 #, fuzzy
 msgid "_Cancel"
 msgstr "Francia"
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Exportar solicitud de certificación"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Ocurrió un error al exportar el certificado"
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr "Ocurrió un error al exportar la solicitud de certificación."
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Certificado exportado con éxito"
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr "Solicitud de certificación exportada correctamente"
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr "Exportar clave privada cifrada."
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Clave privada exportada con éxito"
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportar clave privada sin cifrar."
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportar todo el certificado en un paquete PKCS#12"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Exportar solicitud de certificación - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -192,7 +192,7 @@ msgstr ""
 "Seleccione qué parte almacenada de la solicitud de certificación desea "
 "exportar:"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -200,7 +200,7 @@ msgstr ""
 "<i>Exporta la solicitud de certificación a un fichero público en formato "
 "PEM</i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -210,15 +210,15 @@ msgstr ""
 "clave. Este fichero sólo debería ser accesible para el titular de la "
 "soliticud de certificación.</i>"
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -228,11 +228,11 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado de AC?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -250,15 +250,15 @@ msgstr ""
 "certificados generados con él, por lo que todos deberían regenerarse con un "
 "nuevo certificado de AC."
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr "Cambiando contraseña de AC - gnoMint"
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -266,60 +266,60 @@ msgstr ""
 "La contraseña actual que ha introducido no coincide con la contraseña real "
 "de la base de datos."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. Se canceló la "
 "operación."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al establecer la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr "Contraseña establecida con éxito"
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "Contraseña eliminada con éxito"
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Guardar parámetros Diffie-Hellman"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parámetros Diffie-Hellman guardados correctamente"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "Seleccione fichero PEM a importar"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Hubo problemas al importar el fichero '%s'"
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr "Seleccione directorio a importar"
 
@@ -3806,10 +3806,10 @@ msgid ""
 "issuing CAs has expired, so an expired CA's whole subtree is hidden "
 "alongside it."
 msgstr ""
-"Si se desmarca, los certificados cuya validez ya ha terminado se ocultan "
-"del árbol. Un certificado también se considera caducado si lo está alguna "
-"de sus autoridades emisoras, de modo que un AC caducado oculta también "
-"todo su subárbol."
+"Si se desmarca, los certificados cuya validez ya ha terminado se ocultan del "
+"árbol. Un certificado también se considera caducado si lo está alguna de sus "
+"autoridades emisoras, de modo que un AC caducado oculta también todo su "
+"subárbol."
 
 #: gui/main_window.ui.h:29
 msgid "_Help"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -78,15 +78,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -94,7 +94,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -102,121 +102,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -227,68 +227,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -81,15 +81,15 @@ msgstr "_Ouvrir une base de données de certificats"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Demandes en signature de certificat</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,84 +106,84 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Numéro"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Activation"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Expiration"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Révocation"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Exporter un certificat"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Exporter une CSR"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Erreur pendant l'exportation du certificat."
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr "Erreur pendant l'exportation de la Requête de Signature de Certificat."
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Certificat exporté avec succès."
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr "CSR exporté avec succès."
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr "Exporter la clé privée chiffrée"
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Clé privée exportée avec succès"
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporter la clé privée non chiffrée"
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporter l'intégralité du certificat vers un paquet au format PKCS#12"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Exportation de Requête de Signature de Certificat - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -191,13 +191,13 @@ msgstr ""
 "Veuillez choisir la partie de la Requête de Signature de Certificat "
 "sauvegardée que vous souhaitez exporter :"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr "<i>Exporter la CSR vers un fichier public, au format PEM.</i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -207,27 +207,27 @@ msgstr ""
 "passe, au format PKCS#8. Ce fichier ne devrait être accessible que par le "
 "titulaire de la CSR.</i>"
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -238,16 +238,16 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr "Modifier le mot de passe de l'Autorité de Certification - gnoMint"
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -255,60 +255,60 @@ msgstr ""
 "Le mot de passe que vous venez d'entrer ne correspond pas au mot de passe "
 "actuel de la base de données."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant l'affectationdu mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr "Mot de passe mis en place avec succès."
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "Mot de passe supprimé avec succès."
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Sauvegarder les paramètres Diffie-Hellman"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Les paramètres Diffie-Hellman ont été sauvegardés avec succès"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "Choisir le fichier PEM à importer"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problème pendant l'importation du fichier '%s'"
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr "Sélectionner le répertoire à importer"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -81,15 +81,15 @@ msgstr "_Apri il database di certificato"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificati</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -105,84 +105,84 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Revoca"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Esporta certificato"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Esporta la richiesta di firma di certificato (CSR)"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Errore durante l'esportazione del certificato."
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr "Errore durante l'esportazione del CSR."
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Certificato esportato correttamente"
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr "Richiesta di firma di certificato (CSR) esportata correttamente"
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr "Esporta la chiave privata criptata"
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Chiave privata esportata correttamente"
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Esporta chiave privata non criptata"
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Esporta l'intero certificato nel pacchetto PKCS#12"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Esporta CSR - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -190,7 +190,7 @@ msgstr ""
 "Si prega di scegliere quale parte della richiesta di firma di certificato "
 "(CSR) salvata si vuole esportare:"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -198,7 +198,7 @@ msgstr ""
 "<i>Esporta la richiesta di firma di certificato (CSR) in un file pubblico, "
 "in formato PEM.</i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -208,27 +208,27 @@ msgstr ""
 "Questo file deve essere accessibile solamente da parte del soggetto della "
 "richiesta di firma di certificato (CSR).</i>"
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -239,17 +239,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -257,60 +257,60 @@ msgstr ""
 "La password attualmente inserita non corrisponde con la reale e corrente "
 "password del database."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la modifica della password del database. L'operazione è stata "
 "annullata."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Errore nello stabilire la password del database. L'operazione è stata "
 "annullata."
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr "Password stabilita correttamente"
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la rimozione della password del database. L'operazione è "
 "stata annullata."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "Password rimossa correttamente"
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Salva i parametri Diffie-Hellman"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parametri Diffie-Hellman salvati correttamente"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "Selezionare il file PEM da importare"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -93,7 +93,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -101,121 +101,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Periodic"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Activacion"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Expiracion"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Revocacion"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Error inesperada"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -226,68 +226,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -77,15 +77,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -93,7 +93,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -101,121 +101,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -226,68 +226,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -81,15 +81,15 @@ msgstr "_Открыть базу сертификатов"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Сертификат</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -97,7 +97,7 @@ msgstr "<b>Запрос на Подпись Сертификата</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -106,84 +106,84 @@ msgstr "%m/%d/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Серийный номер"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Активация"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Срок истечения"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Отзыв"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Экспорт сертификата"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Экспорт запроса на подпись сертификата"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Произошла ошибка во время экспорта сертификата."
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr "Произошла ошибка во время экспорта CSR."
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Сертификат успешно экспортирован"
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr "Запрос на подпись сертификата успешно экспортирован"
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr "Экспорт зашифрованного закрытого ключ"
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Закрытый ключ успешно экспортирован"
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Экспорт незашифрованного закрытого ключа"
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Экспорт всего сертификата в PKCS#12 пакет"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Экспорт CSR - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -191,7 +191,7 @@ msgstr ""
 "Пожалуйста, выберите какую часть сохранённого Запроса на Подпись Сертификата "
 "вы хотите экспортировать:"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -199,7 +199,7 @@ msgstr ""
 "<i>Экспорт Запроса на Подпись Сертификата в незашифрованный файл PEM формата."
 "</i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -208,27 +208,27 @@ msgstr ""
 "<i>Экспрорт сохранённого закрытого ключа в PKCS#8 файл защищённый паролем. "
 "Этот файл должен быть доступен владельцу Запроса на Подпись Сертификата.</i>"
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Неожиданная ошибка"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -239,15 +239,15 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr "Изменить CA пароль - gnoMint"
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -255,54 +255,54 @@ msgstr ""
 "Текущий пароль, который вы ввели, не совпадает с текущим актуальным паролем "
 "базы."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr "Произошла  ошибка при смене пароля базы. Операция отменена."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr "Пароль установлен успешно"
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr "Произошла ошибка при удалении пароля базы. Операция отменена."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "Пароль удалён успешно."
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Сохранить Diffie-Hellman параметры"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Параметры Diffie-Hellman сохранены успешно"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "Выберите PEM файл для импорта"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Проблема при импорте файла '%s'"
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr "Выберите каталог для импорта"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -78,15 +78,15 @@ msgstr ""
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -94,7 +94,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -102,121 +102,121 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr ""
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr ""
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr ""
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr ""
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr ""
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr ""
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr ""
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr ""
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr ""
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -227,68 +227,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr ""
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr ""
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 11:12+0200\n"
+"POT-Creation-Date: 2026-05-21 11:47+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -80,15 +80,15 @@ msgstr "_Öppna certifikatdatabas"
 msgid "Base de datos de certificados de gnoMint"
 msgstr ""
 
-#: src/ca.c:223
+#: src/ca.c:227
 msgid "<b>Certificates</b>"
 msgstr "<b>Certifikat</b>"
 
-#: src/ca.c:361
+#: src/ca.c:390
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
-#: src/ca.c:404 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
+#: src/ca.c:433 src/ca-cli-callbacks.c:172 src/ca-cli-callbacks.c:186
 #: src/ca-cli-callbacks.c:201 src/ca-cli-callbacks.c:629
 #: src/ca-cli-callbacks.c:638 src/ca-cli-callbacks.c:1258
 #: src/ca-cli-callbacks.c:1267 src/certificate_properties.c:178
@@ -96,7 +96,7 @@ msgstr "<b>Certifikatsigneringsbegäran</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: src/ca.c:407 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
+#: src/ca.c:436 src/ca-cli-callbacks.c:175 src/ca-cli-callbacks.c:189
 #: src/ca-cli-callbacks.c:204 src/ca-cli-callbacks.c:632
 #: src/ca-cli-callbacks.c:641 src/ca-cli-callbacks.c:1261
 #: src/ca-cli-callbacks.c:1270 src/certificate_properties.c:181
@@ -105,84 +105,84 @@ msgstr "%Y/%m/%d %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: src/ca.c:556 src/certificate_properties.c:588 src/crl.c:184
+#: src/ca.c:586 src/certificate_properties.c:588 src/crl.c:184
 #: src/new_cert.c:192 src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
-#: src/ca.c:591
+#: src/ca.c:622
 msgid "Serial"
 msgstr "Serienummer"
 
-#: src/ca.c:598
+#: src/ca.c:630
 msgid "Activation"
 msgstr "Aktivering"
 
-#: src/ca.c:605
+#: src/ca.c:640
 msgid "Expiration"
 msgstr "Utgång"
 
-#: src/ca.c:612
+#: src/ca.c:650
 msgid "Revocation"
 msgstr "Spärrning"
 
-#: src/ca.c:910
+#: src/ca.c:951
 msgid "Export certificate"
 msgstr "Exportera certifikat"
 
-#: src/ca.c:913 src/ca.c:920 src/ca.c:1022 src/ca.c:1073 src/ca.c:1124
-#: src/ca.c:1970 src/ca.c:2076 src/ca.c:2110 src/crl.c:257 src/main.c:330
+#: src/ca.c:954 src/ca.c:961 src/ca.c:1063 src/ca.c:1114 src/ca.c:1165
+#: src/ca.c:2011 src/ca.c:2117 src/ca.c:2151 src/crl.c:257 src/main.c:330
 #: src/main.c:402 src/main.c:490 gui/san_editor_dialog.ui.h:9
 msgid "_Cancel"
 msgstr ""
 
-#: src/ca.c:914 src/ca.c:921 src/ca.c:1023 src/ca.c:1074 src/ca.c:1125
-#: src/ca.c:1971 src/crl.c:258
+#: src/ca.c:955 src/ca.c:962 src/ca.c:1064 src/ca.c:1115 src/ca.c:1166
+#: src/ca.c:2012 src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: src/ca.c:917
+#: src/ca.c:958
 msgid "Export certificate signing request"
 msgstr "Exportera certificate signing request"
 
-#: src/ca.c:932 src/ca.c:968 src/ca.c:978 src/export.c:278
+#: src/ca.c:973 src/ca.c:1009 src/ca.c:1019 src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Det inträffade ett fel då certifikatet skulle exporteras."
 
-#: src/ca.c:934 src/ca.c:970 src/ca.c:980
+#: src/ca.c:975 src/ca.c:1011 src/ca.c:1021
 msgid "There was an error while exporting CSR."
 msgstr "Det inträffade ett fel då CSR skulle exporteras."
 
-#: src/ca.c:993 src/ca.c:1159
+#: src/ca.c:1034 src/ca.c:1200
 msgid "Certificate exported successfully"
 msgstr "Certifikatet exporterades"
 
-#: src/ca.c:1000
+#: src/ca.c:1041
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: src/ca.c:1019
+#: src/ca.c:1060
 msgid "Export crypted private key"
 msgstr "Exportera krypterad privat nyckel"
 
-#: src/ca.c:1048 src/ca.c:1100
+#: src/ca.c:1089 src/ca.c:1141
 msgid "Private key exported successfully"
 msgstr "Privat nyckel exporterades"
 
-#: src/ca.c:1070
+#: src/ca.c:1111
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportera okrypterad privat nyckel"
 
-#: src/ca.c:1121
+#: src/ca.c:1162
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportera helt certifikat i PKCS#12-paket"
 
-#: src/ca.c:1192
+#: src/ca.c:1233
 msgid "Export CSR - gnoMint"
 msgstr "Exportera CSR - gnoMint"
 
-#: src/ca.c:1197
+#: src/ca.c:1238
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -190,7 +190,7 @@ msgstr ""
 "Vänligen välj vilken del av den sparade Certificate Signing Request du vill "
 "exportera:"
 
-#: src/ca.c:1202
+#: src/ca.c:1243
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -198,7 +198,7 @@ msgstr ""
 "<i>Exportera Certificate Signing Request till en publik fil, i PEM-format.</"
 "i>"
 
-#: src/ca.c:1207
+#: src/ca.c:1248
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -208,27 +208,27 @@ msgstr ""
 "fil. Filen bör endast kunna kommas åt av den till vilken Certificate Signing "
 "Request är utfärdat.</i>"
 
-#: src/ca.c:1271
+#: src/ca.c:1312
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: src/ca.c:1331
+#: src/ca.c:1372
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: src/ca.c:1332
+#: src/ca.c:1373
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: src/ca.c:1340
+#: src/ca.c:1381
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: src/ca.c:1341
+#: src/ca.c:1382
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -239,72 +239,72 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: src/ca.c:1384
+#: src/ca.c:1425
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: src/ca.c:1748
+#: src/ca.c:1789
 msgid "Change CA password - gnoMint"
 msgstr "Ändra CA-lösenord - gnoMint"
 
-#: src/ca.c:1766
+#: src/ca.c:1807
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 "Det lösenord Du skrivit in är inte det som behövs för den valda databasen."
 
-#: src/ca.c:1781
+#: src/ca.c:1822
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle bytas. Operationen avbröts."
 
-#: src/ca.c:1790
+#: src/ca.c:1831
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: src/ca.c:1800 src/ca-cli-callbacks.c:1091
+#: src/ca.c:1841 src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: src/ca.c:1810
+#: src/ca.c:1851
 msgid "Password established successfully"
 msgstr ""
 
-#: src/ca.c:1820
+#: src/ca.c:1861
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle tas bort. Operationen "
 "avbröts."
 
-#: src/ca.c:1829
+#: src/ca.c:1870
 msgid "Password removed successfully"
 msgstr "Lösenordet togs bort"
 
-#: src/ca.c:1967
+#: src/ca.c:2008
 msgid "Save Diffie-Hellman parameters"
 msgstr "Spara Diffie-Hellman-parametrar"
 
-#: src/ca.c:1993
+#: src/ca.c:2034
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-parametrar sparades"
 
 #. Import single file
-#: src/ca.c:2073
+#: src/ca.c:2114
 msgid "Select PEM file to import"
 msgstr "Välj PEM-fil att importera"
 
-#: src/ca.c:2077 src/ca.c:2111 src/main.c:331 src/main.c:403 src/main.c:491
+#: src/ca.c:2118 src/ca.c:2152 src/main.c:331 src/main.c:403 src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: src/ca.c:2094
+#: src/ca.c:2135
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Ett problem inträffade vid importerandet av filen '%s'"
 
-#: src/ca.c:2107
+#: src/ca.c:2148
 msgid "Select directory to import"
 msgstr "Välj katalog att importera"
 

--- a/src/ca.c
+++ b/src/ca.c
@@ -302,12 +302,28 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 	
 	gtk_tree_store_append (new_model, &iter, (last_parent_iter ? last_parent_iter: cert_parent_iter));
 
-	/* Grey out the row if the certificate's effective validity has
-	 * ended. effective_expiration was computed above with cascade
-	 * through any parent CAs. */
-	const gchar *row_foreground =
-	    (effective_expiration > 0 && effective_expiration < time (NULL))
-	        ? "gray" : NULL;
+	/* Three-state row foreground based on effective_expiration
+	 * (which already cascades through parent CAs):
+	 *   - gray   : already expired
+	 *   - #cc7700: expires within `expire-warning-days` days (amber)
+	 *   - NULL   : healthy
+	 *
+	 * The warning window is a preference; 0 disables the amber state. */
+	const gchar *row_foreground = NULL;
+	if (effective_expiration > 0) {
+		time_t now = time (NULL);
+		if (effective_expiration < now) {
+			row_foreground = "gray";
+		} else {
+			gint warn_days = preferences_get_expire_warning_days ();
+			if (warn_days > 0) {
+				time_t threshold = now +
+				    (time_t) warn_days * 86400;
+				if (effective_expiration < threshold)
+					row_foreground = "#cc7700";
+			}
+		}
+	}
 
         if (! argv[CA_FILE_CERT_COLUMN_REVOCATION])
                 gtk_tree_store_set (new_model, &iter,

--- a/src/ca.c
+++ b/src/ca.c
@@ -96,6 +96,34 @@ static GtkTreeIter * last_cert_iter = NULL;
 static gboolean csr_title_inserted=FALSE;
 static GtkTreeIter * csr_parent_iter = NULL;
 
+/* Pure helper exposed for unit tests: classify a row's foreground color
+ * given its effective expiration timestamp, a "now" reference, and the
+ * warning-window in days. Returns a static string literal (so callers
+ * don't free it) or NULL for the default color.
+ *
+ *   effective_expiration  | now / warn_days     | result
+ *   ---------------------+--------------------+-----------
+ *   0  (no expiration)    | (any)              | NULL
+ *   < now                 | (any)              | "gray"
+ *   < now + warn_days*day | warn_days > 0      | "#cc7700"
+ *   anything else                              | NULL
+ */
+const gchar *
+ca_compute_row_foreground (time_t effective_expiration, time_t now,
+                           gint warn_days)
+{
+    if (effective_expiration <= 0)
+        return NULL;
+    if (effective_expiration < now)
+        return "gray";
+    if (warn_days > 0) {
+        time_t threshold = now + (time_t) warn_days * 86400;
+        if (effective_expiration < threshold)
+            return "#cc7700";
+    }
+    return NULL;
+}
+
 static gboolean view_csr = TRUE;
 static gboolean view_rcrt = TRUE;
 static gboolean view_expired = TRUE;
@@ -302,28 +330,9 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 	
 	gtk_tree_store_append (new_model, &iter, (last_parent_iter ? last_parent_iter: cert_parent_iter));
 
-	/* Three-state row foreground based on effective_expiration
-	 * (which already cascades through parent CAs):
-	 *   - gray   : already expired
-	 *   - #cc7700: expires within `expire-warning-days` days (amber)
-	 *   - NULL   : healthy
-	 *
-	 * The warning window is a preference; 0 disables the amber state. */
-	const gchar *row_foreground = NULL;
-	if (effective_expiration > 0) {
-		time_t now = time (NULL);
-		if (effective_expiration < now) {
-			row_foreground = "gray";
-		} else {
-			gint warn_days = preferences_get_expire_warning_days ();
-			if (warn_days > 0) {
-				time_t threshold = now +
-				    (time_t) warn_days * 86400;
-				if (effective_expiration < threshold)
-					row_foreground = "#cc7700";
-			}
-		}
-	}
+	const gchar *row_foreground = ca_compute_row_foreground (
+	    effective_expiration, time (NULL),
+	    preferences_get_expire_warning_days ());
 
         if (! argv[CA_FILE_CERT_COLUMN_REVOCATION])
                 gtk_tree_store_set (new_model, &iter,

--- a/src/ca.h
+++ b/src/ca.h
@@ -25,6 +25,10 @@
 
 #ifndef GNOMINTCLI
 #include <gtk/gtk.h>
+#include <time.h>
+
+const gchar *ca_compute_row_foreground (time_t effective_expiration,
+                                        time_t now, gint warn_days);
 
 gboolean ca_refresh_model_callback ();
 gboolean ca_treeview_row_activated (GtkTreeView *tree_view,

--- a/src/preferences-gui.c
+++ b/src/preferences-gui.c
@@ -122,6 +122,22 @@ void preferences_set_expired_visible (gboolean new_value)
         g_settings_set_boolean (preferences_settings, "expired-visible", new_value);
 }
 
+gint preferences_get_expire_warning_days ()
+{
+        /* Defensive: this getter is called from __ca_refresh_model_add_certificate
+         * which the workflow test suite exercises without going through
+         * preferences_init (it builds only the GTK builders, not the whole
+         * application state). Fall back to the schema default of 30. */
+        if (! preferences_settings)
+                return 30;
+        return g_settings_get_int (preferences_settings, "expire-warning-days");
+}
+
+void preferences_set_expire_warning_days (gint new_value)
+{
+        g_settings_set_int (preferences_settings, "expire-warning-days", new_value);
+}
+
 gboolean preferences_get_crq_visible ()
 {
         return g_settings_get_boolean (preferences_settings, "crq-visible");

--- a/src/preferences-gui.h
+++ b/src/preferences-gui.h
@@ -39,6 +39,9 @@ void preferences_set_revoked_visible (gboolean new_value);
 gboolean preferences_get_expired_visible(void);
 void preferences_set_expired_visible (gboolean new_value);
 
+gint preferences_get_expire_warning_days(void);
+void preferences_set_expire_warning_days (gint new_value);
+
 gboolean preferences_get_crq_visible(void);
 void preferences_set_crq_visible (gboolean new_value);
 

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -53,6 +53,7 @@
 #include <gnutls/x509.h>
 #include "tls.h"
 #include "wizard_window.h"
+#include "ca.h"
 
 #ifndef GNOMINT_UI_DIR
 # error "GNOMINT_UI_DIR must be set at compile time (path to gui/)"
@@ -979,6 +980,65 @@ out:
 }
 
 /* ------------------------------------------------------------------ */
+/*  Scenario 10 (issue #51): expire-warning amber state               */
+/* ------------------------------------------------------------------ */
+
+/* Pure-function exercise of ca_compute_row_foreground across the
+ * matrix of (effective_expiration, warning_days) combinations. The
+ * helper drives the three-state tree foreground; nailing it down here
+ * means a future refactor that breaks the boundaries (off-by-one on
+ * the warning threshold, wrong color string, accidentally amber-ing
+ * already-expired rows, etc.) fails the test rather than silently
+ * shipping. */
+static int
+scenario_expire_warning_foreground (void)
+{
+    fprintf (stderr,
+             "==> scenario: expire-warning foreground (issue #51)\n");
+
+    const time_t now = 1700000000;          /* fixed reference, ~2023 */
+    const time_t day = 86400;
+
+    struct {
+        const char *name;
+        time_t      effective_expiration;
+        gint        warn_days;
+        const char *expected;               /* NULL or string literal */
+    } cases[] = {
+        { "no expiration / no warning",    0,                30, NULL },
+        { "no expiration / 0-day warning", 0,                 0, NULL },
+        { "expired yesterday",             now - day,        30, "gray" },
+        { "expired 5 years ago",           now - 5 * 365 * day, 30, "gray" },
+        { "expires today + epsilon",       now + 1,          30, "#cc7700" },
+        { "expires in 5 days",             now + 5 * day,    30, "#cc7700" },
+        { "expires in 29 days",            now + 29 * day,   30, "#cc7700" },
+        { "expires exactly at threshold",  now + 30 * day,   30, NULL },
+        { "expires in 60 days",            now + 60 * day,   30, NULL },
+        { "expires in 60 days, 90d warn",  now + 60 * day,   90, "#cc7700" },
+        { "warn_days = 0 disables amber",  now + 5 * day,     0, NULL },
+        { "warn_days < 0 treated as off",  now + 5 * day,    -1, NULL },
+    };
+    int failures = 0;
+
+    for (size_t i = 0; i < G_N_ELEMENTS (cases); i++) {
+        const gchar *got = ca_compute_row_foreground (
+            cases[i].effective_expiration, now, cases[i].warn_days);
+        if (g_strcmp0 (got, cases[i].expected) != 0) {
+            fail_test ("expire-warning-foreground",
+                       "%s: expected %s, got %s",
+                       cases[i].name,
+                       cases[i].expected ? cases[i].expected : "(null)",
+                       got ? got : "(null)");
+            failures++;
+        }
+    }
+
+    fprintf (stderr, "    %zu cases, %d failures\n",
+             G_N_ELEMENTS (cases), failures);
+    return failures == 0 ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Driver                                                            */
 /* ------------------------------------------------------------------ */
 
@@ -1004,6 +1064,7 @@ main (int argc, char **argv)
     scenario_all_ui_files_load ();
     scenario_cert_properties_populate ();
     scenario_email_address ();
+    scenario_expire_warning_foreground ();
 
     /* Phase 2B scenarios drive production code paths that load .ui
      * files from PACKAGE_DATA_DIR (new_ca_window.c et al). That path


### PR DESCRIPTION
Extends the foreground-column infrastructure from PR #48 to a three-state display:

| effective_expiration | row foreground |
|---|---|
| Past | \`gray\` (existing) |
| Within \`expire-warning-days\` days from now | \`#cc7700\` (amber) |
| Anything later | default |

The cascade rule from PR #48 still applies — amber kicks in when an ancestor CA's notAfter falls in the warning window even if the leaf's own date is further out, so renewals catch the whole chain at once.

## What's new

- GSettings key \`expire-warning-days\` (default 30). Setting it to 0 disables the amber state entirely.
- \`preferences_get_expire_warning_days\` / \`preferences_set_expire_warning_days\` helpers. The getter is defensive against a NULL \`preferences_settings\` so the workflow test suite — which doesn't call \`preferences_init\` — keeps passing.
- The three-state foreground logic is extracted into a pure \`ca_compute_row_foreground (effective_expiration, now, warn_days)\` helper. \`__ca_refresh_model_add_certificate\` now calls that helper instead of inlining the rules.

## Tests

\`scenario_expire_warning_foreground\` exercises the helper against a 12-case matrix:

\`\`\`
==> scenario: expire-warning foreground (issue #51)
    12 cases, 0 failures
\`\`\`

Cases cover: no-expiration / past / today-plus-epsilon / 5d / 29d / exactly-at-threshold / 60d / 60d-with-90d-warn / warn=0 / warn=-1. Any future refactor that drifts off-by-one or swaps the colour codes fails the test.

Closes #51.