### PR TITLE
Make key-size selector algorithm-aware in New-CA / New-CSR

### DIFF
--- a/gui/new_ca_window.ui
+++ b/gui/new_ca_window.ui
@@ -466,14 +466,45 @@ Common Name (CN):</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSpinButton" id="keylength_spinbutton">
+                  <object class="GtkBox" id="keylength_hbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="adjustment">adjustmentCAKeyLength</property>
-                    <property name="snap_to_ticks">True</property>
-                    <property name="numeric">True</property>
-                    <property name="wrap">True</property>
-                    <property name="update_policy">if-valid</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">horizontal</property>
+                    <child>
+                      <object class="GtkSpinButton" id="keylength_spinbutton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="adjustment">adjustmentCAKeyLength</property>
+                        <property name="snap_to_ticks">True</property>
+                        <property name="numeric">True</property>
+                        <property name="wrap">True</property>
+                        <property name="update_policy">if-valid</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="ecdsa_curve_combo">
+                        <property name="visible">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="active_id">256</property>
+                        <items>
+                          <item id="256" translatable="yes">P-256 (256 bits)</item>
+                          <item id="384" translatable="yes">P-384 (384 bits)</item>
+                          <item id="521" translatable="yes">P-521 (521 bits)</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
@@ -511,6 +542,7 @@ Common Name (CN):</property>
                         <property name="use_underline">True</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">rsa_radiobutton</property>
+                        <signal name="toggled" handler="on_new_ca_privkey_type_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -527,6 +559,7 @@ Common Name (CN):</property>
                         <property name="use_underline">True</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">rsa_radiobutton</property>
+                        <signal name="toggled" handler="on_new_ca_privkey_type_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -543,6 +576,7 @@ Common Name (CN):</property>
                         <property name="use_underline">True</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">rsa_radiobutton</property>
+                        <signal name="toggled" handler="on_new_ca_privkey_type_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gui/new_req_window.ui
+++ b/gui/new_req_window.ui
@@ -640,17 +640,48 @@ subject.&lt;/small&gt;</property>
                 <property name="border_width">6</property>
                 <property name="column_homogeneous">True</property>
                 <child>
-                  <object class="GtkSpinButton" id="keylength_spinbutton1">
+                  <object class="GtkBox" id="keylength_hbox1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="editable">False</property>
-                    <property name="max_length">5</property>
-                    <property name="invisible_char">•</property>
-                    <property name="adjustment">AdjustmentKeyLengthSpinButton1</property>
-                    <property name="climb_rate">1024</property>
-                    <property name="snap_to_ticks">True</property>
-                    <property name="numeric">True</property>
-                    <property name="update_policy">if-valid</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">horizontal</property>
+                    <child>
+                      <object class="GtkSpinButton" id="keylength_spinbutton1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="editable">False</property>
+                        <property name="max_length">5</property>
+                        <property name="invisible_char">•</property>
+                        <property name="adjustment">AdjustmentKeyLengthSpinButton1</property>
+                        <property name="climb_rate">1024</property>
+                        <property name="snap_to_ticks">True</property>
+                        <property name="numeric">True</property>
+                        <property name="update_policy">if-valid</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="ecdsa_curve_combo1">
+                        <property name="visible">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="active_id">256</property>
+                        <items>
+                          <item id="256" translatable="yes">P-256 (256 bits)</item>
+                          <item id="384" translatable="yes">P-384 (384 bits)</item>
+                          <item id="521" translatable="yes">P-521 (521 bits)</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
@@ -689,6 +720,7 @@ subject.&lt;/small&gt;</property>
                         <property name="use_underline">True</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">rsa_radiobutton1</property>
+                        <signal name="toggled" handler="on_new_req_privkey_type_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -705,6 +737,7 @@ subject.&lt;/small&gt;</property>
                         <property name="use_underline">True</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">rsa_radiobutton1</property>
+                        <signal name="toggled" handler="on_new_req_privkey_type_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -721,6 +754,7 @@ subject.&lt;/small&gt;</property>
                         <property name="use_underline">True</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">rsa_radiobutton1</property>
+                        <signal name="toggled" handler="on_new_req_privkey_type_toggle" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -2759,6 +2759,15 @@ msgid ""
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
 msgstr ""
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Mida en bits de la clau privada:"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr ""
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3729,9 +3738,6 @@ msgstr "* Ús com a entitat certificadora habilitat.\n"
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Mida en bits de la clau privada:"
 
 #~ msgid "Private key type:"
 #~ msgstr "Tipus de clau privada:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -2597,6 +2597,15 @@ msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program; if not, write to the Free Software Foundation, Inc., 51 "
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
+msgstr ""
+
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr ""
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
 msgstr ""
 
 #: ../src/new_cert.c:350

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -2736,6 +2736,15 @@ msgid ""
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
 msgstr ""
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Länge des geheimen Schlüssels in Bit"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr ""
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3592,9 +3601,6 @@ msgstr ""
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Länge des geheimen Schlüssels in Bit"
 
 #~ msgid "Private key type:"
 #~ msgstr "Typ des geheimen Schlüssels:"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -2866,6 +2866,15 @@ msgstr ""
 "con este programa; si no es así, escriba a la Free Software Foundation, "
 "Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, EE.UU."
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Longitud en bits de la clave privada:"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr "Curva ECDSA:"
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3925,9 +3934,6 @@ msgstr ""
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Longitud en bits de la clave privada:"
 
 #~ msgid "Private key type:"
 #~ msgstr "Tipo de clave privada:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -2604,6 +2604,15 @@ msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program; if not, write to the Free Software Foundation, Inc., 51 "
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
+msgstr ""
+
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr ""
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
 msgstr ""
 
 #: ../src/new_cert.c:350

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -2749,6 +2749,15 @@ msgid ""
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
 msgstr ""
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Taille en bits de la clé privée :"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr ""
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3753,9 +3762,6 @@ msgstr "* Utilisable pour une Autorité de Certification.\n"
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Taille en bits de la clé privée :"
 
 #~ msgid "Private key type:"
 #~ msgstr "Type de clé privée :"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -2696,6 +2696,15 @@ msgid ""
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
 msgstr ""
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Lunghezza in bit della chiave privata:"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr ""
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3646,9 +3655,6 @@ msgstr ""
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Lunghezza in bit della chiave privata:"
 
 #~ msgid "Private key type:"
 #~ msgstr "Tipologia di chiave privata:"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -2603,6 +2603,15 @@ msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program; if not, write to the Free Software Foundation, Inc., 51 "
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
+msgstr ""
+
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr ""
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
 msgstr ""
 
 #: ../src/new_cert.c:350

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -2606,6 +2606,15 @@ msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program; if not, write to the Free Software Foundation, Inc., 51 "
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
+msgstr ""
+
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr ""
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
 msgstr ""
 
 #: ../src/new_cert.c:350

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -2842,6 +2842,15 @@ msgstr ""
 "Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA "
 "02111-1307, USA."
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Длина в битах закрытого ключа:"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr ""
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3851,9 +3860,6 @@ msgstr "* Использование Центра Сертификации вк�
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Длина в битах закрытого ключа:"
 
 #~ msgid "Private key type:"
 #~ msgstr "Тип закрытого ключа:"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -2608,6 +2608,15 @@ msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program; if not, write to the Free Software Foundation, Inc., 51 "
 "Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."
+msgstr ""
+
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr ""
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
 msgstr ""
 
 #: ../src/new_cert.c:350

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 12:42+0200\n"
+"POT-Creation-Date: 2026-05-21 18:10+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2667,6 +2667,15 @@ msgstr ""
 "program. Om inte, skriv till Free Software Foundation, Inc., 51 Franklin "
 "Street, Fifth Floor, Boston, MA 02110-1301, USA."
 
+#: ../src/new_ca_window.c:114 ../src/new_ca_window.c:124
+#: ../src/new_req_window.c:302 ../src/new_req_window.c:312
+msgid "Private key bit length:"
+msgstr "Bitlängd för privat nyckel:"
+
+#: ../src/new_ca_window.c:131 ../src/new_req_window.c:319
+msgid "ECDSA curve:"
+msgstr ""
+
 #: ../src/new_cert.c:350
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
@@ -3563,9 +3572,6 @@ msgstr ""
 
 #~ msgid "DSA"
 #~ msgstr "DSA"
-
-#~ msgid "Private key bit length:"
-#~ msgstr "Bitlängd för privat nyckel:"
 
 #~ msgid "Private key type:"
 #~ msgstr "Typ av privat nyckel:"

--- a/src/new_ca_window.c
+++ b/src/new_ca_window.c
@@ -38,6 +38,9 @@ GtkBuilder * new_ca_window_gtkb = NULL;
 GtkWidget *san_manager_widget = NULL;
 
 
+G_MODULE_EXPORT void on_new_ca_privkey_type_toggle (GtkToggleButton *button,
+                                                    gpointer        user_data);
+
 void new_ca_window_display()
 {
 	// Workaround for libglade
@@ -70,6 +73,11 @@ void new_ca_window_display()
 		gtk_container_add(GTK_CONTAINER(alignment), san_manager_widget);
 		gtk_widget_show_all(san_manager_widget);
 	}
+
+	/* Force initial spinbutton/curve-combo visibility to match the
+	 * active radio (gtk_widget_show_all elsewhere ignores the .ui's
+	 * visible=False on the curve combo). */
+	on_new_ca_privkey_type_toggle (NULL, NULL);
 }
 
 
@@ -87,19 +95,46 @@ void new_ca_tab_activate (int tab_number)
 G_MODULE_EXPORT void on_new_ca_privkey_type_toggle (GtkToggleButton *button,
 						     gpointer        user_data)
 {
-	GtkToggleButton *rsatoggle = GTK_TOGGLE_BUTTON(gtk_builder_get_object (new_ca_window_gtkb, "rsa_radiobutton"));
-	GtkAdjustment *adj = GTK_ADJUSTMENT(gtk_builder_get_object (new_ca_window_gtkb, "adjustmentCAKeyLength"));
-	gdouble value = gtk_spin_button_get_value (GTK_SPIN_BUTTON(gtk_builder_get_object(new_ca_window_gtkb, "keylength_spinbutton")));
+	GtkToggleButton *rsatoggle   = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_ca_window_gtkb, "rsa_radiobutton"));
+	GtkToggleButton *dsatoggle   = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_ca_window_gtkb, "dsa_radiobutton"));
+	GtkToggleButton *ecdsatoggle = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_ca_window_gtkb, "ecdsa_radiobutton"));
+	GtkToggleButton *eddsatoggle = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_ca_window_gtkb, "eddsa_radiobutton"));
 
-	if (gtk_toggle_button_get_active(rsatoggle)) {
-		// RSA is active
+	GtkAdjustment *adj = GTK_ADJUSTMENT (gtk_builder_get_object (new_ca_window_gtkb, "adjustmentCAKeyLength"));
+	GtkWidget *spin    = GTK_WIDGET (gtk_builder_get_object (new_ca_window_gtkb, "keylength_spinbutton"));
+	GtkWidget *combo   = GTK_WIDGET (gtk_builder_get_object (new_ca_window_gtkb, "ecdsa_curve_combo"));
+	GtkLabel  *label   = GTK_LABEL  (gtk_builder_get_object (new_ca_window_gtkb, "label21"));
+	gdouble    value   = gtk_spin_button_get_value (GTK_SPIN_BUTTON (spin));
+
+	if (rsatoggle && gtk_toggle_button_get_active (rsatoggle)) {
 		gtk_adjustment_set_upper (adj, 10240);
-	} else {
-		// DSA is active
+		gtk_widget_show (spin);
+		if (combo) gtk_widget_hide (combo);
+		if (label) {
+			gtk_label_set_text (label, _("Private key bit length:"));
+			gtk_widget_show (GTK_WIDGET (label));
+		}
+	} else if (dsatoggle && gtk_toggle_button_get_active (dsatoggle)) {
 		gtk_adjustment_set_upper (adj, 3072);
 		if (value > 3072)
-			gtk_spin_button_set_value (GTK_SPIN_BUTTON(gtk_builder_get_object(new_ca_window_gtkb, "keylength_spinbutton")), 
-						   3072);
+			gtk_spin_button_set_value (GTK_SPIN_BUTTON (spin), 3072);
+		gtk_widget_show (spin);
+		if (combo) gtk_widget_hide (combo);
+		if (label) {
+			gtk_label_set_text (label, _("Private key bit length:"));
+			gtk_widget_show (GTK_WIDGET (label));
+		}
+	} else if (ecdsatoggle && gtk_toggle_button_get_active (ecdsatoggle)) {
+		gtk_widget_hide (spin);
+		if (combo) gtk_widget_show (combo);
+		if (label) {
+			gtk_label_set_text (label, _("ECDSA curve:"));
+			gtk_widget_show (GTK_WIDGET (label));
+		}
+	} else if (eddsatoggle && gtk_toggle_button_get_active (eddsatoggle)) {
+		gtk_widget_hide (spin);
+		if (combo) gtk_widget_hide (combo);
+		if (label) gtk_widget_hide (GTK_WIDGET (label));
 	}
 }
 
@@ -305,9 +340,20 @@ G_MODULE_EXPORT void on_new_ca_commit_clicked (GtkButton *widg,
 			ca_creation_data->key_type = 0; /* RSA */
 	}
 
-	widget = GTK_WIDGET(gtk_builder_get_object (new_ca_window_gtkb, "keylength_spinbutton"));
-	active = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON(widget));
-	ca_creation_data->key_bitlength = active;
+	if (ca_creation_data->key_type == 2 /* ECDSA */) {
+		/* Read the curve from the ECDSA combo. The combo's active_id is
+		 * the bit-length of the curve as a string (256/384/521). */
+		GtkComboBoxText *combo = GTK_COMBO_BOX_TEXT (
+			gtk_builder_get_object (new_ca_window_gtkb, "ecdsa_curve_combo"));
+		const gchar *id = combo ? gtk_combo_box_get_active_id (GTK_COMBO_BOX (combo)) : NULL;
+		ca_creation_data->key_bitlength = id ? atoi (id) : 256;
+	} else if (ca_creation_data->key_type == 3 /* EdDSA */) {
+		ca_creation_data->key_bitlength = 0;  /* fixed by the curve */
+	} else {
+		widget = GTK_WIDGET (gtk_builder_get_object (new_ca_window_gtkb, "keylength_spinbutton"));
+		active = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (widget));
+		ca_creation_data->key_bitlength = active;
+	}
 
 	widget = GTK_WIDGET(gtk_builder_get_object (new_ca_window_gtkb, "months_before_expiration_spinbutton"));
 	active = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON(widget));

--- a/src/new_req_window.c
+++ b/src/new_req_window.c
@@ -227,6 +227,9 @@ G_MODULE_EXPORT void new_req_inherit_fields_toggled (GtkToggleButton *button, gp
 
 
 
+G_MODULE_EXPORT void on_new_req_privkey_type_toggle (GtkToggleButton *button,
+                                                     gpointer        user_data);
+
 void new_req_window_display()
 {
 	GtkBuilder *san_builder;
@@ -263,6 +266,10 @@ void new_req_window_display()
 		gtk_container_add(GTK_CONTAINER(alignment), san_manager_widget1);
 		gtk_widget_show_all(san_manager_widget1);
 	}
+
+	/* Force initial spinbutton/curve-combo visibility to match the
+	 * active radio. */
+	on_new_req_privkey_type_toggle (NULL, NULL);
 }
 
 void new_req_tab_activate (int tab_number)
@@ -276,19 +283,46 @@ void new_req_tab_activate (int tab_number)
 G_MODULE_EXPORT void on_new_req_privkey_type_toggle (GtkToggleButton *button,
 						     gpointer        user_data)
 {
-	GtkToggleButton *rsatoggle = GTK_TOGGLE_BUTTON(gtk_builder_get_object (new_req_window_gtkb, "rsa_radiobutton1"));
-	GtkAdjustment *adj = GTK_ADJUSTMENT(gtk_builder_get_object (new_req_window_gtkb, "AdjustmentKeyLengthSpinButton1"));
-	gdouble value = gtk_spin_button_get_value (GTK_SPIN_BUTTON(gtk_builder_get_object(new_req_window_gtkb, "keylength_spinbutton1")));
+	GtkToggleButton *rsatoggle   = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_req_window_gtkb, "rsa_radiobutton1"));
+	GtkToggleButton *dsatoggle   = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_req_window_gtkb, "dsa_radiobutton1"));
+	GtkToggleButton *ecdsatoggle = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_req_window_gtkb, "ecdsa_radiobutton1"));
+	GtkToggleButton *eddsatoggle = GTK_TOGGLE_BUTTON (gtk_builder_get_object (new_req_window_gtkb, "eddsa_radiobutton1"));
 
-	if (gtk_toggle_button_get_active(rsatoggle)) {
-		// RSA is active
+	GtkAdjustment *adj = GTK_ADJUSTMENT (gtk_builder_get_object (new_req_window_gtkb, "AdjustmentKeyLengthSpinButton1"));
+	GtkWidget *spin    = GTK_WIDGET (gtk_builder_get_object (new_req_window_gtkb, "keylength_spinbutton1"));
+	GtkWidget *combo   = GTK_WIDGET (gtk_builder_get_object (new_req_window_gtkb, "ecdsa_curve_combo1"));
+	GtkLabel  *label   = GTK_LABEL  (gtk_builder_get_object (new_req_window_gtkb, "label99"));
+	gdouble    value   = gtk_spin_button_get_value (GTK_SPIN_BUTTON (spin));
+
+	if (rsatoggle && gtk_toggle_button_get_active (rsatoggle)) {
 		gtk_adjustment_set_upper (adj, 10240);
-	} else {
-		// DSA is active
+		gtk_widget_show (spin);
+		if (combo) gtk_widget_hide (combo);
+		if (label) {
+			gtk_label_set_text (label, _("Private key bit length:"));
+			gtk_widget_show (GTK_WIDGET (label));
+		}
+	} else if (dsatoggle && gtk_toggle_button_get_active (dsatoggle)) {
 		gtk_adjustment_set_upper (adj, 3072);
 		if (value > 3072)
-			gtk_spin_button_set_value (GTK_SPIN_BUTTON(gtk_builder_get_object(new_req_window_gtkb, "keylength_spinbutton1")), 
-						   3072);
+			gtk_spin_button_set_value (GTK_SPIN_BUTTON (spin), 3072);
+		gtk_widget_show (spin);
+		if (combo) gtk_widget_hide (combo);
+		if (label) {
+			gtk_label_set_text (label, _("Private key bit length:"));
+			gtk_widget_show (GTK_WIDGET (label));
+		}
+	} else if (ecdsatoggle && gtk_toggle_button_get_active (ecdsatoggle)) {
+		gtk_widget_hide (spin);
+		if (combo) gtk_widget_show (combo);
+		if (label) {
+			gtk_label_set_text (label, _("ECDSA curve:"));
+			gtk_widget_show (GTK_WIDGET (label));
+		}
+	} else if (eddsatoggle && gtk_toggle_button_get_active (eddsatoggle)) {
+		gtk_widget_hide (spin);
+		if (combo) gtk_widget_hide (combo);
+		if (label) gtk_widget_hide (GTK_WIDGET (label));
 	}
 }
 
@@ -556,9 +590,18 @@ G_MODULE_EXPORT void on_new_req_commit_clicked (GtkButton *widg,
 			csr_creation_data->key_type = 0; /* RSA */
 	}
 
-	widget = GTK_WIDGET(gtk_builder_get_object (new_req_window_gtkb, "keylength_spinbutton1"));
-	active = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON(widget));
-	csr_creation_data->key_bitlength = active;
+	if (csr_creation_data->key_type == 2 /* ECDSA */) {
+		GtkComboBoxText *combo = GTK_COMBO_BOX_TEXT (
+			gtk_builder_get_object (new_req_window_gtkb, "ecdsa_curve_combo1"));
+		const gchar *id = combo ? gtk_combo_box_get_active_id (GTK_COMBO_BOX (combo)) : NULL;
+		csr_creation_data->key_bitlength = id ? atoi (id) : 256;
+	} else if (csr_creation_data->key_type == 3 /* EdDSA */) {
+		csr_creation_data->key_bitlength = 0;
+	} else {
+		widget = GTK_WIDGET (gtk_builder_get_object (new_req_window_gtkb, "keylength_spinbutton1"));
+		active = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (widget));
+		csr_creation_data->key_bitlength = active;
+	}
 
 	if (ca_file_is_password_protected()) {
 		csr_creation_data->password = pkey_manage_ask_password();

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -1351,6 +1351,115 @@ scenario_ecdsa_eddsa_keygen (void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Scenario: key-length selector swaps with algorithm                */
+/* ------------------------------------------------------------------ */
+
+/* Opens new_ca_window_display and asserts:
+ *   RSA selected: keylength_spinbutton visible, ecdsa_curve_combo hidden.
+ *   ECDSA selected: spinbutton hidden, combo visible, active id "256".
+ *   Ed25519 selected: both hidden.
+ * Catches regressions where the toggle handler forgets to swap widgets. */
+extern GtkBuilder *new_ca_window_gtkb;
+extern void new_ca_window_display (void);
+
+static int
+scenario_keylength_selector (void)
+{
+    int rc = 1;
+    fprintf (stderr, "==> scenario: key-length selector swaps with algorithm\n");
+
+    if (!test_init_main_window ())
+        return 1;
+
+    /* Don't auto-dismiss — we need the dialog up to poke its widgets. */
+    new_ca_window_display ();
+    drain_events ();
+
+    if (!new_ca_window_gtkb) {
+        fail_test ("keylength-selector", "new_ca_window_gtkb is NULL");
+        goto out;
+    }
+
+    GtkWidget *spin = GTK_WIDGET (gtk_builder_get_object (new_ca_window_gtkb,
+                                                           "keylength_spinbutton"));
+    GtkWidget *combo = GTK_WIDGET (gtk_builder_get_object (new_ca_window_gtkb,
+                                                            "ecdsa_curve_combo"));
+    GtkToggleButton *rsa = GTK_TOGGLE_BUTTON (gtk_builder_get_object (
+        new_ca_window_gtkb, "rsa_radiobutton"));
+    GtkToggleButton *ecdsa = GTK_TOGGLE_BUTTON (gtk_builder_get_object (
+        new_ca_window_gtkb, "ecdsa_radiobutton"));
+    GtkToggleButton *eddsa = GTK_TOGGLE_BUTTON (gtk_builder_get_object (
+        new_ca_window_gtkb, "eddsa_radiobutton"));
+
+    if (!spin || !combo || !rsa || !ecdsa || !eddsa) {
+        fail_test ("keylength-selector", "missing widget(s) in builder");
+        goto out;
+    }
+
+    /* RSA (default): spin visible, combo hidden. */
+    gtk_toggle_button_set_active (rsa, TRUE);
+    drain_events ();
+    if (!gtk_widget_get_visible (spin)) {
+        fail_test ("keylength-selector", "RSA: spinbutton should be visible");
+        goto out;
+    }
+    if (gtk_widget_get_visible (combo)) {
+        fail_test ("keylength-selector", "RSA: combo should be hidden");
+        goto out;
+    }
+    fprintf (stderr, "    RSA: spin shown, combo hidden OK\n");
+
+    /* ECDSA: combo shown, spin hidden, active id = "256". */
+    gtk_toggle_button_set_active (ecdsa, TRUE);
+    drain_events ();
+    if (gtk_widget_get_visible (spin)) {
+        fail_test ("keylength-selector", "ECDSA: spinbutton should be hidden");
+        goto out;
+    }
+    if (!gtk_widget_get_visible (combo)) {
+        fail_test ("keylength-selector", "ECDSA: combo should be visible");
+        goto out;
+    }
+    const gchar *id = gtk_combo_box_get_active_id (GTK_COMBO_BOX (combo));
+    if (!id || g_strcmp0 (id, "256") != 0) {
+        fail_test ("keylength-selector",
+                   "ECDSA: combo active_id = \"%s\", expected \"256\"",
+                   id ? id : "(null)");
+        goto out;
+    }
+    fprintf (stderr, "    ECDSA: combo shown (default %s), spin hidden OK\n", id);
+
+    /* Ed25519: both hidden. */
+    gtk_toggle_button_set_active (eddsa, TRUE);
+    drain_events ();
+    if (gtk_widget_get_visible (spin)) {
+        fail_test ("keylength-selector", "Ed25519: spinbutton should be hidden");
+        goto out;
+    }
+    if (gtk_widget_get_visible (combo)) {
+        fail_test ("keylength-selector", "Ed25519: combo should be hidden");
+        goto out;
+    }
+    fprintf (stderr, "    Ed25519: both hidden OK\n");
+
+    rc = 0;
+
+out:
+    /* Destroy the dialog so subsequent scenarios start clean. */
+    if (new_ca_window_gtkb) {
+        GObject *win = gtk_builder_get_object (new_ca_window_gtkb,
+                                                "new_ca_window");
+        if (win && GTK_IS_WIDGET (win))
+            gtk_widget_destroy (GTK_WIDGET (win));
+        g_object_unref (new_ca_window_gtkb);
+        new_ca_window_gtkb = NULL;
+    }
+    drain_events ();
+    int crits = critical_messages_check_and_reset ("keylength-selector");
+    return (rc == 0 && crits == 0) ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Driver                                                            */
 /* ------------------------------------------------------------------ */
 
@@ -1400,6 +1509,7 @@ main (int argc, char **argv)
         scenario_sign_csr ();
         scenario_revoke_cert ();
         scenario_wizard_window ();
+        scenario_keylength_selector ();
     } else {
         fprintf (stderr,
                  "==> Phase 2B scenarios skipped: %s not found.\n"


### PR DESCRIPTION
## Summary
- RSA / DSA: keep the existing spin button (1024..10240 / capped at 3072 for DSA).
- ECDSA: hide the spin button and show a **GtkComboBoxText** with P-256 / P-384 / P-521.
- Ed25519: hide the whole bit-length row (key size is fixed by the curve).
- Label text swaps between *"Private key bit length:"* and *"ECDSA curve:"* as appropriate.
- Toggle handler wired to all four radios (was previously only on \`rsa_radiobutton\`, so DSA→ECDSA transitions never fired); invoked once at \`new_ca_window_display\` time so the initial state matches the active radio.
- Commit handler reads \`gtk_combo_box_get_active_id\` (\"256\"/\"384\"/\"521\") and writes \`creation_data->key_bitlength\` accordingly.

## Why
The previous UI (merged in #61) showed the same RSA-style spin button for ECDSA and Ed25519. With ECDSA the value was silently overridden unless it happened to be 384/521; with Ed25519 it was ignored entirely. A user picking ECDSA with the spin button at \"2048\" got a P-256 key with no indication. The screenshot in PR #62 makes the bug obvious.

## Test plan
- [x] \`make\` clean (no new warnings)
- [x] \`make -C tests check\` — 5 suites pass, including the new \`scenario_keylength_selector\` which:
  - toggles RSA → asserts spin visible, combo hidden
  - toggles ECDSA → asserts spin hidden, combo visible, default \`active_id == \"256\"\`
  - toggles Ed25519 → asserts both hidden
- [x] Manual screenshot capture under Xvfb of all four algorithm states (see PR #62 docs/assets/screenshots once both land)

Closes the UX gap raised on the #49 PR comment thread.