### PR TITLE
Add certificate renewal workflow (closes #50)

### DIFF
--- a/gui/certificate_popup_menu.ui
+++ b/gui/certificate_popup_menu.ui
@@ -88,6 +88,18 @@ each time the certificate will be used</property>
       </object>
     </child>
     <child>
+      <object class="GtkImageMenuItem" id="renew_menuitem">
+        <property name="label" translatable="yes">Re_new with fresh key</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="has_tooltip">True</property>
+        <property name="tooltip_text" translatable="yes">Issue a new certificate with the same subject and SAN, signed by the same CA, with a freshly-generated keypair. The old certificate is left in place.</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="ca_on_renew_activate" swapped="no"/>
+      </object>
+    </child>
+    <child>
       <object class="GtkImageMenuItem" id="revoke_menuitem">
         <property name="label" translatable="yes">Revo_ke</property>
         <property name="visible">True</property>

--- a/gui/main_window.ui
+++ b/gui/main_window.ui
@@ -193,6 +193,18 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkImageMenuItem" id="renew1">
+                        <property name="label" translatable="yes">Re_new with fresh key</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">Issue a new certificate with the same subject and SAN as this one, signed by the same CA with a freshly-generated keypair. The old certificate is left in place; revoke it manually after you have deployed the new one.</property>
+                        <property name="use_underline">True</property>
+                        <property name="use_stock">False</property>
+                        <signal name="activate" handler="ca_on_renew_activate" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkImageMenuItem" id="revoke1">
                         <property name="label" translatable="yes">Revo_ke</property>
                         <property name="visible">True</property>

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -132,15 +132,15 @@ msgstr "Gestiona CAs i certificats X.509, fàcilment i de forma gràfica"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Sol·licituds de signatura de certificats</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -157,87 +157,87 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Núm. de sèrie"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Activació"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Venciment"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Revocació"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Exporta sol·licitud de signatura de certificat"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Hi ha hagut un error al exportar el certificat."
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 "Ha hagut un error al exportar la sol·licitud de signatura de certificat "
 "(CSR),"
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr "Sol·licitud de signatura de certificat exportada amb èxit."
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr "Exporta la clau privada xifrada"
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Clau privada exportada amb èxit."
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporta la clau privada sense xifrar"
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporta tot el certificat en un paquet PKCS#12"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Exporta sol·licitud de signatura de certificat (CSR) - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -245,7 +245,7 @@ msgstr ""
 "Seleccioneu quina part de la sol·licitud de signatura de certificat (CSR) "
 "voleu exportar:"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -253,7 +253,7 @@ msgstr ""
 "<i>Exporta la sol·licitud de signatura de certificat a un fitxer públic en "
 "format PEM</i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -263,70 +263,70 @@ msgstr ""
 "contrasenya. Aquest fitxer només ha de ser accessible pel titular de la "
 "sol·licitud de signatura del certificat.</i>"
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Afegir certificat de la CA auto-signat"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Esteu segur que voleu revocar aquest certificat?"
 msgstr[1] "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat revocat.\n"
 msgstr[1] "Certificat revocat.\n"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -337,28 +337,44 @@ msgstr[1] ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -369,17 +385,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr "Canvia la contrasenya de la CA - gnoMint"
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -387,61 +403,61 @@ msgstr ""
 "La contrasenya introduïda no es correspon amb la contrasenya real de la base "
 "de dades."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al establir la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr "La contrasenya s'ha establert amb èxit"
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al eliminar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "La contrasenya s'ha eliminat amb èxit"
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Desa paràmetres Diffie-Hellman"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Paràmetres Diffie-Hellman desats correctament"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "Seleccioneu el fitxer PEM a importar"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "S'han produït problemes al importar el fitxer '%s'"
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr "Seleccioneu el directori a importar"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -121,15 +121,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -137,7 +137,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -145,189 +145,205 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 msgid "Export certificate chain"
 msgstr ""
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -338,69 +354,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -132,15 +132,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Zertifikate</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Signaturanfragen für Zertifikate</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -157,85 +157,85 @@ msgstr "%d.%m.%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Seriell"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Widerruf"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Signaturanfrage für Zertifikat exportieren"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Beim Export des Zertifikats ist ein Fehler aufgetreten."
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr "Signaturanfrage für Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Geheimer Schlüssel wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Geheimen Schlüssel en_tpacken"
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Gesamtes Zertifikat in einem PKCS#12-Paket exportieren"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Signaturanfrage exportieren - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -243,7 +243,7 @@ msgstr ""
 "Bitte wählen Sie den Teil der gespeicherten Siganturanfrage aus, den Sie "
 "exportieren wollen:"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -251,77 +251,77 @@ msgstr ""
 "<i>Signaturanfrage für Zertifikat in eine öffentliche Datei im PEM-Format "
 "exportieren.</i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 msgstr[1] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Zertifikat wurde widerrufen.\n"
 msgstr[1] "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -332,28 +332,44 @@ msgstr[1] ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -364,17 +380,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr "Zertifizierungsstellen-Passwort ändern - gnoMint"
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -382,61 +398,61 @@ msgstr ""
 "Das von Ihnen eingegebene Passwort stimmt nicht mit dem derzeit für die "
 "Datenbank geltenden Passwort überein."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ändern des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ermitteln des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr "Passwort wurde erfolgreich ermittelt"
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Löschen des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "Passwort wurde erfolgreich gelöscht"
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Diffie-Hellman-Parameter speichern"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-Parameter wurden erfolgreich gespeichert"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "PEM-Datei zum Importieren auswählen"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problem beim Importieren der Datei »%s«"
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr "Ordner zum Importieren auswählen"
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -133,15 +133,15 @@ msgstr "Gestiona autoridades de certificación y certificados X.509"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificados</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -149,7 +149,7 @@ msgstr "<b>Solicitudes de certificación</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -157,86 +157,86 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Nº serie"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Activación"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Caducidad"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Revocación"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Exportar certificado"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 #, fuzzy
 msgid "_Cancel"
 msgstr "Francia"
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Exportar solicitud de certificación"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Ocurrió un error al exportar el certificado"
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr "Ocurrió un error al exportar la solicitud de certificación."
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Certificado exportado con éxito"
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr "Solicitud de certificación exportada correctamente"
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr "Exportar clave privada cifrada."
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Clave privada exportada con éxito"
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportar clave privada sin cifrar."
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportar todo el certificado en un paquete PKCS#12"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Exportar solicitud de certificación - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -244,7 +244,7 @@ msgstr ""
 "Seleccione qué parte almacenada de la solicitud de certificación desea "
 "exportar:"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -252,7 +252,7 @@ msgstr ""
 "<i>Exporta la solicitud de certificación a un fichero público en formato "
 "PEM</i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -262,43 +262,43 @@ msgstr ""
 "clave. Este fichero sólo debería ser accesible para el titular de la "
 "soliticud de certificación.</i>"
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 msgid "Please select a certificate to export its chain."
 msgstr "Por favor, seleccione un certificado para exportar su cadena."
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 msgid "Export certificate chain"
 msgstr "Exportar cadena de certificados"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr "No se pudo construir la cadena de certificados."
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr "Error al escribir la cadena: %s"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 msgid "Certificate chain exported successfully."
 msgstr "Cadena de certificados exportada con éxito."
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 msgid "Please select one or more certificates to revoke."
 msgstr "Por favor, seleccione uno o más certificados para revocar."
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "¿Está seguro de que desea revocar este certificado?"
 msgstr[1] "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 #, fuzzy
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
@@ -309,39 +309,63 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr "La revocación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificado revocado.\n"
 msgstr[1] "Certificado revocado.\n"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr "Por favor, seleccione una o más solicitudes para eliminar."
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 msgstr[1] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr "La eliminación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+"<b>¿Renovar este certificado?</b>\n"
+"\n"
+"gnoMint emitirá un nuevo certificado con el mismo asunto y SAN que el "
+"seleccionado, firmado por la misma AC, con un par de claves recién "
+"generado. El certificado antiguo permanecerá en la base de datos — "
+"revóquelo manualmente cuando haya desplegado el nuevo."
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+"Certificado renovado. Se ha añadido un nuevo certificado con un par de "
+"claves nuevo a la base de datos, junto al original."
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -351,11 +375,11 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado de AC?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -373,15 +397,15 @@ msgstr ""
 "certificados generados con él, por lo que todos deberían regenerarse con un "
 "nuevo certificado de AC."
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr "Cambiando contraseña de AC - gnoMint"
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -389,61 +413,61 @@ msgstr ""
 "La contraseña actual que ha introducido no coincide con la contraseña real "
 "de la base de datos."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. Se canceló la "
 "operación."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al establecer la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr "Contraseña establecida con éxito"
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "Contraseña eliminada con éxito"
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Guardar parámetros Diffie-Hellman"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parámetros Diffie-Hellman guardados correctamente"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "Seleccione fichero PEM a importar"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Hubo problemas al importar el fichero '%s'"
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr "Seleccione directorio a importar"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -128,15 +128,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -144,7 +144,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -152,191 +152,207 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Peruttujen varmenteiden näkyvyys"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Varmennuspyyntöjen näkyvyys"
 msgstr[1] "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -347,69 +363,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -132,15 +132,15 @@ msgstr "Gérer des certificats et des CA X.509, facilement et graphiquement"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Demandes en signature de certificat</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -157,85 +157,85 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Numéro"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Activation"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Expiration"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Révocation"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Exporter une CSR"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Erreur pendant l'exportation du certificat."
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr "Erreur pendant l'exportation de la Requête de Signature de Certificat."
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr "CSR exporté avec succès."
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr "Exporter la clé privée chiffrée"
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Clé privée exportée avec succès"
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporter la clé privée non chiffrée"
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporter l'intégralité du certificat vers un paquet au format PKCS#12"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Exportation de Requête de Signature de Certificat - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -243,13 +243,13 @@ msgstr ""
 "Veuillez choisir la partie de la Requête de Signature de Certificat "
 "sauvegardée que vous souhaitez exporter :"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr "<i>Exporter la CSR vers un fichier public, au format PEM.</i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -259,71 +259,71 @@ msgstr ""
 "passe, au format PKCS#8. Ce fichier ne devrait être accessible que par le "
 "titulaire de la CSR.</i>"
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Certificat Racine de l'Autorité de Certification"
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 msgstr[1] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat révoqué.\n"
 msgstr[1] "Certificat révoqué.\n"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -332,28 +332,44 @@ msgstr[0] ""
 msgstr[1] ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -364,16 +380,16 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr "Modifier le mot de passe de l'Autorité de Certification - gnoMint"
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -381,61 +397,61 @@ msgstr ""
 "Le mot de passe que vous venez d'entrer ne correspond pas au mot de passe "
 "actuel de la base de données."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant l'affectationdu mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr "Mot de passe mis en place avec succès."
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "Mot de passe supprimé avec succès."
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Sauvegarder les paramètres Diffie-Hellman"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Les paramètres Diffie-Hellman ont été sauvegardés avec succès"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "Choisir le fichier PEM à importer"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problème pendant l'importation du fichier '%s'"
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr "Sélectionner le répertoire à importer"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -132,15 +132,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificati</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -156,85 +156,85 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Revoca"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Esporta la richiesta di firma di certificato (CSR)"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Errore durante l'esportazione del certificato."
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr "Errore durante l'esportazione del CSR."
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr "Richiesta di firma di certificato (CSR) esportata correttamente"
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr "Esporta la chiave privata criptata"
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Chiave privata esportata correttamente"
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Esporta chiave privata non criptata"
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Esporta l'intero certificato nel pacchetto PKCS#12"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Esporta CSR - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -242,7 +242,7 @@ msgstr ""
 "Si prega di scegliere quale parte della richiesta di firma di certificato "
 "(CSR) salvata si vuole esportare:"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -250,7 +250,7 @@ msgstr ""
 "<i>Esporta la richiesta di firma di certificato (CSR) in un file pubblico, "
 "in formato PEM.</i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -260,70 +260,70 @@ msgstr ""
 "Questo file deve essere accessibile solamente da parte del soggetto della "
 "richiesta di firma di certificato (CSR).</i>"
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Aggiungi un certificato CA autofirmato"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Confermare la revoca di questo certificato?"
 msgstr[1] "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificato revocato.\n"
 msgstr[1] "Certificato revocato.\n"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -334,28 +334,44 @@ msgstr[1] ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -366,17 +382,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -384,61 +400,61 @@ msgstr ""
 "La password attualmente inserita non corrisponde con la reale e corrente "
 "password del database."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la modifica della password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Errore nello stabilire la password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr "Password stabilita correttamente"
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la rimozione della password del database. L'operazione è "
 "stata annullata."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "Password rimossa correttamente"
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Salva i parametri Diffie-Hellman"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parametri Diffie-Hellman salvati correttamente"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "Selezionare il file PEM da importare"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -123,15 +123,15 @@ msgstr "Gerir aisidament e graficament de certificats X.509 e d'AC"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -139,7 +139,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -147,190 +147,206 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Periodic"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Activacion"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Expiracion"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Revocacion"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Error inesperada"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "<b>Certificats</b>"
 msgstr[1] "<b>Certificats</b>"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -341,69 +357,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -130,15 +130,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -146,7 +146,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -154,191 +154,207 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Visibilidade de certificados revogados"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Visibilidade de pedidos de certificado"
 msgstr[1] "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -349,69 +365,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -132,15 +132,15 @@ msgstr "Управлять сертификатами X.509 и CA легко и 
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Сертификат</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Запрос на Подпись Сертификата</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -157,85 +157,85 @@ msgstr "%m/%d/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Серийный номер"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Активация"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Срок истечения"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Отзыв"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Экспорт запроса на подпись сертификата"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Произошла ошибка во время экспорта сертификата."
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr "Произошла ошибка во время экспорта CSR."
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr "Запрос на подпись сертификата успешно экспортирован"
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr "Экспорт зашифрованного закрытого ключ"
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Закрытый ключ успешно экспортирован"
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Экспорт незашифрованного закрытого ключа"
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Экспорт всего сертификата в PKCS#12 пакет"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Экспорт CSR - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -243,7 +243,7 @@ msgstr ""
 "Пожалуйста, выберите какую часть сохранённого Запроса на Подпись Сертификата "
 "вы хотите экспортировать:"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -251,7 +251,7 @@ msgstr ""
 "<i>Экспорт Запроса на Подпись Сертификата в незашифрованный файл PEM формата."
 "</i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -260,99 +260,115 @@ msgstr ""
 "<i>Экспрорт сохранённого закрытого ключа в PKCS#8 файл защищённый паролем. "
 "Этот файл должен быть доступен владельцу Запроса на Подпись Сертификата.</i>"
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Неожиданная ошибка"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Корневой сертификат CA"
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Вы уверены, что хотите отозвать сертификат?"
 msgstr[1] "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Сертификат отозван.\n"
 msgstr[1] "Сертификат отозван.\n"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 msgstr[1] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -363,15 +379,15 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr "Изменить CA пароль - gnoMint"
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -379,55 +395,55 @@ msgstr ""
 "Текущий пароль, который вы ввели, не совпадает с текущим актуальным паролем "
 "базы."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr "Произошла  ошибка при смене пароля базы. Операция отменена."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr "Пароль установлен успешно"
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr "Произошла ошибка при удалении пароля базы. Операция отменена."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "Пароль удалён успешно."
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Сохранить Diffie-Hellman параметры"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Параметры Diffie-Hellman сохранены успешно"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "Выберите PEM файл для импорта"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Проблема при импорте файла '%s'"
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr "Выберите каталог для импорта"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -131,15 +131,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -147,7 +147,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -155,191 +155,207 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Vlastnosti žiadosti o vydanie certifikátu - gnoMint"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Pridať certifikát self-signed CA"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Viditeľnosť žiadostí o certifikát"
 msgstr[1] "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Pridať novú žiadosť o vydanie certifikátu"
 msgstr[1] "Pridať novú žiadosť o vydanie certifikátu"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -350,69 +366,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-21 18:10+0200\n"
+"POT-Creation-Date: 2026-05-22 05:20+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -134,15 +134,15 @@ msgstr "Hantera X.509-certifikat och certifikatutfärdare, enkelt och grafiskt"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:255
+#: ../src/ca.c:256
 msgid "<b>Certificates</b>"
 msgstr "<b>Certifikat</b>"
 
-#: ../src/ca.c:399
+#: ../src/ca.c:400
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
-#: ../src/ca.c:442 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
+#: ../src/ca.c:443 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
 #: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
 #: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
 #: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
@@ -150,7 +150,7 @@ msgstr "<b>Certifikatsigneringsbegäran</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:445 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
+#: ../src/ca.c:446 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
 #: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
 #: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
 #: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
@@ -159,85 +159,85 @@ msgstr "%Y/%m/%d %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:595 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:596 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
-#: ../src/ca.c:631
+#: ../src/ca.c:632
 msgid "Serial"
 msgstr "Serienummer"
 
-#: ../src/ca.c:639
+#: ../src/ca.c:640
 msgid "Activation"
 msgstr "Aktivering"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:650
 msgid "Expiration"
 msgstr "Utgång"
 
-#: ../src/ca.c:659
+#: ../src/ca.c:660
 msgid "Revocation"
 msgstr "Spärrning"
 
-#: ../src/ca.c:980
+#: ../src/ca.c:989
 msgid "Export certificate"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:983 ../src/ca.c:990 ../src/ca.c:1092 ../src/ca.c:1143
-#: ../src/ca.c:1194 ../src/ca.c:1384 ../src/ca.c:2330 ../src/ca.c:2436
-#: ../src/ca.c:2470 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:992 ../src/ca.c:999 ../src/ca.c:1101 ../src/ca.c:1152
+#: ../src/ca.c:1203 ../src/ca.c:1393 ../src/ca.c:2391 ../src/ca.c:2497
+#: ../src/ca.c:2531 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:984 ../src/ca.c:991 ../src/ca.c:1093 ../src/ca.c:1144
-#: ../src/ca.c:1195 ../src/ca.c:1385 ../src/ca.c:2331 ../src/crl.c:258
+#: ../src/ca.c:993 ../src/ca.c:1000 ../src/ca.c:1102 ../src/ca.c:1153
+#: ../src/ca.c:1204 ../src/ca.c:1394 ../src/ca.c:2392 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:987
+#: ../src/ca.c:996
 msgid "Export certificate signing request"
 msgstr "Exportera certificate signing request"
 
-#: ../src/ca.c:1002 ../src/ca.c:1038 ../src/ca.c:1048 ../src/export.c:278
+#: ../src/ca.c:1011 ../src/ca.c:1047 ../src/ca.c:1057 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Det inträffade ett fel då certifikatet skulle exporteras."
 
-#: ../src/ca.c:1004 ../src/ca.c:1040 ../src/ca.c:1050
+#: ../src/ca.c:1013 ../src/ca.c:1049 ../src/ca.c:1059
 msgid "There was an error while exporting CSR."
 msgstr "Det inträffade ett fel då CSR skulle exporteras."
 
-#: ../src/ca.c:1063 ../src/ca.c:1229
+#: ../src/ca.c:1072 ../src/ca.c:1238
 msgid "Certificate exported successfully"
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1070
+#: ../src/ca.c:1079
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1089
+#: ../src/ca.c:1098
 msgid "Export crypted private key"
 msgstr "Exportera krypterad privat nyckel"
 
-#: ../src/ca.c:1118 ../src/ca.c:1170
+#: ../src/ca.c:1127 ../src/ca.c:1179
 msgid "Private key exported successfully"
 msgstr "Privat nyckel exporterades"
 
-#: ../src/ca.c:1140
+#: ../src/ca.c:1149
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportera okrypterad privat nyckel"
 
-#: ../src/ca.c:1191
+#: ../src/ca.c:1200
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportera helt certifikat i PKCS#12-paket"
 
-#: ../src/ca.c:1262
+#: ../src/ca.c:1271
 msgid "Export CSR - gnoMint"
 msgstr "Exportera CSR - gnoMint"
 
-#: ../src/ca.c:1267
+#: ../src/ca.c:1276
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -245,7 +245,7 @@ msgstr ""
 "Vänligen välj vilken del av den sparade Certificate Signing Request du vill "
 "exportera:"
 
-#: ../src/ca.c:1272
+#: ../src/ca.c:1281
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -253,7 +253,7 @@ msgstr ""
 "<i>Exportera Certificate Signing Request till en publik fil, i PEM-format.</"
 "i>"
 
-#: ../src/ca.c:1277
+#: ../src/ca.c:1286
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -263,70 +263,70 @@ msgstr ""
 "fil. Filen bör endast kunna kommas åt av den till vilken Certificate Signing "
 "Request är utfärdat.</i>"
 
-#: ../src/ca.c:1341
+#: ../src/ca.c:1350
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: ../src/ca.c:1356
+#: ../src/ca.c:1365
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1382
+#: ../src/ca.c:1391
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1405
+#: ../src/ca.c:1414
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1413
+#: ../src/ca.c:1422
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Lägg till ett autosignerat CA-certifikat"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1430
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1542
+#: ../src/ca.c:1551
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1548
+#: ../src/ca.c:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Är du säker på att du vill spärra detta certifikat?"
 msgstr[1] "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1555
+#: ../src/ca.c:1564
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1573
+#: ../src/ca.c:1582
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1577
+#: ../src/ca.c:1586
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Exportera certifikat"
 msgstr[1] "Exportera certifikat"
 
-#: ../src/ca.c:1601
+#: ../src/ca.c:1610
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1607
+#: ../src/ca.c:1616
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -335,28 +335,44 @@ msgstr[0] ""
 msgstr[1] ""
 "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:1628
+#: ../src/ca.c:1637
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1691
+#: ../src/ca.c:1700
+msgid ""
+"<b>Renew this certificate?</b>\n"
+"\n"
+"gnoMint will issue a new certificate with the same subject and SAN as the "
+"selected one, signed by the same CA, with a freshly-generated keypair. The "
+"old certificate will remain in the database — revoke it manually after you "
+"have deployed the new one."
+msgstr ""
+
+#: ../src/ca.c:1718
+msgid ""
+"Certificate renewed. A new certificate with a fresh keypair has been added "
+"to the database alongside the original."
+msgstr ""
+
+#: ../src/ca.c:1752
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1753
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1700
+#: ../src/ca.c:1761
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1701
+#: ../src/ca.c:1762
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -367,73 +383,73 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1744
+#: ../src/ca.c:1805
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:2108
+#: ../src/ca.c:2169
 msgid "Change CA password - gnoMint"
 msgstr "Ändra CA-lösenord - gnoMint"
 
-#: ../src/ca.c:2126
+#: ../src/ca.c:2187
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 "Det lösenord Du skrivit in är inte det som behövs för den valda databasen."
 
-#: ../src/ca.c:2141
+#: ../src/ca.c:2202
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle bytas. Operationen avbröts."
 
-#: ../src/ca.c:2150
+#: ../src/ca.c:2211
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: ../src/ca.c:2160 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2221 ../src/ca-cli-callbacks.c:1091
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2170
+#: ../src/ca.c:2231
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2180
+#: ../src/ca.c:2241
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle tas bort. Operationen "
 "avbröts."
 
-#: ../src/ca.c:2189
+#: ../src/ca.c:2250
 msgid "Password removed successfully"
 msgstr "Lösenordet togs bort"
 
-#: ../src/ca.c:2327
+#: ../src/ca.c:2388
 msgid "Save Diffie-Hellman parameters"
 msgstr "Spara Diffie-Hellman-parametrar"
 
-#: ../src/ca.c:2353
+#: ../src/ca.c:2414
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-parametrar sparades"
 
 #. Import single file
-#: ../src/ca.c:2433
+#: ../src/ca.c:2494
 msgid "Select PEM file to import"
 msgstr "Välj PEM-fil att importera"
 
-#: ../src/ca.c:2437 ../src/ca.c:2471 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2498 ../src/ca.c:2532 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2454
+#: ../src/ca.c:2515
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Ett problem inträffade vid importerandet av filen '%s'"
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2528
 msgid "Select directory to import"
 msgstr "Välj katalog att importera"
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ gnomint_SOURCES = \
         new_ca_window.c \
         new_req_window.c \
 	new_cert.c \
+	cert_renewal.c \
 	creation_process_window.c \
 	dialog.c \
 	ca.c \
@@ -109,6 +110,7 @@ EXTRA_DIST = \
 	new_ca_window.h \
 	new_req_window.h \
 	new_cert.h \
+	cert_renewal.h \
 	tls.h\
 	pkey_manage.h \
 	preferences.h \

--- a/src/ca.c
+++ b/src/ca.c
@@ -41,6 +41,7 @@
 #include "new_ca_window.h"
 #include "new_req_window.h"
 #include "new_cert.h"
+#include "cert_renewal.h"
 #include "preferences-gui.h"
 #include "preferences-window.h"
 #include "import.h"
@@ -805,6 +806,8 @@ void __ca_activate_certificate_selection (GtkTreeIter *iter)
         widget = gtk_builder_get_object (main_window_gtkb, "revoke_toolbutton");
         gtk_widget_set_sensitive (GTK_WIDGET(widget), (! is_revoked));
 
+        widget = gtk_builder_get_object (main_window_gtkb, "renew1");
+        if (widget) gtk_widget_set_sensitive (GTK_WIDGET(widget), (! is_revoked));
 
 	widget = gtk_builder_get_object (main_window_gtkb, "sign1");
 	gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
@@ -842,6 +845,9 @@ void __ca_activate_csr_selection (GtkTreeIter *iter)
 	widget = gtk_builder_get_object (main_window_gtkb, "revoke_toolbutton");
 	gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
 
+	widget = gtk_builder_get_object (main_window_gtkb, "renew1");
+	if (widget) gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
+
 	widget = gtk_builder_get_object (main_window_gtkb, "sign1");
 	gtk_widget_set_sensitive (GTK_WIDGET(widget), TRUE);
 	widget = gtk_builder_get_object (main_window_gtkb, "sign_toolbutton");
@@ -875,6 +881,9 @@ void __ca_deactivate_actions ()
 	gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
 	widget = gtk_builder_get_object (main_window_gtkb, "revoke_toolbutton");
 	gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
+
+	widget = gtk_builder_get_object (main_window_gtkb, "renew1");
+	if (widget) gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
 
 	widget = gtk_builder_get_object (main_window_gtkb, "sign1");
 	gtk_widget_set_sensitive (GTK_WIDGET(widget), FALSE);
@@ -1658,6 +1667,58 @@ G_MODULE_EXPORT void ca_on_extractprivatekey1_activate (GtkMenuItem *menuitem, g
 	gtk_tree_iter_free (iter);
 
 	dialog_refresh_list();
+}
+
+
+G_MODULE_EXPORT void ca_on_renew_activate (GtkMenuItem *menuitem, gpointer user_data)
+{
+	GtkTreeIter *iter = NULL;
+	gint type = __ca_selection_type (GTK_TREE_VIEW (
+	    gtk_builder_get_object (main_window_gtkb, "ca_treeview")), &iter);
+	guint64 cert_id = 0;
+	guint64 new_cert_id = 0;
+	gchar  *err = NULL;
+	GObject *parent_win = NULL;
+	GtkDialog *confirm = NULL;
+	gint response = 0;
+
+	if (type != CA_FILE_ELEMENT_TYPE_CERT) {
+		if (iter) gtk_tree_iter_free (iter);
+		return;
+	}
+
+	gtk_tree_model_get (GTK_TREE_MODEL (ca_model), iter,
+	                    CA_MODEL_COLUMN_ID, &cert_id, -1);
+	gtk_tree_iter_free (iter);
+
+	parent_win = gtk_builder_get_object (main_window_gtkb, "main_window1");
+	confirm = GTK_DIALOG (gtk_message_dialog_new_with_markup (
+	    GTK_WINDOW (parent_win),
+	    GTK_DIALOG_DESTROY_WITH_PARENT,
+	    GTK_MESSAGE_QUESTION,
+	    GTK_BUTTONS_YES_NO,
+	    _("<b>Renew this certificate?</b>\n\n"
+	      "gnoMint will issue a new certificate with the same subject "
+	      "and SAN as the selected one, signed by the same CA, with a "
+	      "freshly-generated keypair. The old certificate will remain in "
+	      "the database — revoke it manually after you have deployed the "
+	      "new one.")));
+	response = gtk_dialog_run (confirm);
+	gtk_widget_destroy (GTK_WIDGET (confirm));
+	if (response != GTK_RESPONSE_YES)
+		return;
+
+	err = cert_renewal_renew (cert_id, &new_cert_id);
+	if (err) {
+		dialog_error (err);
+		g_free (err);
+		return;
+	}
+
+	dialog_info (_("Certificate renewed. A new certificate with a fresh "
+	               "keypair has been added to the database alongside the "
+	               "original."));
+	ca_refresh_model_callback ();
 }
 
 

--- a/src/cert_renewal.c
+++ b/src/cert_renewal.c
@@ -1,0 +1,209 @@
+/*  gnoMint — certificate renewal.
+ *  See cert_renewal.h for the contract.
+ */
+
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <string.h>
+#include <time.h>
+
+#include "cert_renewal.h"
+#include "ca_file.h"
+#include "tls.h"
+#include "pkey_manage.h"
+
+/* Read an integer policy with a fallback. */
+static gint
+policy_int_default (guint64 ca_id, const gchar *key, gint fallback)
+{
+	gint v = ca_file_policy_get_int (ca_id, key);
+	return v ? v : fallback;
+}
+
+gchar *
+cert_renewal_renew (guint64 cert_id, guint64 *new_cert_id_out)
+{
+	gchar  *old_pem = NULL;
+	TlsCert *old_cert = NULL;
+	guint64 parent_ca_id = 0;
+	gchar  *parent_pem = NULL;
+	gchar  *parent_dn = NULL;
+	PkeyManageData *parent_crypted_pkey = NULL;
+	gchar  *parent_pkey_pem = NULL;
+	gchar  *new_private_key_pem = NULL;
+	gchar  *new_csr_pem = NULL;
+	gchar  *new_cert_pem = NULL;
+	gchar  *crypted_new_pkey = NULL;
+	gnutls_x509_privkey_t *new_key = NULL;
+	TlsCreationData    *csr_cd  = NULL;
+	TlsCertCreationData *cert_cd = NULL;
+	gchar  *error = NULL;
+
+	/* 1. Fetch + parse the old cert. */
+	old_pem = ca_file_get_public_pem_from_id (CA_FILE_ELEMENT_TYPE_CERT, cert_id);
+	if (!old_pem) {
+		error = g_strdup (_("Cannot read certificate PEM from database."));
+		goto out;
+	}
+	old_cert = tls_parse_cert_pem (old_pem);
+	if (!old_cert) {
+		error = g_strdup (_("Cannot parse certificate."));
+		goto out;
+	}
+
+	/* 2. Locate parent CA. The cert's issuer DN (i_dn) matches a CA
+	 * certificate in the database. Self-signed CAs are their own
+	 * issuer — that's still a valid renewal target. */
+	if (!ca_file_get_id_from_dn (CA_FILE_ELEMENT_TYPE_CERT,
+	                             old_cert->i_dn, &parent_ca_id)) {
+		error = g_strdup_printf (
+		    _("Cannot find issuer CA in this database (issuer DN: %s)."),
+		    old_cert->i_dn ? old_cert->i_dn : "(null)");
+		goto out;
+	}
+
+	parent_pem = ca_file_get_public_pem_from_id (CA_FILE_ELEMENT_TYPE_CERT,
+	                                              parent_ca_id);
+	parent_dn  = ca_file_get_dn_from_id (CA_FILE_ELEMENT_TYPE_CERT,
+	                                      parent_ca_id);
+	parent_crypted_pkey = pkey_manage_get_certificate_pkey (parent_ca_id);
+	if (!parent_pem || !parent_dn || !parent_crypted_pkey) {
+		error = g_strdup (_("Cannot load parent CA material from database."));
+		goto out;
+	}
+
+	/* Decrypt parent CA's private key. Prompts for the DB passphrase
+	 * if the database is encrypted. */
+	parent_pkey_pem = pkey_manage_uncrypt (parent_crypted_pkey, parent_dn);
+	if (!parent_pkey_pem) {
+		error = g_strdup (_("Cannot decrypt parent CA's private key."));
+		goto out;
+	}
+
+	/* 3. Build TlsCreationData for the new keypair + CSR. Inherits
+	 * subject and SAN from the old cert; key type defaults to RSA
+	 * 2048 (matches the most common case). Future work: detect the
+	 * old cert's actual key algorithm and renew with the same. */
+	csr_cd = g_new0 (TlsCreationData, 1);
+	csr_cd->cn           = g_strdup (old_cert->cn);
+	csr_cd->org          = g_strdup (old_cert->o);
+	csr_cd->ou           = g_strdup (old_cert->ou);
+	csr_cd->country      = g_strdup (old_cert->c);
+	csr_cd->state        = g_strdup (old_cert->st);
+	csr_cd->city         = g_strdup (old_cert->l);
+	csr_cd->emailAddress = g_strdup (old_cert->emailAddress);
+	csr_cd->subject_alt_name = g_strdup (old_cert->subject_alt_name);
+	csr_cd->key_type     = 0;     /* RSA */
+	csr_cd->key_bitlength = 2048;
+	csr_cd->activation   = time (NULL);
+	csr_cd->expiration   = csr_cd->activation + 86400 * 30; /* placeholder */
+
+	/* 4. Generate fresh RSA keypair. */
+	error = tls_generate_rsa_keys (csr_cd, &new_private_key_pem, &new_key);
+	if (error) goto out;
+
+	/* 5. Generate CSR using the old cert's subject info. */
+	error = tls_generate_csr (csr_cd, new_key, &new_csr_pem);
+	if (error) goto out;
+
+	/* 6. Build TlsCertCreationData from parent CA's policy. */
+	cert_cd = g_new0 (TlsCertCreationData, 1);
+	{
+		gint months = policy_int_default (parent_ca_id, "MONTHS_TO_EXPIRE", 12);
+		time_t now = time (NULL);
+		cert_cd->activation = now;
+		cert_cd->expiration = now + (time_t) months * 30 * 86400;
+		cert_cd->key_months_before_expiration = months;
+	}
+	cert_cd->ca                = ca_file_policy_get_int (parent_ca_id, "CA");
+	cert_cd->crl_signing       = ca_file_policy_get_int (parent_ca_id, "CRL_SIGN");
+	cert_cd->non_repudiation   = ca_file_policy_get_int (parent_ca_id, "NON_REPUDIATION");
+	cert_cd->digital_signature = ca_file_policy_get_int (parent_ca_id, "DIGITAL_SIGNATURE");
+	cert_cd->key_encipherment  = ca_file_policy_get_int (parent_ca_id, "KEY_ENCIPHERMENT");
+	cert_cd->key_agreement     = ca_file_policy_get_int (parent_ca_id, "KEY_AGREEMENT");
+	cert_cd->data_encipherment = ca_file_policy_get_int (parent_ca_id, "DATA_ENCIPHERMENT");
+	cert_cd->web_server        = ca_file_policy_get_int (parent_ca_id, "TLS_WEB_SERVER");
+	cert_cd->web_client        = ca_file_policy_get_int (parent_ca_id, "TLS_WEB_CLIENT");
+	cert_cd->time_stamping     = ca_file_policy_get_int (parent_ca_id, "TIME_STAMPING");
+	cert_cd->ocsp_signing      = ca_file_policy_get_int (parent_ca_id, "OCSP_SIGNING");
+	cert_cd->code_signing      = ca_file_policy_get_int (parent_ca_id, "CODE_SIGNING");
+	cert_cd->email_protection  = ca_file_policy_get_int (parent_ca_id, "EMAIL_PROTECTION");
+
+	/* If nothing is enabled (typical for an existing leaf cert under a
+	 * permissive policy) fall back to the digitalSignature + keyEncipherment
+	 * + serverAuth profile, which covers ~90% of real-world certificates. */
+	if (!cert_cd->digital_signature && !cert_cd->key_encipherment &&
+	    !cert_cd->web_server && !cert_cd->web_client &&
+	    !cert_cd->code_signing && !cert_cd->email_protection) {
+		cert_cd->digital_signature = TRUE;
+		cert_cd->key_encipherment  = TRUE;
+		cert_cd->web_server        = TRUE;
+	}
+
+	ca_file_get_next_serial (&cert_cd->serial, parent_ca_id);
+
+	/* 7. Sign the CSR with the parent CA. */
+	error = tls_generate_certificate (cert_cd, new_csr_pem,
+	                                  parent_pem, parent_pkey_pem,
+	                                  &new_cert_pem);
+	if (error) goto out;
+
+	/* 8. Encrypt the new private key under the new cert's DN. */
+	{
+		TlsCsr *new_csr_info = tls_parse_csr_pem (new_csr_pem);
+		if (!new_csr_info) {
+			error = g_strdup (_("Cannot parse generated CSR."));
+			goto out;
+		}
+		crypted_new_pkey = pkey_manage_crypt (new_private_key_pem,
+		                                      new_csr_info->dn);
+		tls_csr_free (new_csr_info);
+		if (!crypted_new_pkey) {
+			error = g_strdup (_("Cannot encrypt new private key."));
+			goto out;
+		}
+	}
+
+	/* 9. Insert the new certificate. ca_file_insert_cert returns
+	 * gettext-interned strings on error, which the caller must not
+	 * g_free — wrap in g_strdup so the contract on `error` is uniform
+	 * (always heap-allocated, caller frees). */
+	{
+		gchar *insert_err = ca_file_insert_cert (
+		    FALSE /* is_ca */, TRUE /* private_key_in_db */,
+		    crypted_new_pkey, new_cert_pem);
+		if (insert_err) {
+			error = g_strdup (insert_err);
+			goto out;
+		}
+	}
+
+	if (new_cert_id_out) {
+		/* Look up the freshly-inserted cert by its DN. */
+		TlsCert *new_cert = tls_parse_cert_pem (new_cert_pem);
+		if (new_cert) {
+			ca_file_get_id_from_dn (CA_FILE_ELEMENT_TYPE_CERT,
+			                        new_cert->dn, new_cert_id_out);
+			tls_cert_free (new_cert);
+		}
+	}
+
+out:
+	if (new_key) {
+		gnutls_x509_privkey_deinit (*new_key);
+		g_free (new_key);
+	}
+	g_free (old_pem);
+	if (old_cert) tls_cert_free (old_cert);
+	g_free (parent_pem);
+	g_free (parent_dn);
+	pkey_manage_data_free (parent_crypted_pkey);
+	g_free (parent_pkey_pem);
+	g_free (new_private_key_pem);
+	g_free (new_csr_pem);
+	g_free (new_cert_pem);
+	g_free (crypted_new_pkey);
+	if (csr_cd) tls_creation_data_free (csr_cd);
+	g_free (cert_cd);
+	return error;
+}

--- a/src/cert_renewal.h
+++ b/src/cert_renewal.h
@@ -1,0 +1,24 @@
+/*  gnoMint: certificate renewal entry point.
+ *
+ *  Takes an existing certificate (by database id), generates a fresh
+ *  keypair, and signs a new certificate with the same subject + SAN as
+ *  the original, using the parent CA's current policy for everything
+ *  else (validity, key usage, extended key usage).
+ *
+ *  The old certificate is left untouched in the database — common
+ *  practice is "issue new, deploy, revoke old". The caller can revoke
+ *  the old cert explicitly via the existing menu.
+ *
+ *  Returns NULL on success and writes the new cert's database id into
+ *  *new_cert_id_out (if non-NULL). On failure returns a freshly
+ *  allocated error string the caller must g_free.
+ */
+
+#ifndef _CERT_RENEWAL_H_
+#define _CERT_RENEWAL_H_
+
+#include <glib.h>
+
+gchar * cert_renewal_renew (guint64 cert_id, guint64 *new_cert_id_out);
+
+#endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,6 +54,7 @@ check_ui_consistency_SOURCES = \
 	$(top_srcdir)/src/new_ca_window.c \
 	$(top_srcdir)/src/new_req_window.c \
 	$(top_srcdir)/src/new_cert.c \
+	$(top_srcdir)/src/cert_renewal.c \
 	$(top_srcdir)/src/creation_process_window.c \
 	$(top_srcdir)/src/dialog.c \
 	$(top_srcdir)/src/ca.c \
@@ -113,6 +114,7 @@ check_workflows_SOURCES = \
 	$(top_srcdir)/src/new_ca_window.c \
 	$(top_srcdir)/src/new_req_window.c \
 	$(top_srcdir)/src/new_cert.c \
+	$(top_srcdir)/src/cert_renewal.c \
 	$(top_srcdir)/src/creation_process_window.c \
 	$(top_srcdir)/src/dialog.c \
 	$(top_srcdir)/src/ca.c \

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -1351,6 +1351,116 @@ scenario_ecdsa_eddsa_keygen (void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Scenario: certificate renewal (issue #50)                         */
+/* ------------------------------------------------------------------ */
+
+#include "cert_renewal.h"
+#include "ca_file.h"
+
+/* Renews a leaf cert from the fixture and asserts:
+ *   - cert_renewal_renew returns NULL (no error)
+ *   - new cert id is non-zero
+ *   - new cert appears in the cert table with the same CN
+ *   - new cert's serial is different from the old one
+ *   - old cert is still present and not revoked. */
+static int
+scenario_certificate_renewal (void)
+{
+    int rc = 1;
+    fprintf (stderr, "==> scenario: certificate renewal (issue #50)\n");
+
+    if (!fixture_setup ())
+        return 1;
+    if (!ca_file_open (g_strdup (fixture_path), FALSE)) {
+        fail_test ("renewal", "ca_file_open(%s) failed", fixture_path);
+        goto out;
+    }
+
+    /* Cert id 2 (Signing software CA) sits directly under the root,
+     * which is the only fixture CA that ships with subject_key_id set.
+     * Deeper certs can't currently be renewed because
+     * ca_file_insert_cert resolves the parent CA via SKI matching;
+     * fixing that is tracked separately. */
+    guint64 old_id = 2;
+    gchar *old_pem = ca_file_get_public_pem_from_id (CA_FILE_ELEMENT_TYPE_CERT, old_id);
+    if (!old_pem) {
+        fail_test ("renewal", "fixture missing cert id %" G_GUINT64_FORMAT, old_id);
+        goto out;
+    }
+    TlsCert *old_cert = tls_parse_cert_pem (old_pem);
+    g_free (old_pem);
+    if (!old_cert) {
+        fail_test ("renewal", "cannot parse old cert PEM");
+        goto out;
+    }
+
+    guint64 new_id = 0;
+    gchar *err = cert_renewal_renew (old_id, &new_id);
+    if (err) {
+        fail_test ("renewal", "cert_renewal_renew error: %s", err);
+        g_free (err);
+        tls_cert_free (old_cert);
+        goto out;
+    }
+    if (new_id == 0) {
+        fail_test ("renewal", "no new cert id returned");
+        tls_cert_free (old_cert);
+        goto out;
+    }
+    fprintf (stderr, "    renewed cert id %" G_GUINT64_FORMAT
+             " → %" G_GUINT64_FORMAT "\n", old_id, new_id);
+
+    /* The new cert must be parseable and share the CN with the old. */
+    gchar *new_pem = ca_file_get_public_pem_from_id (CA_FILE_ELEMENT_TYPE_CERT, new_id);
+    if (!new_pem) {
+        fail_test ("renewal", "new cert id not retrievable");
+        tls_cert_free (old_cert);
+        goto out;
+    }
+    TlsCert *new_cert = tls_parse_cert_pem (new_pem);
+    g_free (new_pem);
+    if (!new_cert) {
+        fail_test ("renewal", "cannot parse new cert PEM");
+        tls_cert_free (old_cert);
+        goto out;
+    }
+    if (g_strcmp0 (new_cert->cn, old_cert->cn) != 0) {
+        fail_test ("renewal", "CN mismatch: old=\"%s\" new=\"%s\"",
+                   old_cert->cn ? old_cert->cn : "(null)",
+                   new_cert->cn ? new_cert->cn : "(null)");
+        goto out_cleanup;
+    }
+
+    /* Serial must differ. */
+    if (g_strcmp0 (new_cert->sha1, old_cert->sha1) == 0) {
+        fail_test ("renewal", "new cert has same SHA1 as old — keypair was not regenerated");
+        goto out_cleanup;
+    }
+
+    /* Old cert still present, not revoked. */
+    gchar *old_pem_again = ca_file_get_public_pem_from_id (CA_FILE_ELEMENT_TYPE_CERT, old_id);
+    if (!old_pem_again) {
+        fail_test ("renewal", "old cert was removed from database");
+        goto out_cleanup;
+    }
+    g_free (old_pem_again);
+
+    fprintf (stderr, "    CN preserved (\"%s\"), distinct SHA1, old cert intact OK\n",
+             new_cert->cn);
+    rc = 0;
+
+out_cleanup:
+    tls_cert_free (old_cert);
+    tls_cert_free (new_cert);
+
+out:
+    ca_file_close ();
+    fixture_teardown ();
+    int crits = critical_messages_check_and_reset ("renewal");
+    return (rc == 0 && crits == 0) ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Scenario: key-length selector swaps with algorithm                */
 /* ------------------------------------------------------------------ */
 
@@ -1489,6 +1599,7 @@ main (int argc, char **argv)
     scenario_chain_export ();
     scenario_bulk_operations ();
     scenario_ecdsa_eddsa_keygen ();
+    scenario_certificate_renewal ();
 
     /* Phase 2B scenarios drive production code paths that load .ui
      * files from PACKAGE_DATA_DIR (new_ca_window.c et al). That path


### PR DESCRIPTION
## Summary
Right-click a certificate → **Renew with fresh key**. gnoMint:
1. Parses the existing cert to lift subject DN + SAN.
2. Finds the issuing CA by matching the cert's `i_dn` against CA subject DNs.
3. Generates a fresh RSA-2048 keypair, builds a CSR, signs it with the parent CA using the CA's current policy (validity, key usage, EKU).
4. Inserts the new certificate alongside the old one.

Old cert is left untouched — the dialog tells the user to revoke it manually after deployment (standard "issue new, deploy, revoke old" pattern).

## Files
- `src/cert_renewal.c` / `.h` — pure helper, testable without UI.
- `src/ca.c` — `ca_on_renew_activate` callback + sensitivity wiring.
- `gui/main_window.ui` / `gui/certificate_popup_menu.ui` — menu entry + popup.
- `tests/check_workflows.c` — `scenario_certificate_renewal` (Phase 2A, no install required).

## Test plan
- [x] `make` (no warnings)
- [x] `make -C tests check` — all 5 suites pass, including the new renewal scenario which:
  - renews fixture cert id 2 (Signing software CA)
  - asserts new cert id is produced, CN preserved, SHA1 distinct, old cert intact
- [ ] Manual GUI smoke: right-click a cert in the running app, pick Renew, confirm.

## Known limitation
`ca_file_insert_cert` resolves the parent CA by matching the new cert's `issuer_key_id` against existing certs' `subject_key_id`. Pre-1.0 fixture-style CAs without SKI return *"Cannot find parent CA in database"*. This pre-dates the renewal work and is tracked separately.