### PR TITLE
CLI parity: renewcert / exportchain / revokemany / deletemany / ECDSA prompt / startup expiry notice

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -132,53 +132,53 @@ msgstr "Gestiona CAs i certificats X.509, fàcilment i de forma gràfica"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Núm. de sèrie"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Activació"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Venciment"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Revocació"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,66 +189,66 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Exporta sol·licitud de signatura de certificat"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Hi ha hagut un error al exportar el certificat."
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 "Ha hagut un error al exportar la sol·licitud de signatura de certificat "
 "(CSR),"
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr "Sol·licitud de signatura de certificat exportada amb èxit."
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr "Exporta la clau privada xifrada"
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Clau privada exportada amb èxit."
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporta la clau privada sense xifrar"
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporta tot el certificat en un paquet PKCS#12"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Exporta sol·licitud de signatura de certificat (CSR) - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -256,7 +256,7 @@ msgstr ""
 "Seleccioneu quina part de la sol·licitud de signatura de certificat (CSR) "
 "voleu exportar:"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -264,7 +264,7 @@ msgstr ""
 "<i>Exporta la sol·licitud de signatura de certificat a un fitxer públic en "
 "format PEM</i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -274,70 +274,70 @@ msgstr ""
 "contrasenya. Aquest fitxer només ha de ser accessible pel titular de la "
 "sol·licitud de signatura del certificat.</i>"
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Afegir certificat de la CA auto-signat"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Esteu segur que voleu revocar aquest certificat?"
 msgstr[1] "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat revocat.\n"
 msgstr[1] "Certificat revocat.\n"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -348,12 +348,12 @@ msgstr[1] ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -363,29 +363,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -396,17 +396,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr "Canvia la contrasenya de la CA - gnoMint"
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -414,99 +414,99 @@ msgstr ""
 "La contrasenya introduïda no es correspon amb la contrasenya real de la base "
 "de dades."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al establir la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr "La contrasenya s'ha establert amb èxit"
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al eliminar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "La contrasenya s'ha eliminat amb èxit"
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Desa paràmetres Diffie-Hellman"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Paràmetres Diffie-Hellman desats correctament"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "Seleccioneu el fitxer PEM a importar"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "S'han produït problemes al importar el fitxer '%s'"
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr "Seleccioneu el directori a importar"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr "newdb <nom del fitxer>"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 "Tanca el fitxer actual i crea una nova base de dades amb el nom del fitxer "
 "indicat"
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr "opendb <nom del fitxer>"
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr "Tanca el fitxer actual i obre el fitxer amb el nom indicat"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr "savedbas <nom del fitxer>"
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Desa el fitxer actual amb un nom diferent"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr "Obtén l'estat actual (fitxer obert, nombre de certificats, etc..)"
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
@@ -515,35 +515,35 @@ msgstr ""
 "llista també els certificats revocats."
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 "Llista les sol·licituds de signatura de certificats (CSR) existents a la "
 "base de dades"
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr "add-csr [id-de-la-CA-per-heretar-camps]"
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 "Comença un nou procés de creació de sol·licitud de signatura de certificat "
 "(CSR)"
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 "Inicia un nou procés de creació d'Entitat Certificadora (CA) auto-signada"
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr "extractcertpkey <id. del certificat> <nom del fitxer>"
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
@@ -552,11 +552,11 @@ msgstr ""
 "proporcionat i desar-la al fitxer indicat."
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr "extractcsrpkey <id. de csr> <nom del fitxer>"
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
@@ -565,187 +565,238 @@ msgstr ""
 "emmagatzemar-la en el fitxer proporcionat."
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr "revoke <id del certificat>"
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr "Revoca el certificat amb l'identificador proporcionat"
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr "sign <id-CSR> <id-cert-CA>"
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr "Genera un certificat firmant el CSR proporcionat amb la CA indicada"
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr "delete <id. de CSR>"
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 "Esborra la sol·licitud de signatura del certificat indicada de la base de "
 "dades"
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr "crlgen <id. de la CA> <nom del fitxer>"
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 "Genera un nou CRL per la CA indicada, desant-lo al fitxer <nom del fitxer>"
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr "dhgen <longitud en bits del nombre primer><nom del fitxer>"
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 "Genera un nou conjunt de paràmetres DH, desant-lo al fitxer <nom del fitxer>"
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Canvia la contrasenya de la base de dades actual"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr "importfile <nom del fitxer>"
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr "Importa el fitxer amb el nom indicat"
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr "importdir <nom del directori>"
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 "Importa el directori indicat, interpretant-lo com el directori d'una CA "
 "realitzada amb OpenSSL"
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr "showcert <id del certificat>"
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Mostra propietats del certificat indicat"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr "showcsr <id de la CSR>"
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 "Mostra propietats de la sol·licitud de signatura del certificat indicada"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr "showpolicy <id del certificat de la CA>"
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr "Mostra la política de la CA"
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr "setpolicy <id de certificat de la CA> <id de la política> <valor>"
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr "Canvia la política indicada de la CA"
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr "Mostra les preferències del programa"
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr "setpreference <id de prefèrencia> <valor>"
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr "Estableix la preferència del programa indicada"
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+#, fuzzy
+msgid "renewcert <cert-id>"
+msgstr "showcert <id del certificat>"
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <id. del certificat> <nom del fitxer>"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+#, fuzzy
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr "revoke <id del certificat>"
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+#, fuzzy
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr "delete <id. de CSR>"
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Mostra el missatge \"Quant al...\""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr "Mostra informació de la garantia"
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr "Mostra informació sobre la distribució del programa"
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Mostra informació de la versió"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "Mostra (aquest) missatge d'ajuda"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Tanca la base de dades i surt del programa"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Obrint la base de dades %s..."
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " D'acord.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Error.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -760,7 +811,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -769,7 +820,7 @@ msgstr ""
 "Aquest programa es proporciona SENSE QUALSEVOL TIPUS DE GARANTIA; per més\n"
 "detalls, teclegi 'warranty'.\n"
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -782,12 +833,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Error: Cometes desaparellades\n"
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -795,183 +846,183 @@ msgstr ""
 "Ordre no vàlida. Teclegi 'help' per aconseguir una llista d'ordres "
 "reconegudes.\n"
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Nombre incorrecte de paràmetres\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Sintaxi: %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "El fitxer ja existeix, se sobreescriurà."
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr "Esteu segur? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr "S'han produït problemes al obrir la nova base de dades de la CA '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "S'ha obert el fitxer '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr "S'han produït problemes al obrir la base de dades de la CA '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "Fitxer obert actualment: %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Nombre de certificats al fitxer: %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr "Nombre de CSRs en el fitxer: %d\n"
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Certificats a la base de dades:\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr "\t\tRevocació\n"
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr "Sol·licituds de certificat a la base de dades:\n"
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr "Id.\tId. pare\tTitular de la CSR\t\tClau en BD?\n"
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr "L'identificador de la CA proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
@@ -980,111 +1031,127 @@ msgstr ""
 "Introduïu les dades corresponents al titular de la sol·licitud de signatura "
 "del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr "Introduïu el país (C)"
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr "Introduïu el nom de l'estat o la província (ST)"
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr "Introduïu la localitat o la ciutat (L)"
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr "Introduïu l'organització (O)"
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr "Introduïu la Unitat organitzativa (OU)"
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr "Introduïu Nom habitual (CN)"
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#, fuzzy
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Introduïu el tipus de clau que es crearà (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Introduïu la mida de la clau en bits (múltiple de 1024)"
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr "Aquestes són les propietats de la CSR proporcionada:\n"
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr "Titular:\n"
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tNom distintiu: "
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr "Parella de claus\n"
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tTipus: %s\n"
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tLongitud en bits: %d\n"
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Voleu canviar quelcom? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Ara es crearà una petició de signatura del certificat (CSR) amb aquestes "
 "propietats."
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr "Esteu segur [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operació cancel·lada\n"
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1093,7 +1160,7 @@ msgstr ""
 "Introduïu les dades corresponents al titular de la nova Entitat "
 "Certificadora (CA):\n"
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1101,216 +1168,216 @@ msgstr ""
 "Introduïu el nombre de mesos abans la caducitat de la nova Entitat "
 "certificadora"
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Aquestes són les propietats proporcionades per a la nova CA:\n"
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr "Validesa\n"
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr "Validesa:\n"
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tCaduca el: %s\n"
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr "Es crearà una nova Entitat certificadora (CA) amb aquestes propietats."
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr "L'identificador de certificat proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Clau privada extreta amb èxit al fitxer: '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr "L'identificador de la CSR proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr "Aquest certificat serà revocat."
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificat revocat.\n"
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Usos del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Ús com a entitat certificadora habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Ús com a entitat certificadora deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr "* Ús per a la firma de CRLs habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr "* Ús per a la firma de CRLs deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Ús per a la signatura digital habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Ús per a la signatura digital deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "Ús per al xifrat de dades habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "Ús per al xifrat de claus habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "Ús per al xifrat de claus deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "Ús per al no repudi habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "Ús per al no repudi deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "Ús per a la negociació de claus habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "Ús per a la negociació de claus deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Finalitats del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Finalitat per a la protecció del correu electrònic habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Finalitat per a la protecció del correu electrònic deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Finalitat per a la firma de codi  habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Finalitat per a la firma de codi deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Finalitat de client web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Finalitat de client web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Finalitat de servidor web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Finalitat de servidor web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Finalitat de marca horària habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Finalitat de marca horària deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "* Finalitat de signatura OCSP habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "* Finalitat de signatura OCSP deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Qualsevol finalitat habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Qualsevol finalitat deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr "Ara es signarà la següent petició de signatura de certificat (CSR):\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr "amb el certificat corresponent a aquesta CA:\n"
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1318,199 +1385,199 @@ msgstr ""
 "Màxim nombre de mesos abans de la caducitat del nou certificat (0 per a "
 "cancel·lar):"
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr "El nou certificat es validarà per als següents usos i finalitats:\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr "Desitgeu canviar alguna propietat del nou certificat? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* Habilitar ús com Entitat certificadora? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Ús com a Entitat certificadora deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* Habilitar ús per a la signatura de CRL? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Ús per a la signatura de CRL deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Habilitar l'ús per a la signatura digital? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Ús per a la signatura digital deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Habilitar l'ús per al xifratge de dades? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Ús per al xifratge de dades deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Habilitar l'ús per al xifrat de claus? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Ús per al xifratge de claus deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr "Habilitar l'ús per al no repudi? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr "* Ús per al no repudi deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "Habilitar l'ús per a negociació de claus? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "* Ús per a la negociació de claus deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de protecció de correu electrònic? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 "* Finalitat de protecció del correu electrònic deshabilitada per una "
 "directiva.\n"
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de signatura de codi? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Finalitat de signatura de codi deshabilitada per una directiva.\n"
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de client web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Finalitat de client web TLS deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de servidor web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Finalitat de servidor web TLS deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "Habilitat la finalitat de marcatge temporal? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:963
+#: ../src/ca-cli-callbacks.c:1041
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "Finalitat de marcatge temporal deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:967
+#: ../src/ca-cli-callbacks.c:1045
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "Habilitar la finalitat per a la signatura d'OCSP? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:968
+#: ../src/ca-cli-callbacks.c:1046
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 "* Finalitat per a la signatura d'OCSP deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:972
+#: ../src/ca-cli-callbacks.c:1050
 msgid "Enable any purpose? [Yes]/No "
 msgstr "Habilitar l'ús per a qualsevol finalitat? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:974
+#: ../src/ca-cli-callbacks.c:1052
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 "* L'ús per a qualsevol finalitat s'ha deshabilitat amb una directiva.\n"
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 "S'ha obtingut tota la informació necessària per la generació del certificat."
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "Voleu continuar amb la signatura i generació del certificat? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:988
+#: ../src/ca-cli-callbacks.c:1066
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificat signat.\n"
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This Certificate Signing Request will be deleted."
 msgstr "La sol·licitud de signatura de certificat (CSR) s'esborrarà."
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr "Aquesta operació no pot desfer-se. Esteu segur? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1016
+#: ../src/ca-cli-callbacks.c:1094
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Sol·licitud de signatura de certificat esborrada.\n"
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1119
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "CRL generada amb èxit i desada al fitxer '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "La longitud en bits del nombre primer ha de ser múltiple enter de 1024"
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Els paràmetres Diffie-Hellman s'han creat i s'han desat correctament al "
 "fitxer '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr "Actualment la base de dades no es troba protegida per contrasenya."
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "Desitgeu protegir-la amb contrasenya? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1523,37 +1590,37 @@ msgstr ""
 "faci ús de\n"
 "qualsevol clau privada a la base de dades."
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr "Introduïu la contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr "Torneu a introduir la contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr "Les contrasenyes introduïdes són diferents."
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Contrasenya establerta amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr "No s'ha fet res.\n"
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr "Actualment la base de dades ESTÀ protegida amb contrasenya."
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "Desitgeu eliminar aquesta protecció amb contrasenya? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1562,13 +1629,13 @@ msgstr ""
 "Per eliminar la protecció amb contrasenya, heu de proporcionar la \n"
 "contrasenya actual.\n"
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Introduïu la contrasenya actual de la base de dades (Buida per a "
 "cancel·lar): "
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1576,7 +1643,7 @@ msgstr ""
 "La contrasenya actual introduïda\n"
 "no coincideix amb la contrasenya real de la base de dades."
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1584,12 +1651,12 @@ msgstr ""
 "S'ha produït un error al eliminar la contrasenya de\n"
 "la base de dades. S'ha cancel·lat l'operació."
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Contrasenya eliminada amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
@@ -1597,7 +1664,7 @@ msgstr ""
 "Ha de proporcionar la contrasenya actual de la base de dades abans de "
 "canviar-la.\n"
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1611,15 +1678,15 @@ msgstr ""
 "Aquesta contrasenya es demanarà sempre que gnoMint faci ús d'alguna clau\n"
 "privada a la base de dades."
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr "Introduïu la nova contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr "Torneu a introduïr la contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1627,296 +1694,296 @@ msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. \n"
 "S'ha cancel·lat la operació"
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "La contrasenya s'ha canviat amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr "S'han produït problemes en importar el fitxer indicat."
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Fitxer importat amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Directori importat amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr "Certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tNúm. de sèrie: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr "\tNom distintiu (DN): %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr "Cap."
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tIdentificador únic: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr "Emissor:\n"
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Empremtes digitals:\n"
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tEmpremta digital SHA1: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tEmpremta digital MD5: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tEmpremta digital SHA1: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Sol·licitud de signatura de certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 "Els certificats generats hereten el país de la CA                           "
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 "Els certificats generats hereten l'estat/província de la "
 "CA                             "
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 "Els certificats generats hereten localitat o ciutat de la "
 "CA                          "
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 "Els certificats generats hereten l'Organització de la "
 "CA                      "
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 "Els certificats generats hereten la unitat organitzacional de la "
 "CA               "
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 "El país dels certificats generats ha de coincidir amb la CA            "
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 "L'Estat o província dels cert. generats ha de coincidir amb la "
 "CA              "
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 "La localitat o ciutat dels cert. generats ha de coincidir amb la "
 "CA           "
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 "L'organització dels cert. generats ha de coincidir amb la de la CA       "
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr "La Unitat Organitzativa dels cert. generats ha de coincidir amb la CA"
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Nombre màxim d'hores entre actualitzacions de CRLs                       "
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 "Num. màxim de mesos abans de la caducitat dels nous certificats           "
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Habilitar l'ús com a CA en els certificats "
 "generats                                 "
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Habilitar l'ús per a signatura de CRLs en els certificats "
 "generats                           "
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Habilitar l'ús per al no repudi en els certificats "
 "generats                     "
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Habilita l'ús per a la signatura digital en els cert. "
 "generats                  "
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Habilita l'ús per al xifratge de claus en els cert. "
 "generats                   "
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Habilita l'ús per a la negociació de claus en els cert. "
 "generats                      "
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Habilita l'ús per al xifratge de dades en els cert. "
 "generats                  "
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Habilita la finalitat de servidor web TLS per als cert. "
 "generats                 "
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Habilita la finalitat de client web TLS per als cert. "
 "generats                 "
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1925,7 +1992,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1933,14 +2000,14 @@ msgstr ""
 "  David Marín https://launchpad.net/~davefx\n"
 "  Sergio Oller https://launchpad.net/~zeehio"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1958,7 +2025,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1975,101 +2042,168 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s versió %s\n"
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr "Ordres disponibles:\n"
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "L'identificador de la CA proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Creant un certificat arrel de la CA"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "web server"
 msgstr "Servidor web TLS"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "email server"
 msgstr "Servidor web TLS"
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Nombre de CSRs en el fitxer: %d\n"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "S'ha produït un error signant el certificat"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Usos del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy
 msgid "Web Server"
 msgstr "Servidor web TLS"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+#, fuzzy
+msgid "Usage: renewcert <cert-id>"
+msgstr "showcert <id del certificat>"
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#, fuzzy
+msgid "The given certificate id is not valid"
+msgstr "L'identificador de certificat proporcionat no és vàlid"
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+#, fuzzy
+msgid "Renew? [Yes]/No "
+msgstr "Esteu segur [Sí]/No "
+
+#: ../src/ca-cli-callbacks.c:1925
+msgid "Certificate renewed. New certificate id: %"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1933
+#, fuzzy
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <id. del certificat> <nom del fitxer>"
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Afegir certificat de la CA auto-signat"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Certificat revocat.\n"
+msgstr[1] "Certificat revocat.\n"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -121,52 +121,52 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -177,153 +177,153 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 msgid "Export certificate chain"
 msgstr ""
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -333,28 +333,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -365,326 +365,373 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr ""
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr ""
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr ""
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr ""
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr ""
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr ""
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr ""
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid "exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -694,14 +741,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -710,787 +757,802 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:963
-#, c-format
-msgid "* Time Stamping purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:967
-msgid "Enable OCSP Signing purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:968
-#, c-format
-msgid "* OCSP Signing purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:972
-msgid "Enable any purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:974
-#, c-format
-msgid "* Any purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid ""
-"All the mandatory data for the certificate generation has been gathered."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid "Do you want to proceed with the signing? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:988
-#, c-format
-msgid "Certificate signed.\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This Certificate Signing Request will be deleted."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This operation cannot be undone. Are you sure? Yes/[No] "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1016
-#, c-format
-msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:1041
 #, c-format
+msgid "* Time Stamping purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1045
+msgid "Enable OCSP Signing purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1046
+#, c-format
+msgid "* OCSP Signing purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1050
+msgid "Enable any purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1052
+#, c-format
+msgid "* Any purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid ""
+"All the mandatory data for the certificate generation has been gathered."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid "Do you want to proceed with the signing? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1066
+#, c-format
+msgid "Certificate signed.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This Certificate Signing Request will be deleted."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This operation cannot be undone. Are you sure? Yes/[No] "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1094
+#, c-format
+msgid "Certificate Signing Request deleted.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1119
+#, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1498,275 +1560,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1775,7 +1837,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1784,14 +1846,14 @@ msgstr ""
 "  Kuvaly [LCT] https://launchpad.net/~kuvaly\n"
 "  Luboš Staněk https://launchpad.net/~lubek"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1809,7 +1871,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1826,97 +1888,159 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, c-format
 msgid "Certificate type: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+msgid "The given certificate id is not valid"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+msgid "Renew? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1925
+msgid "Certificate renewed. New certificate id: %"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+msgid "Cannot write chain file."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -132,53 +132,53 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Zertifikate</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Seriell"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Widerruf"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +189,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Signaturanfrage für Zertifikat exportieren"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Beim Export des Zertifikats ist ein Fehler aufgetreten."
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr "Signaturanfrage für Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Geheimer Schlüssel wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Geheimen Schlüssel en_tpacken"
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Gesamtes Zertifikat in einem PKCS#12-Paket exportieren"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Signaturanfrage exportieren - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,7 +254,7 @@ msgstr ""
 "Bitte wählen Sie den Teil der gespeicherten Siganturanfrage aus, den Sie "
 "exportieren wollen:"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -262,77 +262,77 @@ msgstr ""
 "<i>Signaturanfrage für Zertifikat in eine öffentliche Datei im PEM-Format "
 "exportieren.</i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 msgstr[1] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Zertifikat wurde widerrufen.\n"
 msgstr[1] "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -343,12 +343,12 @@ msgstr[1] ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -358,29 +358,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -391,17 +391,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr "Zertifizierungsstellen-Passwort ändern - gnoMint"
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -409,101 +409,101 @@ msgstr ""
 "Das von Ihnen eingegebene Passwort stimmt nicht mit dem derzeit für die "
 "Datenbank geltenden Passwort überein."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ändern des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ermitteln des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr "Passwort wurde erfolgreich ermittelt"
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Löschen des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "Passwort wurde erfolgreich gelöscht"
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Diffie-Hellman-Parameter speichern"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-Parameter wurden erfolgreich gespeichert"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "PEM-Datei zum Importieren auswählen"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problem beim Importieren der Datei »%s«"
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr "Ordner zum Importieren auswählen"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 "Aktuelle Datei schließen und eine neue Datenbank mit dem angegebenen "
 "Dateinamen anlegen"
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr ""
 "Aktuelle Datei schließen und eine Datei mit dem angegebenen Namen öffnen"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Die aktuelle Datei unter einem anderen Namen speichern"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 "Aktuellen Status ermitteln (geöffnete Datei, Anzahl der Zertifikate usw.)"
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
@@ -512,30 +512,30 @@ msgstr ""
 "die widerrufenen Zertifikate auf"
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
@@ -544,191 +544,239 @@ msgstr ""
 "entpacken und in die angegebene Datei speichern"
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr "Das Zertifikat mit der angegebenen internen Kennung widerrufen"
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Passwort für die aktuelle Datenbank ändern"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr ""
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Eigenschaften des angegebenen Zertifikats anzeigen"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr "Eigenschaften der angegebenen Signaturanfrage anzeigen"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr "Programmeinstellungen anzeigen"
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr "Die gewählte Programmeinstellung festlegen"
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "Zertifikat exportieren"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Info-Meldung anzeigen"
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Versionsinformation anzeigen"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "(Diese) Hilfemeldung anzeigen"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Datenbank schließen und Programm beenden"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Datenbank »%s« wird geöffnet …"
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Fehler.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -743,14 +791,14 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -759,12 +807,12 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Nicht übereinstimmende Anführungszeichen\n"
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -772,303 +820,319 @@ msgstr ""
 "Ungültiger Befehl. Geben Sie »help« ein, um eine Liste der möglichen Befehle "
 "zu erhalten.\n"
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Falsche Anzahl der Parameter.\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Syntax: %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "Die Datei existiert bereits und wird überschrieben werden."
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr "Problem beim Öffnen  der neuen Zertifizierungsstellen-Datenbank »%s«\n"
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "Datei »%s« wurde geöffnet\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr "Problem beim Öffnen der Zertifizierungsstellen-Datenbank »%s«\n"
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "Gegenwärtig geöffnete Datei: %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Anzahl der Zertifikate in Datei: %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr "Anzahl der Siganturanfragen in Datei: %d\n"
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Zertifikate in Datenbank:\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr "Zertifikatanfragen in Datenbank:\n"
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr "Die angegebene Kennung der Zertifizierungsstelle ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr "Land eingeben (C)"
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr "Bundesland oder Kanton eingeben (ST)"
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr "Ort oder Stadt eingeben (L)"
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr "Organisation eingeben (O)"
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr "Organisationseinheit eingeben (OU)"
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#, fuzzy
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Typ des zu erzeugenden Schlüssels eingeben (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 "Bitlänge des Schlüssels eingeben (muss ein ganzzahliges Vielfaches von 1024 "
 "sein)"
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr "Schlüsselpaar\n"
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tTyp: %s\n"
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tBitlänge des Schlüssels: %d\n"
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Wollen Sie noch etwas ändern? Ja/[Nein] "
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Sie sind dabei, eine Signaturanfrage für ein Zertifikat mit den folgenden "
 "Parametern zu erstellen."
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr "Sind Sie sicher? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Vorgang wurde abgebrochen.\n"
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1076,218 +1140,218 @@ msgstr ""
 "Geben Sie die Anzahl der Monate bis zum Ablauf der neuen "
 "Zertifizierungsstelle an"
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Dies sind die Eigenschaften der neuen Zertifizierungsstelle:\n"
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr "Gültigkeit\n"
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr "Gültigkeit:\n"
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tAktiviert am: %s\n"
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tLäuft ab am: %s\n"
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Sie sind dabei, eine neue Zertfizierungsstelle mit den folgenden "
 "Eigenschaften zu erstellen:"
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr "Die angegebene Zertifikatkennung ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Geheimer Schlüssel wurde erfolgreich in Datei »%s« entpackt\n"
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr "Die angegebene Kennung der Siganturanfrage ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr "Dieses Zertifikat wird widerrufen werden."
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Zertifikat benutzt:\n"
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Zertifikatzwecke:\n"
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1295,197 +1359,197 @@ msgstr ""
 "Geben Sie die Anzahl der Monate bis zum Ablauf des neuen Zertifikats ein (0 "
 "für abbrechen)"
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 "Wollen Sie irgeneine Eigenschaft des neuen Zertifikats ändern? Ja/[Nein] "
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:963
+#: ../src/ca-cli-callbacks.c:1041
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967
+#: ../src/ca-cli-callbacks.c:1045
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:968
+#: ../src/ca-cli-callbacks.c:1046
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:972
+#: ../src/ca-cli-callbacks.c:1050
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:974
+#: ../src/ca-cli-callbacks.c:1052
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "Wollen Sie das Signieren fortsetzen? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:988
+#: ../src/ca-cli-callbacks.c:1066
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Zertifikat wurde signiert.\n"
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This Certificate Signing Request will be deleted."
 msgstr "Diese Signaturanfrage für ein Zertifikat wird gelöscht werden."
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 "Dieser Vorgang kann nicht rückgängig gemacht werden. Sind Sie sicher? Ja/"
 "[Nein] "
 
-#: ../src/ca-cli-callbacks.c:1016
+#: ../src/ca-cli-callbacks.c:1094
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Signaturanfrage wurde gelöscht.\n"
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1119
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Diffie-Hellman-Parameter wurden erstellt und erfolgreich in Datei »%s« "
 "gespeichert.\n"
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr "Gegenwärtig ist die Datenbank nicht durch ein Passwort geschützt."
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "Wollen Sie sie durch ein Passwort schützen? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1496,37 +1560,37 @@ msgstr ""
 "diese benutzen können. Dieses Passwort wird jedesmal abgefragt,\n"
 "wenn gnoMint einen geheimen Schlüssel in der Datenbank benutzen will."
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr "Passwort eingeben:"
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr "Passwort eingeben (Bestätigung):"
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr "Die eingegebenen Passwörter sind unterschiedlich."
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Passwort wurde erfolgreich festgelegt.\n"
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr "Gegenwärtig IST die Datenbank durchein Passwort geschützt."
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "Wollen Sie diesen Passwortschutz entfernen? Ja/[Nein] "
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1535,13 +1599,13 @@ msgstr ""
 "Zum Entfernen des Passwortschutzes muss das aktuelle Passwort\n"
 "der Datenbank eingegeben werden.\n"
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Bitte geben Sie das aktuelle Passwort der Datenbank ein (leer lassen, um "
 "abzubrechen): "
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1549,7 +1613,7 @@ msgstr ""
 "Das aktuell eingebene Passwort stimmt nicht mit dem\n"
 "aktuellen Passwort der Datenbank überein."
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1557,12 +1621,12 @@ msgstr ""
 "Fehler beim Entfernen des Datenbank-Passworts. \n"
 "Vorgang wurde abgebrochen."
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Passwort wurde erfolgreich entfernt.\n"
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
@@ -1570,7 +1634,7 @@ msgstr ""
 "Sie müssen das aktuelle Datenbank-Passwort eingeben, bevor das Passwort "
 "geändert werden kann.\n"
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1578,15 +1642,15 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr "Neues Passwort eingeben:"
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr "Neues Passwort eingeben (Bestätigung):"
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1594,254 +1658,254 @@ msgstr ""
 "Fehler beim Ändern des Datenbank-Passworts. \n"
 "Vorgang wurde abgebrochen."
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Passwort wurde erfolgreich geändert.\n"
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr "Problem beim Importieren der angegebenen Datei."
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Datei wurde erfolgreich importiert.\n"
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Ordner wurde erfolgreich importiert.\n"
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr "Zertifikat:\n"
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tSeriennummer: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr "Nichts."
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tEindeutige Kennung: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Fingerabdrücke:\n"
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tSHA1-Fingerabdruck: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tMD5-Fingerabdruck: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tSHA1-Fingerabdruck: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Signaturanfrage für Zertifikat:\n"
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr "Sind Sie sicher? Ja/[Nein] : "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr "Id.\tName\t\t\tWert\n"
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr "0\tUnterstützung für Gnome-Schlüsselbund\t%d\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr "Die angegebene Einstellungskennung ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -1850,7 +1914,7 @@ msgstr ""
 "%s Version %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1863,7 +1927,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1873,7 +1937,7 @@ msgstr ""
 "  Mario Blättermann https://launchpad.net/~mariobl-freenet\n"
 "  Michael Honsel https://launchpad.net/~lesnoh"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
@@ -1882,7 +1946,7 @@ msgstr ""
 "Übersetzer:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1900,7 +1964,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1917,101 +1981,167 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s-Version %s\n"
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr "Verfügbare Befehle:\n"
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "Die angegebene Kennung der Zertifizierungsstelle ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Fehler beim Setzen der Version des Zertifikats"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "web server"
 msgstr "TLS-Webserver"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "email server"
 msgstr "TLS-Webserver"
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Schlüsselerzeugung ist fehlgeschlagen"
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Erzeugung der Signaturanfrage ist fehlgeschlagen"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Fehler beim Signieren des Zertifikats"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Zertifikat benutzt:\n"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy
 msgid "Web Server"
 msgstr "TLS-Webserver"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#, fuzzy
+msgid "The given certificate id is not valid"
+msgstr "Die angegebene Zertifikatkennung ist ungültig"
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+#, fuzzy
+msgid "Renew? [Yes]/No "
+msgstr "Sind Sie sicher? [Ja]/Nein "
+
+#: ../src/ca-cli-callbacks.c:1925
+#, fuzzy
+msgid "Certificate renewed. New certificate id: %"
+msgstr "Erzeugung des Zertifikats ist fehlgeschlagen"
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Initialisierung ist fehlgeschlagen: %s\n"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Zertifikat wurde widerrufen.\n"
+msgstr[1] "Zertifikat wurde widerrufen.\n"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -133,52 +133,52 @@ msgstr "Gestiona autoridades de certificación y certificados X.509"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificados</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Nº serie"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Activación"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Caducidad"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Revocación"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -187,71 +187,71 @@ msgid_plural ""
 "<b>%d certificates</b> expire in the next %d days. Right-click each one to "
 "renew with a fresh key."
 msgstr[0] ""
-"<b>%d certificado</b> caduca en los próximos %d días. Haga clic con el "
-"botón derecho sobre él para renovarlo con una clave nueva."
+"<b>%d certificado</b> caduca en los próximos %d días. Haga clic con el botón "
+"derecho sobre él para renovarlo con una clave nueva."
 msgstr[1] ""
 "<b>%d certificados</b> caducan en los próximos %d días. Haga clic con el "
 "botón derecho sobre cada uno para renovarlo con una clave nueva."
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Exportar certificado"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 #, fuzzy
 msgid "_Cancel"
 msgstr "Francia"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Exportar solicitud de certificación"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Ocurrió un error al exportar el certificado"
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr "Ocurrió un error al exportar la solicitud de certificación."
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Certificado exportado con éxito"
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr "Solicitud de certificación exportada correctamente"
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr "Exportar clave privada cifrada."
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Clave privada exportada con éxito"
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportar clave privada sin cifrar."
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportar todo el certificado en un paquete PKCS#12"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Exportar solicitud de certificación - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -259,7 +259,7 @@ msgstr ""
 "Seleccione qué parte almacenada de la solicitud de certificación desea "
 "exportar:"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -267,7 +267,7 @@ msgstr ""
 "<i>Exporta la solicitud de certificación a un fichero público en formato "
 "PEM</i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -277,43 +277,43 @@ msgstr ""
 "clave. Este fichero sólo debería ser accesible para el titular de la "
 "soliticud de certificación.</i>"
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 msgid "Please select a certificate to export its chain."
 msgstr "Por favor, seleccione un certificado para exportar su cadena."
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 msgid "Export certificate chain"
 msgstr "Exportar cadena de certificados"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr "No se pudo construir la cadena de certificados."
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr "Error al escribir la cadena: %s"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 msgid "Certificate chain exported successfully."
 msgstr "Cadena de certificados exportada con éxito."
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 msgid "Please select one or more certificates to revoke."
 msgstr "Por favor, seleccione uno o más certificados para revocar."
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "¿Está seguro de que desea revocar este certificado?"
 msgstr[1] "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 #, fuzzy
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
@@ -324,35 +324,35 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr "La revocación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificado revocado.\n"
 msgstr[1] "Certificado revocado.\n"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr "Por favor, seleccione una o más solicitudes para eliminar."
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 msgstr[1] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr "La eliminación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -368,7 +368,7 @@ msgstr ""
 "El certificado antiguo permanecerá en la base de datos — revóquelo "
 "manualmente cuando haya desplegado el nuevo."
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
@@ -376,11 +376,11 @@ msgstr ""
 "Certificado renovado. Se ha añadido un nuevo certificado con un par de "
 "claves nuevo a la base de datos, junto al original."
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -390,11 +390,11 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado de AC?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -412,15 +412,15 @@ msgstr ""
 "certificados generados con él, por lo que todos deberían regenerarse con un "
 "nuevo certificado de AC."
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr "Cambiando contraseña de AC - gnoMint"
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -428,99 +428,99 @@ msgstr ""
 "La contraseña actual que ha introducido no coincide con la contraseña real "
 "de la base de datos."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. Se canceló la "
 "operación."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al establecer la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr "Contraseña establecida con éxito"
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "Contraseña eliminada con éxito"
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Guardar parámetros Diffie-Hellman"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parámetros Diffie-Hellman guardados correctamente"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "Seleccione fichero PEM a importar"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Hubo problemas al importar el fichero '%s'"
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr "Seleccione directorio a importar"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr "newdb <nombre de fichero>"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 "Cierra el fichero actual y crea una nueva base de datos con el nombre de "
 "fichero indicado"
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr "opendb <nombre de fichero>"
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr "Cierra el fichero actual y abre el fichero con el nombre indicado"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr "savedbas <nombre de fichero>"
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Guarda el fichero actual con un nombre de fichero distinto"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr "Obtiene el estado actual (fichero abierto, nº de certificados, etc...)"
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
@@ -529,32 +529,32 @@ msgstr ""
 "lista también los certificados revocados."
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr "Lista las solicitudes de certificación existentes en la base de datos"
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr "add-csr [id-de-CA-para-heredar-campos]"
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr "Comienza un nuevo proceso de creación de solicitud de certificación"
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 "Iniciar un nuevo proceso de creación de Autoridad de Certificación auto-"
 "firmada"
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr "extractcertpkey <id. de certificado> <nombre de fichero>"
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
@@ -563,11 +563,11 @@ msgstr ""
 "almacenarla en el fichero indicado"
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr "extractcsrpkey <id. de csr> <nombre de fichero>"
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
@@ -576,186 +576,241 @@ msgstr ""
 "fichero proporcionado"
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr "revoke <id de certificado>"
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr "Revocar el certificado con identificador proporcionado"
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr "sign <csr-id> <ca-cert-id>"
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr "Generar certificado firmando el CSR indicado con la AC proporcionada"
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr "delete <id. de csr>"
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr "Borrar solicitud de certificación indicada de la base de datos"
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr "crlgen <id. de ca> <nombre de fichero>"
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 "Generar un nuevo CRL para la AC indicada, almacenándolo en el fichero "
 "<nombre de fichero>"
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr "dhgen <longitud en bits del nº primo><nombre de fichero>"
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 "Generar un nuevo conjunto de parámetros DH, almacenándolo en el fichero "
 "<nombre de fichero>"
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Cambiar contraseña de la base de datos actual"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr "importfile <nombre de fichero>"
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr "Importar fichero con el nombre indicado"
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr "importdir <nombre de directorio>"
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 "Importar el directorio proporcionado, interpretándolo como el directorio de "
 "una AC realizada con OpenSSL"
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr "showcert <id de certificado>"
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Mostrar propiedades del certificado indicado"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr "showcsr <id de solicitud de certificación>"
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr "Mostrar propiedades del CSR proporcionado"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr "showpolicy <id de certificado de AC>"
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr "Mostrar política de la AC"
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr "setpolicy <id de certificado de AC> <id de política> <valor>"
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr "Cambiar política indicada de la AC"
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr "Mostrar preferencias de programa"
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr "setpreference <id de preferencia> <valor>"
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr "Establece la preferencia de programa indicada"
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+#, fuzzy
+msgid "renewcert <cert-id>"
+msgstr "showcert <id de certificado>"
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <id. de certificado> <nombre de fichero>"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+#, fuzzy
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr "revoke <id de certificado>"
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+#, fuzzy
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr "delete <id. de csr>"
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Mostrar mensaje de \"Acerca de...\""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr "Mostrar información de garantía"
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr "Mostrar información sobre la distribución del programa"
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Mostrar información de versión"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "Mostrar (este) mensaje de ayuda"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Cerrar base de datos y salir de programa"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Abriendo base de datos %s..."
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " Correcto.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Error.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, fuzzy, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+"<b>%d certificado</b> caduca en los próximos %d días. Haga clic con el botón "
+"derecho sobre él para renovarlo con una clave nueva."
+msgstr[1] ""
+"<b>%d certificados</b> caducan en los próximos %d días. Haga clic con el "
+"botón derecho sobre cada uno para renovarlo con una clave nueva."
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -770,7 +825,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -779,7 +834,7 @@ msgstr ""
 "Este programa se proporciona SIN GARANTÍAS DE NINGÚN TIPO; para más\n"
 "detalles, teclee 'warranty'.\n"
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -791,12 +846,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Comillas desemparejadas\n"
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -804,184 +859,184 @@ msgstr ""
 "Orden no válida. Teclee 'help' para conseguir una lista de órdenes\n"
 "reconocidas.\n"
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Número incorrecto de parámetros.\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Sintaxis: %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "El fichero ya existe, por lo que se sobreescribirá"
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr "¿Está seguro? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr "Hubo problemas al abrir la nueva base de datos de la AC '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "Fichero '%s' abierto\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr "Hubo problemas al abrir la base de datos de la AC '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "Fichero abierto actualmente: %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Número de certificados en fichero: %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr "Número de CSRs en fichero: %d\n"
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr "%s\t"
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr "Sí\t"
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr "No\t"
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr "%s\t"
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr "\t"
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr "\t"
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr "Sí\t\t"
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr "No\t\t"
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr " \t"
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr "%s\t"
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr "\t"
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr "%s\t"
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr " \n"
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr "%s\n"
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Certificados en base de datos:\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 "Id.\t¿Es CA?\tTitular de certificado\t¿Clave en BD?\tActivación\t\tCaducidad"
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr "\t\tRevocación\n"
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr "%s\t"
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr "%s\t"
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr " \t"
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr "%-24s\t"
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr " \t"
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr " \t"
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr "Sí\n"
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr "No\n"
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr "Solicitudes de certificación en base de datos:\n"
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr "Id.\tId. padre\tTitular CSR\t\t¿Clave en BD?\n"
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr "El identificador de CA proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
@@ -990,111 +1045,127 @@ msgstr ""
 "Por favor: introduzca los datos correspondientes al titular de la solicitud "
 "de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr "Introduzca país (C)"
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr "Introduzca nombre de estado o provincia (ST)"
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr "Introduzca ciudad o localidad (L)"
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr "Introduzca organización (O)"
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr "Introduzca Unidad organizativa (OU)"
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr "Introduzca Nombre común (CN)"
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr "Introduzca dirección de correo (deje vacío para ninguna)"
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#, fuzzy
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Introduzca el tipo de clave que se va a crear (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Introduzca tamaño de clave en bits (múltiplo de 1024)"
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr "Estas son las propiedades proporcionadas del CSR:\n"
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr "Titular:\n"
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tNombre distintivo: "
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, fuzzy, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr "Nombre alternativo de titular"
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr "Par de claves\n"
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tTipo: %s\n"
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tLongitud en bits: %d\n"
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "¿Desea cambiar algo? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Se va a proceder a crear una solicitud de certificación con estas "
 "propiedades."
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr "¿Está seguro? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operación cancelada.\n"
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1103,7 +1174,7 @@ msgstr ""
 "Por favor: introduzca los datos correspondientes al titular de la nueva "
 "autoridad de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1111,218 +1182,218 @@ msgstr ""
 "Introduzca el número máximo de meses antes de la caducidad de lanueva "
 "autoridad de certificación"
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Estas son las propiedades proporcionadas para la nueva AC:\n"
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr "Validez\n"
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr "Validez:\n"
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tActivado el: %s\n"
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tCaduca el: %s\n"
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Se va a proceder a crear una nueva autoridad de certificación con "
 "estaspropiedades."
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr "El identificador de certificado proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Clave privada extraída con éxito al fichero '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr "El identificador de CSR proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr "Este certificado será revocado."
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificado revocado.\n"
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Usos del certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Uso como Autoridad de Certificación habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Uso como Autoridad de Certificación deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr "* Uso para firma de CRLs habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr "* Uso para firma de CRLs deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Uso para firma digital habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Uso para firma digital deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "Uso para cifrado de datos habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Uso para cifrado de claves habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Uso para cifrado de claves deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "* Uso para no repudio habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "* Uso para no repudio deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "* Uso para negociación de claves habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "* Uso para negociación de claves deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Finalidades del certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Finalidad para protección de correo electrónico habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Finalidad para protección de correo electrónico deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Finalidad de firma de código habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Finalidad de firma de código deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Finalidad de cliente web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Finalidad de cliente web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Finalidad de servidor web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Finalidad de servidor web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Finalidad de sellado de tiempo habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Finalidad de sellado de tiempo deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "* Finalidad de firma de OCSP habilitada\n"
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "* Finalidad de firma de OCSP deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Cualquier finalidad habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Cualquier finalidad deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr "Se va a proceder a firmar la siguiente solicitud de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr "con el certificado correspondiente a esta AC:\n"
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1330,197 +1401,197 @@ msgstr ""
 "Máximo número de meses antes de la caducidad del nuevo certificado (0 para "
 "cancelar):"
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 "El nuevo certificado se validará para los siguientes usos y finalidades:\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr "¿Desea cambiar alguna propiedad del nuevo certificado? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* ¿Habilitar uso como Autoridad de certificación? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Uso como Autoridad de Certificación deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* ¿Habilitar uso para firma de CRL? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Uso para firmado de CRL deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* ¿Habilitar uso para firma digital? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Uso para firma digital deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "¿Habilitar uso para cifrado de datos? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Uso para cifrado de datos deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "¿Habilitar uso para cifrado de claves? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Uso para cifrado de claves deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr "¿Habilitar uso para no repudio? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr "* Uso para no repudio deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "¿Habilitar uso para negociación de claves? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "Uso para negociación de claves deshabilitado por politica\n"
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de protección de correo electrónico? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 "* Finalidad de protección de correo electrónico deshabilitada por política.\n"
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de firma de código? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Finalidad de firma de código deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de cliente web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Finalidad de cliente web TLS deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de servidor web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Finalidad de servidor web TLS deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de sellado de tiempo? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:963
+#: ../src/ca-cli-callbacks.c:1041
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "* Finalidad de sellado de tiempo deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:967
+#: ../src/ca-cli-callbacks.c:1045
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad para firma de OCSP? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:968
+#: ../src/ca-cli-callbacks.c:1046
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr "* Finalidad para firma de OCSP deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:972
+#: ../src/ca-cli-callbacks.c:1050
 msgid "Enable any purpose? [Yes]/No "
 msgstr "¿Habilitar uso para cualquier finalidad? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:974
+#: ../src/ca-cli-callbacks.c:1052
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr "* Uso para cualquier finalidad deshabilitado por política.\n"
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 "Ya se cuenta con todos los datos necesarios para la generación del "
 "certificado."
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "¿Desea continuar con la firma y generación del certificado? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:988
+#: ../src/ca-cli-callbacks.c:1066
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificado firmado.\n"
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This Certificate Signing Request will be deleted."
 msgstr "Se borrará esta solicitud de certificación."
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr "Esta operación no puede deshacerse. ¿Está seguro? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1016
+#: ../src/ca-cli-callbacks.c:1094
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Solicitud de certificación borrada.\n"
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1119
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "CRL generada con éxito y guardada en fichero '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "La longitud en bits del número primo debe ser múltiplo entero de 1024"
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Parámetros Diffie-Hellman creados y guardados correctamente en fichero '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr "En estos momentos, la base de datos no está protegida con clave."
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "¿Desea protegerlo con contraseña? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1531,37 +1602,37 @@ msgstr ""
 "hacer uso de ellas. Esta contraseña será solicitada siempre que gnoMint\n"
 "requiera emplear cualquier clave privada de la base de datos."
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr "Introduzca contraseña:"
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr "Introduzca contraseña (confirmación):"
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr "Las contraseñas introducidas son distintas."
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Contraseña establecida con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr "No se ha hecho nada.\n"
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr "En estos momentos, la base de datos ESTÁ protegida con contraseña."
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "¿Desea eliminar esta protección con contraseña? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1570,12 +1641,12 @@ msgstr ""
 "Para eliminar la protección mediante clave, debe proporcionar la \n"
 "contraseña actual.\n"
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Introduzca la contrase_ña actual de la base de datos (Vacía para cancelar): "
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1583,7 +1654,7 @@ msgstr ""
 "La contraseña actual que ha introducido\n"
 "no coincide con la contraseña real de la base de datos."
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1591,12 +1662,12 @@ msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de \n"
 "datos. Se canceló la operación."
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Contraseña eliminada con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
@@ -1604,7 +1675,7 @@ msgstr ""
 "Debe proporcionar la contraseña actual de la base de datos antes de "
 "cambiarla.\n"
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1617,15 +1688,15 @@ msgstr ""
 "solicitada siempre que gnoMint vaya a hacer uso de cualquier\n"
 "clave privada de la base de datos."
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr "Introduzca la nueva contraseña:"
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr "Introduzca contraseña (confirmación):"
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1633,237 +1704,237 @@ msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. \n"
 "Se canceló la operación."
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Contraseña cambiada con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr "Hubo problemas al importar el fichero indicado."
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Fichero importado con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Directorio importado con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr "Certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tNº de serie: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr "\tNombre distintivo: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr "Ninguno."
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tIdentificador único: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr "Emisor:\n"
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Huellas digitales:\n"
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tHuella digital SHA1: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tHuella digital MD5: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tHuella digital SHA256: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Solicitud de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 "Los certificados generados heredan país de la AC                           "
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 "Los certificados generados heredan estado/provincia de la "
 "AC                             "
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 "Los certificados generados heredan localidad o ciudad de la "
 "AC                          "
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 "Los certificados generados heredan Organización de la "
 "AC                      "
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 "Los certificados generados heredan unidad organizacional de la "
 "AC               "
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 "El país de los certificados generados debe coincidir con la AC            "
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 "Estado o provincia de certif. generados debe coincidir con la "
 "AC              "
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 "Localidad o ciudad de certif. generados debe coincidir con la AC           "
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 "Organización de certif. generados debe coincidir con la de la AC       "
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr "Unidad organizativa de certif. debe coincidir con la de la AC"
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Número máximo de horas entre actualizaciones de CRLs                       "
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr "Punto de distribución de CRL (URL donde se publica la CRL)"
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 "Máximo nº de meses antes de caducidad de nuevos certificados           "
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Habilitar uso como AC en certificados "
 "generados                                 "
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Habilitar uso para firma de CRLs en certificados "
 "generados                           "
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Habilitar uso para no repudio en certificados generados                     "
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Habilitar uso para firma digital en certificados generados                  "
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Habilitar uso para cifrado de claves en certificados "
 "generados                   "
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Habilitar uso para negociación de claves en certificados "
 "generados                      "
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Habilitar uso para cifrado de datos en certificados "
 "generados                  "
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Habilitar finalidad de servidor web TLS para certific. "
 "generados                 "
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Habilitar finalidad para cliente web TLS en certific. "
 "generados                 "
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 "Habilitar finalidad para sellado de tiempo en certific. "
 "generados                  "
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 "Habilitar finalidad de firma de código en certificados generados            "
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 "Habilitar finalidad para protección de correo-e en cert. "
 "generados               "
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 "Habilitar finalidad de firma de OCSP en certificados "
 "generados                   "
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 "Habilitar cualquier finalidad en certificados "
 "generados                            "
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Mostrando políticas del siguiente certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
@@ -1872,16 +1943,16 @@ msgstr ""
 "\n"
 "Políticas:\n"
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr "Id.\tDescripción\t\t\t\t\t\t\t\tValor\n"
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr "El identificador de política proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
@@ -1890,35 +1961,35 @@ msgstr ""
 "Se va a asignar a la política\n"
 "'%s' el nuevo valor '%s'."
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr "¿Está seguro? Sí/[No] : "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr "Política establecida correctamente a '%s'.\n"
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr "Preferencias actuales de gnoMint-cli:\n"
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr "Id.\tNombre\t\t\tValor\n"
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr "0\tSoporte de gnome-keyring\t%d\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr "El identificador de preferencia proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
@@ -1926,7 +1997,7 @@ msgid ""
 msgstr ""
 "Va a asignar a la preferencia 'Soporte de gnome-keyring' el nuevo valor '%d'."
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -1935,7 +2006,7 @@ msgstr ""
 "%s versión %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1948,7 +2019,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1960,7 +2031,7 @@ msgstr ""
 "  Sergio Oller https://launchpad.net/~zeehio\n"
 "  Victor Herrero https://launchpad.net/~victorhera"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
@@ -1969,7 +2040,7 @@ msgstr ""
 "Traductores:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2004,7 +2075,7 @@ msgstr ""
 "<http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2035,98 +2106,173 @@ msgstr ""
 "con este programa; si no es así, visite <http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s versión %s\n"
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr "Órdenes disponibles:\n"
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr "====================\n"
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr "Saliendo de gnomint-cli...\n"
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "El identificador de CA proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr "El tipo de certificado debe ser 'web' o 'email'"
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr "El nombre del servidor no puede estar vacío"
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Creando certificado raíz de la AC"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr "servidor web"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr "servidor de correo"
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Error en generación de claves"
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Error en generación de solicitud"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "Fallo al inicializar: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Error al firmar certificado"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificado exportado con éxito"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Usos del certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr "Servidor Web"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr "Servidor de correo"
+
+#: ../src/ca-cli-callbacks.c:1902
+#, fuzzy
+msgid "Usage: renewcert <cert-id>"
+msgstr "showcert <id de certificado>"
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#, fuzzy
+msgid "The given certificate id is not valid"
+msgstr "El identificador de certificado proporcionado no es válido"
+
+#: ../src/ca-cli-callbacks.c:1911
+#, fuzzy
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+"<b>¿Renovar este certificado?</b>\n"
+"\n"
+"gnoMint emitirá un nuevo certificado con el mismo asunto y SAN que el "
+"seleccionado, firmado por la misma AC, con un par de claves recién generado. "
+"El certificado antiguo permanecerá en la base de datos — revóquelo "
+"manualmente cuando haya desplegado el nuevo."
+
+#: ../src/ca-cli-callbacks.c:1914
+#, fuzzy
+msgid "Renew? [Yes]/No "
+msgstr "¿Está seguro? [Sí]/No "
+
+#: ../src/ca-cli-callbacks.c:1925
+#, fuzzy
+msgid "Certificate renewed. New certificate id: %"
+msgstr "Error en generación del certificado"
+
+#: ../src/ca-cli-callbacks.c:1933
+#, fuzzy
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <id. de certificado> <nombre de fichero>"
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Error al escribir la cadena: %s"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Certificado revocado.\n"
+msgstr[1] "Certificado revocado.\n"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -128,52 +128,52 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -184,155 +184,155 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Peruttujen varmenteiden näkyvyys"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Varmennuspyyntöjen näkyvyys"
 msgstr[1] "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -342,28 +342,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -374,326 +374,373 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr ""
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr ""
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr ""
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr ""
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr ""
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr ""
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr ""
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid "exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -703,14 +750,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -719,787 +766,802 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:963
-#, c-format
-msgid "* Time Stamping purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:967
-msgid "Enable OCSP Signing purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:968
-#, c-format
-msgid "* OCSP Signing purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:972
-msgid "Enable any purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:974
-#, c-format
-msgid "* Any purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid ""
-"All the mandatory data for the certificate generation has been gathered."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid "Do you want to proceed with the signing? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:988
-#, c-format
-msgid "Certificate signed.\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This Certificate Signing Request will be deleted."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This operation cannot be undone. Are you sure? Yes/[No] "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1016
-#, c-format
-msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:1041
 #, c-format
+msgid "* Time Stamping purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1045
+msgid "Enable OCSP Signing purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1046
+#, c-format
+msgid "* OCSP Signing purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1050
+msgid "Enable any purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1052
+#, c-format
+msgid "* Any purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid ""
+"All the mandatory data for the certificate generation has been gathered."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid "Do you want to proceed with the signing? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1066
+#, c-format
+msgid "Certificate signed.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This Certificate Signing Request will be deleted."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This operation cannot be undone. Are you sure? Yes/[No] "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1094
+#, c-format
+msgid "Certificate Signing Request deleted.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1119
+#, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1507,275 +1569,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1784,21 +1846,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Ilkka Tuohela https://launchpad.net/~hile"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1816,7 +1878,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1833,97 +1895,160 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, c-format
 msgid "Certificate type: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+msgid "The given certificate id is not valid"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+msgid "Renew? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1925
+msgid "Certificate renewed. New certificate id: %"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Virhe allekirjoitettaessa varmennetta"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Varmennuspyyntöjen näkyvyys"
+msgstr[1] "Varmennuspyyntöjen näkyvyys"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -132,53 +132,53 @@ msgstr "Gérer des certificats et des CA X.509, facilement et graphiquement"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Numéro"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Activation"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Expiration"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Révocation"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +189,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Exporter une CSR"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Erreur pendant l'exportation du certificat."
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr "Erreur pendant l'exportation de la Requête de Signature de Certificat."
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr "CSR exporté avec succès."
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr "Exporter la clé privée chiffrée"
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Clé privée exportée avec succès"
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporter la clé privée non chiffrée"
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporter l'intégralité du certificat vers un paquet au format PKCS#12"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Exportation de Requête de Signature de Certificat - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,13 +254,13 @@ msgstr ""
 "Veuillez choisir la partie de la Requête de Signature de Certificat "
 "sauvegardée que vous souhaitez exporter :"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr "<i>Exporter la CSR vers un fichier public, au format PEM.</i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -270,71 +270,71 @@ msgstr ""
 "passe, au format PKCS#8. Ce fichier ne devrait être accessible que par le "
 "titulaire de la CSR.</i>"
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Certificat Racine de l'Autorité de Certification"
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 msgstr[1] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat révoqué.\n"
 msgstr[1] "Certificat révoqué.\n"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -343,12 +343,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -358,29 +358,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -391,16 +391,16 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr "Modifier le mot de passe de l'Autorité de Certification - gnoMint"
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -408,331 +408,382 @@ msgstr ""
 "Le mot de passe que vous venez d'entrer ne correspond pas au mot de passe "
 "actuel de la base de données."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant l'affectationdu mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr "Mot de passe mis en place avec succès."
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "Mot de passe supprimé avec succès."
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Sauvegarder les paramètres Diffie-Hellman"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Les paramètres Diffie-Hellman ont été sauvegardés avec succès"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "Choisir le fichier PEM à importer"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problème pendant l'importation du fichier '%s'"
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr "Sélectionner le répertoire à importer"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr "newdb <nom de fichier>"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 "Fermer le fichier et créer une nouvelle base de donnée avec le nom de "
 "fichier spécifié"
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr "opendb <nom de fichier>"
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr "Fermer le fichier et ouvrir le fichier avec le nom de fichier spécifié"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr "savedbas <nom de fichier>"
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Sauvegarder le fichier actuel avec un nom différent"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 "Lister les Requêtes de Signature de Certificats dans la base de données"
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 "addcsr [identifiant d'Autorité de Certification pour hériter de champs]"
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr "extractcertpkey <identifiant de certificat> <nom de fichier>"
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 "extractcsrpkey <identifiant de Requête de Signature de Certificat> <nom de "
 "fichier>"
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr "revoke <identifiant de Certificat>"
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr ""
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 "sign <identifiant de Requête de Signature de Certificat> <identifiant de "
 "Certificat d'Autorité de Certification>"
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr "delete <identifiant de Requête de Signature de Certificat>"
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr "dhgen <taille en bits du nombre premier> <nom de fichier>"
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 "Générer un nouveau jeu de paramètres DH, et le sauvegarder dans le fichier "
 "<nom de fichier>"
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Modifier le mot de passe de la base de données actuelle"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr "importfile <nom de fichier>"
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr "Importer le fichier nommé <nom de fichier>"
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr "importdir <nom de répertoire>"
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr "showcert <identifiant de Certificat>"
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Afficher les propriétés d'un certificat donné"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr "showcsr <identifiant de Requête de Signature de Certificat>"
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 "Afficher les propriétés d'une Requête de Signature de Certificat donnée"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr "showpolicy <identifiant d'Autorité de Certification>"
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr "Afficher la stratégie de l'Autorité de Certification"
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 "setpolicy <identifant d'Autorité de Certification> <identifiant de "
 "Stratégie> <valeur>"
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr ""
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr "setpreference <identifiant de Préférence> <valeur>"
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+#, fuzzy
+msgid "renewcert <cert-id>"
+msgstr "showcert <identifiant de Certificat>"
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <identifiant de certificat> <nom de fichier>"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+#, fuzzy
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr "revoke <identifiant de Certificat>"
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+#, fuzzy
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr "delete <identifiant de Requête de Signature de Certificat>"
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Afficher le message « À propos »"
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr "Afficher les informations de garantie"
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr "Afficher les informations de distribution"
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Afficher les informations de version"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "Afficher ce message d'aide"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Fermer la base de données et quitter le programme"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Ouverture de la base de données %s..."
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Erreur.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -747,14 +798,14 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -763,313 +814,329 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Guillemet manquant\n"
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Nombre de paramètres incorrect.\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Syntaxe : %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "Le fichier existe déjà, il va être remplacé."
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr "Êtes-vous sûr ? Oui/[Non] "
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "Fichier '%s' ouvert\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "Fichier actuellement ouvert : %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Nombre de certificats dans le fichier : %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Certificats dans la base de données :\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr "\t\tRévocation\n"
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr "CsrList ID|%s\t"
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr "CsrList ParentID|%s\t"
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr "CsrList ParentID|\t"
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr "CsrList Subject|%-24s\t"
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr "CsrList PadIfSubject<16|\t"
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr "CsrList PadIfSubject<8|\t"
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr "CsrList PKeyInDB|Y\n"
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr "CsrList PKeyInDB|N\n"
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr "Titulaire de la Requête de Signature de Certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr "Entrez la pays (C)"
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr "Entrez l'état ou la province (ST)"
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr "Entrez la localité ou la ville (L)"
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr "Entrez l'organisation (O)"
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr "Entrez l'unité d'organisation (OU)"
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr "Entrez le nom commun (CN)"
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#, fuzzy
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Entrez le type de clé que vous allez créer (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Entrez la taille en bits de la clé (ce doit être un multiple de 1024)"
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 "Voici les propriétés de la Requête de Signature de Certificat fournie :\n"
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr "Titulaire\n"
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tNom distinct : "
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, fuzzy, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr "Nom alternatif du titulaire"
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr "Paire de clés\n"
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tType : %s\n"
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tTaille en bits de la clé : %d\n"
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Souhaitez vous modifier quelque chose ? Oui/[Non] "
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Vous êtes sur le point de créer une Requête de Signature de Certificat avec "
 "ces propriétés :"
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr "Êtes-vous sur ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Opération annulée.\n"
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr "Titulaire de la nouvelle Autorité de Certification :\n"
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1077,224 +1144,224 @@ msgstr ""
 "Entrez le nombre de mois avant l'expiration de la nouvelle Autorité de "
 "Certification"
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 "Voici les propriétés de la nouvelle Autorité de Certification fournie :\n"
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr "Validité\n"
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr "Validité :\n"
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tActivé le : %s\n"
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tExpire le : %s\n"
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Vous êtes sur le point de créer une nouvelle Autorité de Certification avec "
 "ces propriétés."
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr "L'identifiant de certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Clé privée extraite avec succès dans le fichier '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 "L'identifiant de Requête de Signature de Certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr "Ce certificat sera révoqué."
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificat révoqué.\n"
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Utilisations du certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Utilisable pour une Autorité de Certification.\n"
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Inutilisable pour une Autorité de Certification.\n"
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 "* Utilisable pour la signature de Liste de Révocation de Certificats.\n"
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 "* Inutilisable pour la signature de Liste de Révocation de Certificats.\n"
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Utilisable pour la signature numérique.\n"
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Inutilisable pour la signature numérique.\n"
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "* Utilisable pour le chiffrement de données.\n"
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Utilisable pour le chiffrement de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Inutilisable pour le chiffrement de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "* Utilisable pour la non-répudiation.\n"
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "* Inutilisable pour la non-répudiation.\n"
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "* Utilisable pour l'agrément de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "* Inutilisable pour l'agrément de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Applications du certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Applicable à la protection de courriel.\n"
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Inapplicable à la protection de courriel.\n"
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Applicable à la signature de code.\n"
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Inapplicable à la signature de code.\n"
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Applicable aux clients Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Inapplicable aux clients Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Applicable aux serveurs Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Inapplicable aux serveurs Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Applicable à l'horodatage.\n"
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Inapplicable à l'horodatage.\n"
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "* Applicable à la signature OCSP.\n"
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "* Inapplicable à la signature OCSP.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Applicable à tout.\n"
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Applicable à rien.\n"
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 "Vous êtes sur le point de signer la Requête de Signature de Certificat "
 "suivante :\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1302,7 +1369,7 @@ msgstr ""
 "Donner le nombre de mois avant l'expiration du nouveau certificat (0 pour "
 "annuler)"
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
@@ -1310,249 +1377,249 @@ msgstr ""
 "Le nouveau certificat sera créé avec les utilisations et applications "
 "suivants :\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 "Souhaitez-vous modifier une propriété du nouveau Certificat ? Yes/[Non] "
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* Utilisable pour une Autorité de Certification ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Inutilisable pour une Autorité de Certification, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 "* Utilisable pour la signature de Liste de Révocation de Certificats ? [Oui]/"
 "Non "
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 "* Inutilisable pour la signature de Liste de Révocation de Certificats, par "
 "stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Utilisable pour la signature numérique ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Inutilisable pour la signature numérique, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Utilisable pour le chiffrement de données ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Inutilisable pour le chiffrement de données, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Utilisable pour le chiffrement de clé ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Inutilisable pour le chiffrement de clé, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr "Utilisable pour la non-répudiation ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr "* Inutilisable pour la non-répudiation, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "Utilisable pour l'agrément de clé ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "* Inutilisable pour l'agrément de clé, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "Applicable à la protection de courriel ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr "* Inapplicable à la protection de courriel, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "Applicable à la signature de code ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Inapplicable à la signature de code, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "Applicable aux clients Web TLS ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Inapplicable aux clients Web TLS, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "Applicable aux serveurs Web TLS ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Inapplicable aux serveurs Web TLS, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "Applicable à l'horodatage ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:963
+#: ../src/ca-cli-callbacks.c:1041
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "* Inapplicable à l'horodatage, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:967
+#: ../src/ca-cli-callbacks.c:1045
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "Applicable à la signature OCSP ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:968
+#: ../src/ca-cli-callbacks.c:1046
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr "* Inapplicable à la signature OCSP, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:972
+#: ../src/ca-cli-callbacks.c:1050
 msgid "Enable any purpose? [Yes]/No "
 msgstr "Applicable à tout ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:974
+#: ../src/ca-cli-callbacks.c:1052
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr "* Applicable à tout, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:988
+#: ../src/ca-cli-callbacks.c:1066
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificat signé.\n"
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1016
+#: ../src/ca-cli-callbacks.c:1094
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1119
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 "La Liste de Révocation de Certificats a été générée avec succès dans le "
 "fichier '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "La taille en bits du nombre premier doit être un multiple de 1024"
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Veuillez entrer le mot de passe actuel de la base de données (ne rien mettre "
 "pour annuler) : "
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1560,18 +1627,18 @@ msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. \n"
 "L'opération a été annulée."
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1579,15 +1646,15 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1595,224 +1662,224 @@ msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. \n"
 "L'opération a été annulée."
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "Empreinte numérique SHA1"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Nombre d'heures maximum entre les mises à jours de Liste de Révocation de "
 "Certificats                       "
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Utilisable pour une Autorité de Certification dans les certificats "
 "générés                                 "
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Utilisable pour la signature de Liste de Révocation de Certificats dans les "
 "certificats générés                           "
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Utilisable pour la non-répudiation dans les certificats "
 "générés                     "
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Utilisable pour la signature numérique dans les certificats "
 "générés                  "
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Utilisable pour le chiffrement de clé dans les certificats "
 "générés                   "
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Utilisable pour l'agrément de clé dans les certificats "
 "générés                      "
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Utilisable pour le chiffrement de données dans les certificats "
 "générés                  "
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Applicable aux serveurs Web TLS dans les certificats générés                 "
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Applicable aux clients Web TLS dans les certificats générés                 "
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 "Application pour l'horodatage activée dans les certificats "
 "générés                  "
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 "Application pour serveur de signature de code activée dans les certificats "
 "générés            "
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 "Application pour protection de courriel activée dans les certificats "
 "générés               "
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 "Application pour la signature OCSP activée dans les certificats "
 "générés                   "
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 "Toute application activée dans les certificats "
 "générés                            "
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Affichage des stratégies du certificat suivant :\n"
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
@@ -1821,16 +1888,16 @@ msgstr ""
 "\n"
 "Stratégies :\n"
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr "Identifiant\tDescription\t\t\t\t\t\t\t\tValeur\n"
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr "L'identifiant de stratégie fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, fuzzy, c-format
 msgid ""
 "You are about to assign to the policy\n"
@@ -1839,35 +1906,35 @@ msgstr ""
 "Vous êtes sur le point d'assigner à la stratégie '%s'\n"
 "la nouvelle valeur '%d' ."
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
@@ -1876,14 +1943,14 @@ msgstr ""
 "Vous êtes sur le point d'assigner la nouvelle valeur '%d' à la préférence "
 "'Prise en charge de gnome-keyring'."
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1892,7 +1959,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1903,14 +1970,14 @@ msgstr ""
 "  gnuckx https://launchpad.net/~gnuckx\n"
 "  loquehumaine https://launchpad.net/~loquehumaine"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1928,7 +1995,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1945,102 +2012,170 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr "Commandes disponibles :\n"
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr ""
 "L'identifiant de Requête de Signature de Certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Création du certificat racine de l'Autorité de Certification"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "web server"
 msgstr "Serveur Web TLS"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "email server"
 msgstr "Serveur Web TLS"
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "La génération de la clé a échoué"
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "La génération de la Requête de Signature de Certificat a échouée"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Erreur pendant la signature du certificat"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Utilisations du certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy
 msgid "Web Server"
 msgstr "Serveur Web TLS"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+#, fuzzy
+msgid "Usage: renewcert <cert-id>"
+msgstr "showcert <identifiant de Certificat>"
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#, fuzzy
+msgid "The given certificate id is not valid"
+msgstr "L'identifiant de certificat fourni est incorrect"
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+#, fuzzy
+msgid "Renew? [Yes]/No "
+msgstr "Êtes-vous sur ? [Oui]/Non "
+
+#: ../src/ca-cli-callbacks.c:1925
+#, fuzzy
+msgid "Certificate renewed. New certificate id: %"
+msgstr "La génération du certificat a échoué"
+
+#: ../src/ca-cli-callbacks.c:1933
+#, fuzzy
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <identifiant de certificat> <nom de fichier>"
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "L'initialisation a échoué : %s\n"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Certificat révoqué.\n"
+msgstr[1] "Certificat révoqué.\n"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -132,52 +132,52 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificati</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Revoca"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -188,64 +188,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Esporta la richiesta di firma di certificato (CSR)"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Errore durante l'esportazione del certificato."
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr "Errore durante l'esportazione del CSR."
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr "Richiesta di firma di certificato (CSR) esportata correttamente"
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr "Esporta la chiave privata criptata"
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Chiave privata esportata correttamente"
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Esporta chiave privata non criptata"
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Esporta l'intero certificato nel pacchetto PKCS#12"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Esporta CSR - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -253,7 +253,7 @@ msgstr ""
 "Si prega di scegliere quale parte della richiesta di firma di certificato "
 "(CSR) salvata si vuole esportare:"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -261,7 +261,7 @@ msgstr ""
 "<i>Esporta la richiesta di firma di certificato (CSR) in un file pubblico, "
 "in formato PEM.</i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -271,70 +271,70 @@ msgstr ""
 "Questo file deve essere accessibile solamente da parte del soggetto della "
 "richiesta di firma di certificato (CSR).</i>"
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Aggiungi un certificato CA autofirmato"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Confermare la revoca di questo certificato?"
 msgstr[1] "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificato revocato.\n"
 msgstr[1] "Certificato revocato.\n"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -345,12 +345,12 @@ msgstr[1] ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -360,29 +360,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -393,17 +393,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -411,138 +411,138 @@ msgstr ""
 "La password attualmente inserita non corrisponde con la reale e corrente "
 "password del database."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la modifica della password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Errore nello stabilire la password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr "Password stabilita correttamente"
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la rimozione della password del database. L'operazione è "
 "stata annullata."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "Password rimossa correttamente"
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Salva i parametri Diffie-Hellman"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parametri Diffie-Hellman salvati correttamente"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "Selezionare il file PEM da importare"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr "Chiudere il file corrente e creare un nuovo database con il nome dato"
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr "Chiudere il file corrente ed aprire il file con il nome dato"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Salvare il file corrente con un nome differente"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr "Iniziare un nuovo processo di creazione CSR"
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
@@ -551,181 +551,229 @@ msgstr ""
 "stabilito"
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr "Revocare il certificato con l'ID interno dato"
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr "Eliminare il CSR dato dal database"
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr "Genera un nuovo CRL per il dato CA, salvandolo nel file <filename>"
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 "Genera un nuovo insieme di parametri DH, salvandolo nel file <filename>"
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Cambiare la password per il database corrente"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr "Importare il file con il nome stabilito <filename>"
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr "Importare la cartella stabilita, come una cartella OpenSSL-CA"
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Visualizza le proprietà del certificato stabilito"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr "Visualizza le proprietà del CSR stabilito"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr "Visualizza le preferenze di programma"
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr "setpreference <preference-id> <value>"
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "Esporta certificato"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Visualizza il messaggio di About"
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr "Visualizza le informazioni di garanzia"
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr "Visualizza le informazioni di distribuzione"
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "Visualizza (questo) messaggio di aiuto"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Chiudi il database ed esci dal programma"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Database %s in apertura..."
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Errore.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -740,7 +788,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -749,7 +797,7 @@ msgstr ""
 "Questo programma viene fornito SENZA ALCUNA GARANZIA;\n"
 "per informazioni digitare 'warranty'.\n"
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -761,12 +809,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -774,294 +822,309 @@ msgstr ""
 "Comando non valido. Digitare 'help' per ottenere una lista dei comandi "
 "riconosciuti.\n"
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Numero di parametri non corretto.\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Sintassi: %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "File già esistente, verrà quindi sovrascritto."
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr "Confermare? Si/[No] "
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr "Si è verificato un problema nell'apertura del nuovo database CA '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "Il file '%s' è stato aperto\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr "Si è verificato un problema nell'apertura del database CA '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "File aperto corrente: %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Numero di certificati nel file: %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr "Numero di CSR nel file: %d\n"
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Certificati nel Database:\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr "Richieste di certificato nel database:\n"
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tLungezza in bit della chiave: %d\n"
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Apportare modifiche? Si/[No] "
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Si è in procinto di creare una richiesta di firma di certificato (CSR) con "
 "queste proprietà."
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr "Confermare? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operazione cancellata.\n"
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1070,7 +1133,7 @@ msgstr ""
 "Si prega di inserire i dati corrispondenti al soggetto della nuova autorità "
 "certificativa:\n"
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1078,482 +1141,482 @@ msgstr ""
 "Introdurre il numero di mesi mancanti alla scadenza della nuova autorità "
 "certificativa"
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Queste sono le proprietà fornite dal nuovo CA:\n"
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr "Validità\n"
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr "Validità:\n"
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tAttivazione: %s\n"
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tScadenza: %s\n"
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Si è in procinto di creare una nuova autorità certificativa con queste "
 "proprietà."
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Chiave privata estratta correttamente nel file '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr "L'id. del CSR fornito non è valido"
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr "Il certificato sarà revocato."
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificato revocato.\n"
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Il certificato usa:\n"
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Utilizzo dell'autorità certificativa disabilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Utilizzo della firma digitale abilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Utilizzo della firma digitale disabilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "* Utilizzo della cifratura dati abilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Utilizzo della cifratura di chiave abilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Utilizzo della cifratura di chiave disabilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Scopi del certificato:\n"
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* Abilitare la firma CRL? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Utilizzo della firma CRL disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Abilitare l'utilizzo della firma digitale? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Utilizzo della firma digitale disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Abilitare l'utilizzo della cifratura dei dati? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Utilizzo della cifratura dei dati disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Abilitare l'utilizzo della cifratura di chiave? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Utilizzo della cifratura di chiave disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:963
+#: ../src/ca-cli-callbacks.c:1041
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967
+#: ../src/ca-cli-callbacks.c:1045
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:968
+#: ../src/ca-cli-callbacks.c:1046
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:972
+#: ../src/ca-cli-callbacks.c:1050
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:974
+#: ../src/ca-cli-callbacks.c:1052
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:988
+#: ../src/ca-cli-callbacks.c:1066
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificato firmato.\n"
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This Certificate Signing Request will be deleted."
 msgstr "La richiesta di firma di certificato (CSR) sarà cancellata."
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1016
+#: ../src/ca-cli-callbacks.c:1094
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Richiesta di firma di certificato eliminata.\n"
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1119
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "CRL generato correttamente nel file '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 "La lunghezza in bit del numero primo deve essere un multiplo intero di 1024"
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Parametri Diffie-Hellman creati e salvati correttamente nel file '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr "Attualmente il database non è protetto da password"
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr "Inserire la password:"
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr "Inserire la password (conferma):"
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr "Le password introdotte sono diverse."
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr "Attualmente il database IS è protetto da password."
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Password rimossa correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1561,210 +1624,210 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr "Inserire la nuova password:"
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr "Inserire la nuova password (conferma):"
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Password modificata correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr "Si è verificato un problema durante l'importazione del file fornito."
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "File importato correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Cartella importata correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr "Certificato:\n"
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tNumero di serie: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tID unico: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "Impronta digitale MD5"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Richiesta di firma di certificato (CSR):\n"
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Visualizzazione delle politiche del seguente certificato:\n"
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
@@ -1773,58 +1836,58 @@ msgstr ""
 "\n"
 "Politiche:\n"
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr "La politica fornita non è valida"
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr "Confermare? Si/[No] "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr "La preferenza fornita non è valida"
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -1833,7 +1896,7 @@ msgstr ""
 "%s versione %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1846,7 +1909,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1857,7 +1920,7 @@ msgstr ""
 "  Vincenzo Reale https://launchpad.net/~smart2128\n"
 "  gnuckx https://launchpad.net/~gnuckx"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
@@ -1866,7 +1929,7 @@ msgstr ""
 "Traduttori:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1884,7 +1947,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1901,101 +1964,167 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr "In uscita da gnomint-cli...\n"
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "L'id. del CSR fornito non è valido"
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Creando Certificato CA di Root"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "web server"
 msgstr "Server web TLS"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "email server"
 msgstr "Server web TLS"
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Generazione della chiave fallita"
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Generazione della chiave fallita"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Errore durante la firma del certificato"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Il certificato usa:\n"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy
 msgid "Web Server"
 msgstr "Server web TLS"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#, fuzzy
+msgid "The given certificate id is not valid"
+msgstr "La preferenza fornita non è valida"
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+#, fuzzy
+msgid "Renew? [Yes]/No "
+msgstr "Confermare? [Si]/No "
+
+#: ../src/ca-cli-callbacks.c:1925
+#, fuzzy
+msgid "Certificate renewed. New certificate id: %"
+msgstr "Generazione del certificato fallita"
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Aggiungi un certificato CA autofirmato"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Certificato revocato.\n"
+msgstr[1] "Certificato revocato.\n"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -123,52 +123,52 @@ msgstr "Gerir aisidament e graficament de certificats X.509 e d'AC"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Periodic"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Activacion"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Expiracion"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Revocacion"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -179,154 +179,154 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Error inesperada"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "<b>Certificats</b>"
 msgstr[1] "<b>Certificats</b>"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -336,28 +336,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -368,326 +368,373 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr ""
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr ""
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr ""
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr ""
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr ""
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr ""
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr ""
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid "exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Afichar las informacions de version"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Error.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -702,14 +749,14 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -718,787 +765,802 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:963
-#, c-format
-msgid "* Time Stamping purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:967
-msgid "Enable OCSP Signing purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:968
-#, c-format
-msgid "* OCSP Signing purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:972
-msgid "Enable any purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:974
-#, c-format
-msgid "* Any purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid ""
-"All the mandatory data for the certificate generation has been gathered."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid "Do you want to proceed with the signing? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:988
-#, c-format
-msgid "Certificate signed.\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This Certificate Signing Request will be deleted."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This operation cannot be undone. Are you sure? Yes/[No] "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1016
-#, c-format
-msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:1041
 #, c-format
+msgid "* Time Stamping purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1045
+msgid "Enable OCSP Signing purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1046
+#, c-format
+msgid "* OCSP Signing purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1050
+msgid "Enable any purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1052
+#, c-format
+msgid "* Any purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid ""
+"All the mandatory data for the certificate generation has been gathered."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid "Do you want to proceed with the signing? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1066
+#, c-format
+msgid "Certificate signed.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This Certificate Signing Request will be deleted."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This operation cannot be undone. Are you sure? Yes/[No] "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1094
+#, c-format
+msgid "Certificate Signing Request deleted.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1119
+#, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1506,275 +1568,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1783,21 +1845,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Cédric VALMARY (Tot en òc) https://launchpad.net/~cvalmary"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1815,7 +1877,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1832,97 +1894,159 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+msgid "The given certificate id is not valid"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+msgid "Renew? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1925
+msgid "Certificate renewed. New certificate id: %"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+msgid "Cannot write chain file."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "<b>Certificats</b>"
+msgstr[1] "<b>Certificats</b>"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -130,52 +130,52 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -186,155 +186,155 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Visibilidade de certificados revogados"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Visibilidade de pedidos de certificado"
 msgstr[1] "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -344,28 +344,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -376,326 +376,373 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr ""
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr ""
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr ""
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr ""
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr ""
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr ""
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr ""
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid "exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -705,14 +752,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -721,787 +768,802 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:963
-#, c-format
-msgid "* Time Stamping purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:967
-msgid "Enable OCSP Signing purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:968
-#, c-format
-msgid "* OCSP Signing purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:972
-msgid "Enable any purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:974
-#, c-format
-msgid "* Any purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid ""
-"All the mandatory data for the certificate generation has been gathered."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid "Do you want to proceed with the signing? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:988
-#, c-format
-msgid "Certificate signed.\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This Certificate Signing Request will be deleted."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This operation cannot be undone. Are you sure? Yes/[No] "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1016
-#, c-format
-msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:1041
 #, c-format
+msgid "* Time Stamping purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1045
+msgid "Enable OCSP Signing purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1046
+#, c-format
+msgid "* OCSP Signing purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1050
+msgid "Enable any purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1052
+#, c-format
+msgid "* Any purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid ""
+"All the mandatory data for the certificate generation has been gathered."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid "Do you want to proceed with the signing? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1066
+#, c-format
+msgid "Certificate signed.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This Certificate Signing Request will be deleted."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This operation cannot be undone. Are you sure? Yes/[No] "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1094
+#, c-format
+msgid "Certificate Signing Request deleted.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1119
+#, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1509,275 +1571,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1786,21 +1848,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Enrico Nicoletto https://launchpad.net/~liverig"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1818,7 +1880,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1835,97 +1897,159 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, c-format
 msgid "Certificate type: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+msgid "The given certificate id is not valid"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+msgid "Renew? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1925
+msgid "Certificate renewed. New certificate id: %"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+msgid "Cannot write chain file."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Visibilidade de pedidos de certificado"
+msgstr[1] "Visibilidade de pedidos de certificado"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -132,53 +132,53 @@ msgstr "Управлять сертификатами X.509 и CA легко и 
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Сертификат</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Серийный номер"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Активация"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Срок истечения"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Отзыв"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +189,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Экспорт запроса на подпись сертификата"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Произошла ошибка во время экспорта сертификата."
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr "Произошла ошибка во время экспорта CSR."
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr "Запрос на подпись сертификата успешно экспортирован"
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr "Экспорт зашифрованного закрытого ключ"
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Закрытый ключ успешно экспортирован"
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Экспорт незашифрованного закрытого ключа"
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Экспорт всего сертификата в PKCS#12 пакет"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Экспорт CSR - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,7 +254,7 @@ msgstr ""
 "Пожалуйста, выберите какую часть сохранённого Запроса на Подпись Сертификата "
 "вы хотите экспортировать:"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -262,7 +262,7 @@ msgstr ""
 "<i>Экспорт Запроса на Подпись Сертификата в незашифрованный файл PEM формата."
 "</i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -271,83 +271,83 @@ msgstr ""
 "<i>Экспрорт сохранённого закрытого ключа в PKCS#8 файл защищённый паролем. "
 "Этот файл должен быть доступен владельцу Запроса на Подпись Сертификата.</i>"
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Неожиданная ошибка"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Корневой сертификат CA"
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Вы уверены, что хотите отозвать сертификат?"
 msgstr[1] "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Сертификат отозван.\n"
 msgstr[1] "Сертификат отозван.\n"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 msgstr[1] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -357,29 +357,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -390,15 +390,15 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr "Изменить CA пароль - gnoMint"
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -406,121 +406,121 @@ msgstr ""
 "Текущий пароль, который вы ввели, не совпадает с текущим актуальным паролем "
 "базы."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr "Произошла  ошибка при смене пароля базы. Операция отменена."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr "Пароль установлен успешно"
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr "Произошла ошибка при удалении пароля базы. Операция отменена."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "Пароль удалён успешно."
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Сохранить Diffie-Hellman параметры"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Параметры Diffie-Hellman сохранены успешно"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "Выберите PEM файл для импорта"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Проблема при импорте файла '%s'"
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr "Выберите каталог для импорта"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr "новая база <имяфайла>"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr "Закрыть текущий файл и создать новую базу с данным именем файла"
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr "открыть базу <имяфайла>"
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr "Закрыть текущий файл и открыть файл с заданным именем"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr "сохранить базу <имяфайла>"
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Сохранить текущий файл под другим именем"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr "Получить текущий статус (открытый файл, номер сертификатов, т.д. ...)"
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr "Список сертификатов в базе."
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr "Список CSR в базе"
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr "addcsr [ca-id-for-inherit-fields]"
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr "Стартовать процесс создания нового CSR"
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr "Стартовать процесс создания нового самоподписанного CA"
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr "extractcertpkey <cert-id> <filename>"
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
@@ -529,11 +529,11 @@ msgstr ""
 "его в заданный файл"
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr "extractcsrpkey <csr-id> <filename>"
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
@@ -542,181 +542,232 @@ msgstr ""
 "заданный файл"
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr "revoke <cert-id>"
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr "Отозвать сертификат с данным внутренним номером"
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr "sign <csr-id> <ca-cert-id>"
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr "Генерировать сертификат подписывая данный CSR с данным CA"
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr "delete <csr-id>"
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr "Удалить данный CSR из базы данных"
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr "crlgen <ca-id> <filename>"
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr "Создать новый CRL для данного CA, сохранив его в файле <filename>"
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr "dhgen <prime-bitlength> <filename>"
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 "Генерировать новый набор DH-параметров, сохраняя его в файле <имяфайла>"
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Изменить пароль для текущей базы данных"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr "importfile <filename>"
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr "Импорт файла с заданым именем <имяфайла>"
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr "importdir <dirname>"
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr "Импорт данного каталога как OpenSSL-CA каталога"
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr "showcert <cert-id>"
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Показать свойства данного сертификата"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr "showcsr <csr-id>"
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr "Показать свойства данного CSR"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr "showpolicy <ca-id>"
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr "Показать политики CA"
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr "setpolicy <ca-id> <policy-id> <value>"
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr "Изменить данную политику CA"
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr "Показать настройки программы"
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr "setpreference <preference-id> <value>"
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr "Установить данную настройку программы"
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+#, fuzzy
+msgid "renewcert <cert-id>"
+msgstr "showcert <cert-id>"
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <cert-id> <filename>"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+#, fuzzy
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr "revoke <cert-id>"
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+#, fuzzy
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr "delete <csr-id>"
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Показать сведения о программе"
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr "Показать сведения о гарантиях"
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr "Показать сведения о распространении"
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Показать сведения о версии"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "Показать (это) сообщение помощи"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Закрыть базу данных и выйти из программы"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Открыть базу данных %s..."
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Ошибка.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -731,7 +782,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -740,7 +791,7 @@ msgstr ""
 "Эта программа идёт АБСОЛЮТНО БЕЗ ГАРАНТИЙ;\n"
 "для подробностей наберите 'warranty'.\n"
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -752,12 +803,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Непарные кавычки\n"
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -765,187 +816,187 @@ msgstr ""
 "Неверная команда. Попробуйте 'help' для получения списка распознаваемых "
 "команд.\n"
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Неверное число параметров.\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Синтакс: %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "Файл уже существует, поэтому он будет переписан."
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr "Вы уверены? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr "Проблема при открытии новой базы CA '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "Открыт файл '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 "Проблема с открытием базы CA '%s\n"
 "'\n"
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "Текущий открытый файл: %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Количество сертификатов в файле: %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr "Количество CSR в файле: %d\n"
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr "CertList ID|%s\t"
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr "CertList является CA|Y\t"
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr "CertList является CA|N\t"
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr "CertList Заголовок|%s\t"
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr "CertList ДополнятьЕслиЗаголовок<16|\t"
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr "CertList ДополнятьЕслиЗаголовок<8|\t"
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr "CertList PKeyInDB|Y\t\t"
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr "CertList PKeyInDB|N\t\t"
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr "CertList Активация|\t"
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr "CertList Активация|%s\t"
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr "CertList Истечение срока|\t"
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr "CertList Истечение срока|%s\t"
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr "CertList Отзыв|\n"
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr "CertList Отзыв|%s\n"
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Сертификаты в базе:\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 "Id.\tявляется CA?\tЗаголовок Сертификата\tКлюч в базе?"
 "\tАктивация\t\tИстечение срока"
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr "\t\tОтзыв\n"
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr "CsrList ID|%s\t"
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr "CsrList ID предка|%s\t"
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr "CsrList ID предка|\t"
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr "CsrList Заголовок|%-24s\t"
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr "CsrList ДополнятьЕслиЗаголовок<16|\t"
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr "CsrList ДополнятьЕслиЗаголовок<8|\t"
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr "CsrList PKeyInDB|Y\n"
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr "CsrList PKeyInDB|N\n"
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr "Запросы сертификата в Базе:\n"
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr "Id.\tId предка.\tCSR Заголовок\t\tКлюч в базе?\n"
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr "Заданный идентификатор CA не верен"
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
@@ -954,109 +1005,125 @@ msgstr ""
 "Пожалуйста введите данные соответствующие заголовку Запроса на Подпись "
 "Сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr "Введите страну (C)"
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr "Введите название штата или области (ST)"
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr "Введите название местности или города (L)"
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr "Введите название организации (O)"
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr "Введите название организационной единицы (OU)"
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr "Введите обычное имя (СN)"
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#, fuzzy
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Введите тип ключа, который вы будете создавать (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Введите битовую длину ключа (должно быть кратно 1024)"
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr "Предоставленные свойства CSR:\n"
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr "Заголовок:\n"
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tОтличительное Имя (DN): "
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, fuzzy, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr "Заголовок Альтернативное Имя"
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr "Пара ключей\n"
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tТип: %s\n"
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tБитовая длина ключа: %d\n"
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Хотите ли вы изменить всё? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr "Вы создаёте Запрос на Подпись Сертификата с такими свойствами."
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr "Вы уверены? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Действие отменено.\n"
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1065,223 +1132,223 @@ msgstr ""
 "Пожалуйста введите данные соответствующие заголовку нового Центра "
 "Авторизации:\n"
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 "Введите количество месяцев до истечения срока нового центра авторизации"
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Заданные свойства нового CA:\n"
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr "Годность\n"
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr "Годность:\n"
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tАктивирован: %s\n"
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tСрок истекает: %s\n"
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr "Вы создаёте новый Центр Авторизации со следующими свойствами."
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr "Заданный номер сертификата не верен"
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Закрытый ключ извлечён успешно в файл '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr "Заданный номер CSR не верен"
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr "Сертификат будет отозван."
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Сертификат отозван.\n"
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Сертификат использует:\n"
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Использование Центра Сертификации включено.\n"
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Использование Центра Сертификации отключено.\n"
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr "* Использование подписывания CRL включено.\n"
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr "* Использование для подписи CRL отключено.\n"
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Использование для цифровой подписи разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Использование для цифровой подписи запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "* Использование для шифрования данных разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Использование для шифрования ключей разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Использование для шифрования ключей запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "* Использование для удостоверения в невозможности отказа разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "* Использование для удостоверения в невозможности отказа запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "Использование для согласования ключей разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "Использование для согласования ключей запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Назначение сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Назначение для защиты эл.почты разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Назначение для защиты эл.почты запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Назначение для подписи кода разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Назначение для подписи кода запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Назначение как TLS Веб клиент разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Назначение как TLS Веб клиент запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Назначение как TLS Веб сервер разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Назначение как TLS Веб сервер запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Назначение для отметки времени разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Назначение для отметки времени запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "Назначение для подписи OCSP разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "Назначение для подписи OCSP запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Любое назначение разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Любое назначение запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr "Вы собираетесь подписать следующий Запрос на подпись Сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr "с сертификатом, относящимся к следующему CA:\n"
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1289,7 +1356,7 @@ msgstr ""
 "Введите количество месяцев до истечения нового сертификата (0 для "
 "безсрочного)"
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
@@ -1297,191 +1364,191 @@ msgstr ""
 "Новый сертификат будет сгенерирован для следующего использования и "
 "назначения:\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 "Хотите ли вы изменить какое-либо свойство нового сертификата? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* Разрешить использование для Центра Сертификации? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Использование для Центра Сертификации запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* Разрешить подпись CRL? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Использование для подписи CRL запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Разрешить использование для Цифровой Подписи? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Использование для Цифровой Подписи запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Разрешить использование для Шифрования Данных? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Использование для Шифрования Данных запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Разрешить использование как Ключа Шифрования? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Использование как Ключа Шифрования запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 "Разрешить использование для удостоверения в невозможности отказа (Non-"
 "Repudiation)? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 "* Использование для удостоверения в невозможности отказа (Non-Repudiation) "
 "запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "Разрешить использование для Согласования Ключа? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "* Использование для Согласования Ключа запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "Разрешить назначение для Защиты Эл.Почты? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr "* Назначение для Защиты Эл.Почты запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "Разрешить назначение для Подписи Кода? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Назначения для Подписи Кода запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "Разрешить назначение как TLS веб клиент? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Назначение как TLS веб клиент запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "Разрешить назначение как TLS Веб сервер? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Назначение как TLS веб сервер запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "Разрешить назначения для Временных Меток? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:963
+#: ../src/ca-cli-callbacks.c:1041
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "* Назначение для Временных Меток запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:967
+#: ../src/ca-cli-callbacks.c:1045
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "Разрешить назначение для подписи OCSP? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:968
+#: ../src/ca-cli-callbacks.c:1046
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr "* Назначение для подписи OCSP запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:972
+#: ../src/ca-cli-callbacks.c:1050
 msgid "Enable any purpose? [Yes]/No "
 msgstr "Разрешить любое назначение? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:974
+#: ../src/ca-cli-callbacks.c:1052
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr "* Любое назначение запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr "Все обязательные данные для генерации сертификата были собраны."
 
-#: ../src/ca-cli-callbacks.c:982
+#: ../src/ca-cli-callbacks.c:1060
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "Хотите ли вы продолжить процедуру подписывания? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:988
+#: ../src/ca-cli-callbacks.c:1066
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Сертификат подписан.\n"
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This Certificate Signing Request will be deleted."
 msgstr "Этот Запрос на Подпись Сертификата будет удалён."
 
-#: ../src/ca-cli-callbacks.c:1010
+#: ../src/ca-cli-callbacks.c:1088
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr "Эта операция не может быть отменена. Вы уверены? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:1016
+#: ../src/ca-cli-callbacks.c:1094
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Запрос на Подпись Сертификата удалён.\n"
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1119
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "Генерация CRL в файл '%s' прошла успешно\n"
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "Битовая длинна основного числа должна быть кратна 1024"
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr "Параметры Diffie-Hellman созданы и успешно сохранены в файле '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr "На данный момент база не защищена паролем."
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "Хотите ли вы защитить её паролем? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1492,37 +1559,37 @@ msgstr ""
 "будет запрошен в то время, когда gnoMint будет использовать закрытый ключ в "
 "базе."
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr "Введите пароль:"
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr "Введите пароль (подтверждение):"
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr "Введённые пароли различаются."
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Пароль успешно установлен.\n"
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr "Нечего делать.\n"
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr "На данный момент, база защищена паролем."
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "Хотите ли вы удалить защиту паролем? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1531,11 +1598,11 @@ msgstr ""
 "Для удаления парольной защиты необходимо ввести текущий\n"
 "пароль базы.\n"
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr "Пожалуйста, введите текущий пароль базы (Пустой ввод для отмены): "
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1543,7 +1610,7 @@ msgstr ""
 "Текущий пароль который вы ввели\n"
 "не совпадает с фактическим паролем базы."
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1551,18 +1618,18 @@ msgstr ""
 "Произошла ошибка во время снятия пароля базы. \n"
 "Операция была отменена."
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Пароль успешно удалён.\n"
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr "Вы должны ввести текущий пароль базы перед сменой пароля.\n"
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1574,15 +1641,15 @@ msgstr ""
 "будет запрашиваться каждый раз, когда gnoMint будет использовать закрытый "
 "ключ в базе."
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr "Введите новый пароль:"
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr "Введите новый пароль (подтверждение):"
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1590,244 +1657,244 @@ msgstr ""
 "Произошла ошибка во время смены пароля. \n"
 "Операция была отменена."
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Пароль успешно изменён.\n"
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr "Проблема при импортировании данного файла."
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Файл импортирован успешно.\n"
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Каталог импортирован успешно.\n"
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr "Сертификат:\n"
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tСерийный номер:%s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr "\tОпределяющее Имя (DN): %s\n"
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr "Нет."
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tУникальный ID: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr "Поставщик:\n"
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Отпечатки:\n"
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tSHA1 отпечаток: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tMD5 отпечаток: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tSHA1 отпечаток: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Запрос на Подпись Сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 "Сгенерированные сертификаты наследуют Страну от CA                           "
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 "Сгенерированные сертификаты наследуют Область от "
 "CA                             "
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 "Сгенерированные сертификаты наследуют Местность от "
 "CA                          "
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 "Сгенерированные сертификаты наследуют Организацию от CA                      "
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 "Сгенерированные сертификаты наследуют Организационную Единицу от "
 "CA               "
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 "Страна в сгенерированных сертификатах должны быть такой же как в "
 "CA            "
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 "Область в сгенерированных сертификатах должна быть такой же как в "
 "CA              "
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 "Район в сгенерированных сертификатах должен быть таким же как в CA           "
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 "Организация в сгенерированных сертификатах должна быть такой же как в "
 "CA       "
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 "Организационная Единица в сгенерированных сертификатах должна быть такой же "
 "как в CA"
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Максимальное количество часов между обновлениями CRL                       "
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 "Максимальное количество месяцев до истечения срока новых "
 "сертификатов           "
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Использование для CA разрешено в сгенерированных "
 "сертификатах                                 "
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Использование для Подписи CRL разрешено в сгенерированных "
 "сертификатах                           "
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Использование для заверения невозможности отказа разрешено  сгенерированных "
 "сертификатах                     "
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Использование для цифровой подписи разрешено в сгенерированных "
 "сертификатах                  "
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Использование для шифрования ключей разрешено в сгенерированных "
 "сертификатах                   "
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Использование для согласования ключей разрешено в сгенерированных "
 "сертификатах                      "
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Использование для шифрования данных разрешено в сгенерированных "
 "сертификатах                  "
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Назначение как TLS веб-сервер разрешено в сгенерированных "
 "сертификатах                 "
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Назначение как TLS веб-клиент разрешено в сгенерированных "
 "сертификатах                 "
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 "Назначение для временных меток разрешено сгенерированных "
 "сертификатах                  "
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 "Назначение для подписи кода разрешено в сгенерированных "
 "сертификатах            "
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 "Назначение для защита почты разрешено в сгенерированных "
 "сертификатах               "
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 "Назначение для подписи OCSP разрешено в сгенерированных "
 "сертификатах                   "
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 "Любое назначение рарешено в сгенерированных "
 "сертификатах                            "
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Отображение политик следующего сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
@@ -1836,16 +1903,16 @@ msgstr ""
 "\n"
 "Политики:\n"
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr "Id.\tОписание\t\t\t\t\t\t\t\tЗначение\n"
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr "Данная политика недействительна"
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, fuzzy, c-format
 msgid ""
 "You are about to assign to the policy\n"
@@ -1854,35 +1921,35 @@ msgstr ""
 "Вы собираетесь назначить политике\n"
 "'%s' новое значение '%d'."
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr "Вы уверены? Да/[Нет]: "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, fuzzy, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr "Политика установлена корректно в '%d'.\n"
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr "gnoMint-cli текущие настройки:\n"
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr "Id.\tИмя\t\t\tЗначение\n"
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr "0\tПоддержка Gnome keyring\t%d\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr "Заданный id свойств не верный"
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
@@ -1891,7 +1958,7 @@ msgstr ""
 "Вы собираетесь назначить свойству 'Поддержка Gnome keyring' новое значение "
 "'%d'."
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -1900,7 +1967,7 @@ msgstr ""
 "%s версия %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1913,7 +1980,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1921,7 +1988,7 @@ msgstr ""
 "  David Marín https://launchpad.net/~davefx\n"
 "  aquanaut https://launchpad.net/~thecrux"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
@@ -1930,7 +1997,7 @@ msgstr ""
 "Переводчики:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1966,7 +2033,7 @@ msgstr ""
 "<http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1999,101 +2066,169 @@ msgstr ""
 "<http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s версия %s\n"
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr "Доступные команды:\n"
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr "Выход из gnomint-cli...\n"
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "Заданный идентификатор CA не верен"
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Создание корневого сертификата CA"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "web server"
 msgstr "TLS Веб сервер"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 #, fuzzy
 msgid "email server"
 msgstr "TLS Веб сервер"
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Создание ключей не удалось"
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Оздание CSR не удалось"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Ошибка при подписи сертификата"
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Сертификат использует:\n"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy
 msgid "Web Server"
 msgstr "TLS Веб сервер"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+#, fuzzy
+msgid "Usage: renewcert <cert-id>"
+msgstr "showcert <cert-id>"
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#, fuzzy
+msgid "The given certificate id is not valid"
+msgstr "Заданный номер сертификата не верен"
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+#, fuzzy
+msgid "Renew? [Yes]/No "
+msgstr "Вы уверены? [Да]/Нет "
+
+#: ../src/ca-cli-callbacks.c:1925
+#, fuzzy
+msgid "Certificate renewed. New certificate id: %"
+msgstr "Создание сертификата не удалось"
+
+#: ../src/ca-cli-callbacks.c:1933
+#, fuzzy
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr "extractcertpkey <cert-id> <filename>"
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Не удалось инициализировать: %s\n"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Сертификат отозван.\n"
+msgstr[1] "Сертификат отозван.\n"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -131,52 +131,52 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -187,155 +187,155 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Vlastnosti žiadosti o vydanie certifikátu - gnoMint"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Pridať certifikát self-signed CA"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Viditeľnosť žiadostí o certifikát"
 msgstr[1] "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Pridať novú žiadosť o vydanie certifikátu"
 msgstr[1] "Pridať novú žiadosť o vydanie certifikátu"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -345,28 +345,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -377,326 +377,373 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr ""
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr ""
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr ""
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr ""
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr ""
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr ""
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
 msgstr ""
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
 msgstr ""
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr ""
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr ""
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr ""
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr ""
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr ""
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr ""
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr ""
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr ""
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr ""
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr ""
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr ""
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid "exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -706,14 +753,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -722,787 +769,802 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:963
-#, c-format
-msgid "* Time Stamping purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:967
-msgid "Enable OCSP Signing purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:968
-#, c-format
-msgid "* OCSP Signing purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:972
-msgid "Enable any purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:974
-#, c-format
-msgid "* Any purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid ""
-"All the mandatory data for the certificate generation has been gathered."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid "Do you want to proceed with the signing? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:988
-#, c-format
-msgid "Certificate signed.\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This Certificate Signing Request will be deleted."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This operation cannot be undone. Are you sure? Yes/[No] "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1016
-#, c-format
-msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:1041
 #, c-format
+msgid "* Time Stamping purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1045
+msgid "Enable OCSP Signing purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1046
+#, c-format
+msgid "* OCSP Signing purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1050
+msgid "Enable any purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1052
+#, c-format
+msgid "* Any purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid ""
+"All the mandatory data for the certificate generation has been gathered."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid "Do you want to proceed with the signing? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1066
+#, c-format
+msgid "Certificate signed.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This Certificate Signing Request will be deleted."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This operation cannot be undone. Are you sure? Yes/[No] "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1094
+#, c-format
+msgid "Certificate Signing Request deleted.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1119
+#, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1510,275 +1572,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1787,7 +1849,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1795,14 +1857,14 @@ msgstr ""
 "  David Marín https://launchpad.net/~davefx\n"
 "  jariq https://launchpad.net/~jariq"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1820,7 +1882,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1837,97 +1899,160 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Pridať _žiadosť o vydanie certifikátu"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+msgid "The given certificate id is not valid"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+msgid "Renew? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1925
+msgid "Certificate renewed. New certificate id: %"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Pridať certifikát self-signed CA"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Viditeľnosť žiadostí o certifikát"
+msgstr[1] "Viditeľnosť žiadostí o certifikát"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 11:50+0200\n"
+"POT-Creation-Date: 2026-05-22 12:24+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -134,53 +134,53 @@ msgstr "Hantera X.509-certifikat och certifikatutfärdare, enkelt och grafiskt"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:267
+#: ../src/ca.c:268
 msgid "<b>Certificates</b>"
 msgstr "<b>Certifikat</b>"
 
-#: ../src/ca.c:415
+#: ../src/ca.c:416
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
-#: ../src/ca.c:458 ../src/ca-cli-callbacks.c:172 ../src/ca-cli-callbacks.c:186
-#: ../src/ca-cli-callbacks.c:201 ../src/ca-cli-callbacks.c:629
-#: ../src/ca-cli-callbacks.c:638 ../src/ca-cli-callbacks.c:1258
-#: ../src/ca-cli-callbacks.c:1267 ../src/certificate_properties.c:178
+#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
+#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
+#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:461 ../src/ca-cli-callbacks.c:175 ../src/ca-cli-callbacks.c:189
-#: ../src/ca-cli-callbacks.c:204 ../src/ca-cli-callbacks.c:632
-#: ../src/ca-cli-callbacks.c:641 ../src/ca-cli-callbacks.c:1261
-#: ../src/ca-cli-callbacks.c:1270 ../src/certificate_properties.c:181
+#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
+#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:612 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
-#: ../src/ca.c:648
+#: ../src/ca.c:649
 msgid "Serial"
 msgstr "Serienummer"
 
-#: ../src/ca.c:656
+#: ../src/ca.c:657
 msgid "Activation"
 msgstr "Aktivering"
 
-#: ../src/ca.c:666
+#: ../src/ca.c:667
 msgid "Expiration"
 msgstr "Utgång"
 
-#: ../src/ca.c:676
+#: ../src/ca.c:677
 msgid "Revocation"
 msgstr "Spärrning"
 
-#: ../src/ca.c:709
+#: ../src/ca.c:710
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -191,64 +191,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1046
+#: ../src/ca.c:1047
 msgid "Export certificate"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1049 ../src/ca.c:1056 ../src/ca.c:1158 ../src/ca.c:1209
-#: ../src/ca.c:1260 ../src/ca.c:1450 ../src/ca.c:2450 ../src/ca.c:2556
-#: ../src/ca.c:2590 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
+#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
+#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2451 ../src/crl.c:258
+#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
+#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1053
+#: ../src/ca.c:1054
 msgid "Export certificate signing request"
 msgstr "Exportera certificate signing request"
 
-#: ../src/ca.c:1068 ../src/ca.c:1104 ../src/ca.c:1114 ../src/export.c:278
+#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Det inträffade ett fel då certifikatet skulle exporteras."
 
-#: ../src/ca.c:1070 ../src/ca.c:1106 ../src/ca.c:1116
+#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
 msgid "There was an error while exporting CSR."
 msgstr "Det inträffade ett fel då CSR skulle exporteras."
 
-#: ../src/ca.c:1129 ../src/ca.c:1295
+#: ../src/ca.c:1130 ../src/ca.c:1296
 msgid "Certificate exported successfully"
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1136
+#: ../src/ca.c:1137
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1155
+#: ../src/ca.c:1156
 msgid "Export crypted private key"
 msgstr "Exportera krypterad privat nyckel"
 
-#: ../src/ca.c:1184 ../src/ca.c:1236
+#: ../src/ca.c:1185 ../src/ca.c:1237
 msgid "Private key exported successfully"
 msgstr "Privat nyckel exporterades"
 
-#: ../src/ca.c:1206
+#: ../src/ca.c:1207
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportera okrypterad privat nyckel"
 
-#: ../src/ca.c:1257
+#: ../src/ca.c:1258
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportera helt certifikat i PKCS#12-paket"
 
-#: ../src/ca.c:1328
+#: ../src/ca.c:1329
 msgid "Export CSR - gnoMint"
 msgstr "Exportera CSR - gnoMint"
 
-#: ../src/ca.c:1333
+#: ../src/ca.c:1334
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -256,7 +256,7 @@ msgstr ""
 "Vänligen välj vilken del av den sparade Certificate Signing Request du vill "
 "exportera:"
 
-#: ../src/ca.c:1338
+#: ../src/ca.c:1339
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -264,7 +264,7 @@ msgstr ""
 "<i>Exportera Certificate Signing Request till en publik fil, i PEM-format.</"
 "i>"
 
-#: ../src/ca.c:1343
+#: ../src/ca.c:1344
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -274,70 +274,70 @@ msgstr ""
 "fil. Filen bör endast kunna kommas åt av den till vilken Certificate Signing "
 "Request är utfärdat.</i>"
 
-#: ../src/ca.c:1407
+#: ../src/ca.c:1408
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: ../src/ca.c:1422
+#: ../src/ca.c:1423
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1448
+#: ../src/ca.c:1449
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1471
+#: ../src/ca.c:1472
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1479
+#: ../src/ca.c:1480
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Lägg till ett autosignerat CA-certifikat"
 
-#: ../src/ca.c:1487
+#: ../src/ca.c:1488
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1608
+#: ../src/ca.c:1556
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1614
+#: ../src/ca.c:1562
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Är du säker på att du vill spärra detta certifikat?"
 msgstr[1] "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1569
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1587
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1643
+#: ../src/ca.c:1591
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Exportera certifikat"
 msgstr[1] "Exportera certifikat"
 
-#: ../src/ca.c:1667
+#: ../src/ca.c:1615
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1673
+#: ../src/ca.c:1621
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -346,12 +346,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:1694
+#: ../src/ca.c:1642
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1705
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -361,29 +361,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1775
+#: ../src/ca.c:1723
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1809
+#: ../src/ca.c:1757
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1758
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1818
+#: ../src/ca.c:1766
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1819
+#: ../src/ca.c:1767
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -394,139 +394,139 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1862
+#: ../src/ca.c:1810
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:2228
+#: ../src/ca.c:2176
 msgid "Change CA password - gnoMint"
 msgstr "Ändra CA-lösenord - gnoMint"
 
-#: ../src/ca.c:2246
+#: ../src/ca.c:2194
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 "Det lösenord Du skrivit in är inte det som behövs för den valda databasen."
 
-#: ../src/ca.c:2261
+#: ../src/ca.c:2209
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle bytas. Operationen avbröts."
 
-#: ../src/ca.c:2270
+#: ../src/ca.c:2218
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: ../src/ca.c:2280 ../src/ca-cli-callbacks.c:1091
+#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2290
+#: ../src/ca.c:2238
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2300
+#: ../src/ca.c:2248
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle tas bort. Operationen "
 "avbröts."
 
-#: ../src/ca.c:2309
+#: ../src/ca.c:2257
 msgid "Password removed successfully"
 msgstr "Lösenordet togs bort"
 
-#: ../src/ca.c:2447
+#: ../src/ca.c:2395
 msgid "Save Diffie-Hellman parameters"
 msgstr "Spara Diffie-Hellman-parametrar"
 
-#: ../src/ca.c:2473
+#: ../src/ca.c:2421
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-parametrar sparades"
 
 #. Import single file
-#: ../src/ca.c:2553
+#: ../src/ca.c:2501
 msgid "Select PEM file to import"
 msgstr "Välj PEM-fil att importera"
 
-#: ../src/ca.c:2557 ../src/ca.c:2591 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2574
+#: ../src/ca.c:2522
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Ett problem inträffade vid importerandet av filen '%s'"
 
-#: ../src/ca.c:2587
+#: ../src/ca.c:2535
 msgid "Select directory to import"
 msgstr "Välj katalog att importera"
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "newdb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:37
+#: ../src/ca-cli.c:40
 msgid "Close current file and create a new database with given filename"
 msgstr "Stäng aktuell fil och skapa en ny databas med angivet filnamn."
 
 #. 0
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "opendb <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:38
+#: ../src/ca-cli.c:41
 msgid "Close current file and open the file with given filename"
 msgstr "Stäng aktuell fil och öppna filen med angivet filnamn"
 
 #. 1
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "savedbas <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:39
+#: ../src/ca-cli.c:42
 msgid "Save the current file with a different filename"
 msgstr "Spara aktuell fil under ett annat filnamn"
 
 #. 2
-#: ../src/ca-cli.c:40
+#: ../src/ca-cli.c:43
 msgid "Get current status (opened file, no. of certificates, etc...)"
 msgstr ""
 
 #. 3
-#: ../src/ca-cli.c:41
+#: ../src/ca-cli.c:44
 msgid ""
 "List the certificates in database. With option --see-revoked, lists also the "
 "revoked ones"
 msgstr "Lista"
 
 #. 4
-#: ../src/ca-cli.c:43
+#: ../src/ca-cli.c:46
 msgid "List the CSRs in database"
 msgstr ""
 
 #. 5
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "addcsr [ca-id-for-inherit-fields]"
 msgstr ""
 
-#: ../src/ca-cli.c:44
+#: ../src/ca-cli.c:47
 msgid "Start a new CSR creation process"
 msgstr "Påbörja skapandet av en ny CSR"
 
 #. 6
-#: ../src/ca-cli.c:45
+#: ../src/ca-cli.c:48
 msgid "Start a new self-signed CA creation process"
 msgstr "Påbörja skapandet av en ny självsignerad CA"
 
 #. 7
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid "extractcertpkey <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:46
+#: ../src/ca-cli.c:49
 msgid ""
 "Extract the private key of the certificate with the given internal id and "
 "saves it into the given file"
@@ -535,11 +535,11 @@ msgstr ""
 "sparar den till den angivna filen"
 
 #. 8
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid "extractcsrpkey <csr-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:49
+#: ../src/ca-cli.c:52
 msgid ""
 "Extract the private key of the CSR with the given internal id and saves it "
 "into the given file"
@@ -548,182 +548,230 @@ msgstr ""
 "till den angivna filen"
 
 #. 9
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "revoke <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:52
+#: ../src/ca-cli.c:55
 msgid "Revoke the certificate with the given internal ID"
 msgstr "Återkallar certifikatet med angivet internt id"
 
 #. 10
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "sign <csr-id> <ca-cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:53
+#: ../src/ca-cli.c:56
 msgid "Generate a certificate signing the given CSR with the given CA"
 msgstr ""
 
 #. 11
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "delete <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:54
+#: ../src/ca-cli.c:57
 msgid "Delete the given CSR from the database"
 msgstr "Ta bort angiven CSR från databasen"
 
 #. 12
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "crlgen <ca-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:55
+#: ../src/ca-cli.c:58
 msgid "Generate a new CRL for the given CA, saving it into the file <filename>"
 msgstr ""
 
 #. 13
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "dhgen <prime-bitlength> <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:56
+#: ../src/ca-cli.c:59
 msgid "Generate a new DH-parameter set, saving it into the file <filename>"
 msgstr ""
 "Generera ett set nya  Diffie–Hellman-parametrar och spara det till filen "
 "<filename>"
 
 #. 14
-#: ../src/ca-cli.c:57
+#: ../src/ca-cli.c:60
 msgid "Change password for the current database"
 msgstr "Ändra lösenordet för den aktuella databasen"
 
 #. 15
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "importfile <filename>"
 msgstr ""
 
-#: ../src/ca-cli.c:58
+#: ../src/ca-cli.c:61
 msgid "Import the file with the given name <filename>"
 msgstr "Importera filen med angivet filnamn <filename>"
 
 #. 16
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "importdir <dirname>"
 msgstr ""
 
-#: ../src/ca-cli.c:59
+#: ../src/ca-cli.c:62
 msgid "Import the given directory, as a OpenSSL-CA directory"
 msgstr "Importera angiven katalog som en OpenSSL-CA katalog"
 
 #. 17
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "showcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:60
+#: ../src/ca-cli.c:63
 msgid "Show properties of the given certificate"
 msgstr "Visa egenskaper för angivet certifikat"
 
 #. 18
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "showcsr <csr-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:61
+#: ../src/ca-cli.c:64
 msgid "Show properties of the given CSR"
 msgstr "Visa egenskaper för angiven CSR"
 
 #. 19
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "showpolicy <ca-id>"
 msgstr ""
 
-#: ../src/ca-cli.c:62
+#: ../src/ca-cli.c:65
 msgid "Show CA policy"
 msgstr "Visa CA-policy"
 
 #. 20
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "setpolicy <ca-id> <policy-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:63
+#: ../src/ca-cli.c:66
 msgid "Change the given CA policy"
 msgstr "Ändra angiven CA-policy"
 
 #. 21
-#: ../src/ca-cli.c:64
+#: ../src/ca-cli.c:67
 msgid "Show program preferences"
 msgstr "Visa programmets inställningar"
 
 #. 22
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "setpreference <preference-id> <value>"
 msgstr ""
 
-#: ../src/ca-cli.c:65
+#: ../src/ca-cli.c:68
 msgid "Set the given program preference"
 msgstr "Ställ in angiven programinställning"
 
 #. 23
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "addservercert <ca-id> <cert-type> <server-name>"
 msgstr ""
 
-#: ../src/ca-cli.c:66
+#: ../src/ca-cli.c:69
 msgid "Quick server certificate generation (cert-type: 'web' or 'email')"
 msgstr ""
 
 #. 24
-#: ../src/ca-cli.c:67
+#: ../src/ca-cli.c:70
+msgid "renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli.c:70
+msgid ""
+"Reissue a certificate with the same subject + SAN and a fresh keypair. The "
+"old certificate remains in the database."
+msgstr ""
+
+#: ../src/ca-cli.c:71
+#, fuzzy
+msgid "exportchain <cert-id> <filename>"
+msgstr "Exportera certifikat"
+
+#: ../src/ca-cli.c:71
+msgid ""
+"Export the full certificate chain (leaf → root) for the given certificate as "
+"a PEM bundle."
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:72
+msgid "Revoke many certificates at once. Non-cert ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli.c:73
+msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
+msgstr ""
+
+#: ../src/ca-cli.c:74
 msgid "Show about message"
 msgstr "Visa meddelandet \"Om programmet\""
 
 #. 25
-#: ../src/ca-cli.c:68
+#: ../src/ca-cli.c:75
 msgid "Show warranty information"
 msgstr "Visa information om garanti"
 
 #. 26
-#: ../src/ca-cli.c:69
+#: ../src/ca-cli.c:76
 msgid "Show distribution information"
 msgstr "Visa information om distribution"
 
 #. 27
-#: ../src/ca-cli.c:70
+#: ../src/ca-cli.c:77
 msgid "Show version information"
 msgstr "Visa versionsinformation"
 
 #. 28
-#: ../src/ca-cli.c:71
+#: ../src/ca-cli.c:78
 msgid "Show (this) help message"
 msgstr "Visa hjälpmeddelande (det här)"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:72 ../src/ca-cli.c:73 ../src/ca-cli.c:74
+#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
 msgid "Close database and exit program"
 msgstr "Stäng databasen och avsluta programmet"
 
-#: ../src/ca-cli.c:96
+#: ../src/ca-cli.c:128
 #, c-format
 msgid "Opening database %s..."
 msgstr "Öppnar databasen %s..."
 
-#: ../src/ca-cli.c:100
+#: ../src/ca-cli.c:132
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:102
+#: ../src/ca-cli.c:134
 #, c-format
 msgid " Error.\n"
 msgstr " Fel.\n"
 
-#: ../src/ca-cli.c:129
+#: ../src/ca-cli.c:149
+#, c-format
+msgid ""
+"Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgid_plural ""
+"Notice: %d certificates expire within the next %d days. Use `renewcert <id>` "
+"to reissue.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli.c:183
 #, c-format
 msgid ""
 "\n"
@@ -738,7 +786,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:130
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -747,7 +795,7 @@ msgstr ""
 "Det här programmet levereras UTAN NÅGON SOM HELST GARANTI;\n"
 "för detaljer skriv \"warranty\".\n"
 
-#: ../src/ca-cli.c:131
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -759,12 +807,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:173
+#: ../src/ca-cli.c:227
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Ej ihop-parade citationstecken.\n"
 
-#: ../src/ca-cli.c:251
+#: ../src/ca-cli.c:305
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -772,776 +820,791 @@ msgstr ""
 "Ogiltigt kommando. Försök med 'help' för att få en lista över kommandon som "
 "programmet känner igen.\n"
 
-#: ../src/ca-cli.c:255
+#: ../src/ca-cli.c:309
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Felaktigt antal parametrar.\n"
 
-#: ../src/ca-cli.c:256
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Syntax: %s\n"
 
 #. The file already exists. We ask the user about overwriting it
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
 msgid "The file already exists, so it will be overwritten."
 msgstr "Filen finns redan, så den kommer att skrivas över."
 
-#: ../src/ca-cli-callbacks.c:57 ../src/ca-cli-callbacks.c:106
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
+#: ../src/ca-cli-callbacks.c:807
 msgid "Are you sure? Yes/[No] "
 msgstr "Är Du säker? Yes/[No] "
 
-#: ../src/ca-cli-callbacks.c:79
+#: ../src/ca-cli-callbacks.c:81
 #, c-format
 msgid "Problem when opening new '%s' CA database\n"
 msgstr "Problem vid öppnandet av ny '%s' CA-databas\n"
 
-#: ../src/ca-cli-callbacks.c:83
+#: ../src/ca-cli-callbacks.c:85
 #, c-format
 msgid "File '%s' opened\n"
 msgstr "Filen '%s' öppnad\n"
 
-#: ../src/ca-cli-callbacks.c:93
+#: ../src/ca-cli-callbacks.c:95
 #, c-format
 msgid "Problem when opening '%s' CA database\n"
 msgstr "Problem vid öppnandet av '%s' CA-databas\n"
 
-#: ../src/ca-cli-callbacks.c:127
+#: ../src/ca-cli-callbacks.c:129
 #, c-format
 msgid "Current opened file: %s\n"
 msgstr "Aktuell öppnad fil: %s\n"
 
-#: ../src/ca-cli-callbacks.c:128
+#: ../src/ca-cli-callbacks.c:130
 #, c-format
 msgid "Number of certificates in file: %d\n"
 msgstr "Antal certifikat i filen: %d\n"
 
-#: ../src/ca-cli-callbacks.c:129
+#: ../src/ca-cli-callbacks.c:131
 #, c-format
 msgid "Number of CSRs in file: %d\n"
 msgstr "Antal CSR i filen: %d\n"
 
-#: ../src/ca-cli-callbacks.c:144
+#: ../src/ca-cli-callbacks.c:146
 #, c-format
 msgid "CertList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:147
+#: ../src/ca-cli-callbacks.c:149
 msgid "CertList IsCA|Y\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:149
+#: ../src/ca-cli-callbacks.c:151
 msgid "CertList IsCA|N\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:154
+#: ../src/ca-cli-callbacks.c:156
 #, c-format
 msgid "CertList Subject|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:157
+#: ../src/ca-cli-callbacks.c:159
 msgid "CertList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:159
+#: ../src/ca-cli-callbacks.c:161
 msgid "CertList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:162
+#: ../src/ca-cli-callbacks.c:164
 msgid "CertList PKeyInDB|Y\t\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:164
+#: ../src/ca-cli-callbacks.c:166
 msgid "CertList PKeyInDB|N\t\t"
 msgstr "CertList PKeyiDB|N\t\t"
 
-#: ../src/ca-cli-callbacks.c:168
+#: ../src/ca-cli-callbacks.c:170
 msgid "CertList Activation|\t"
 msgstr "CertList aktivering|\t"
 
-#: ../src/ca-cli-callbacks.c:177
+#: ../src/ca-cli-callbacks.c:179
 #, c-format
 msgid "CertList Activation|%s\t"
 msgstr "CertList aktivering|%s\t"
 
-#: ../src/ca-cli-callbacks.c:182
+#: ../src/ca-cli-callbacks.c:184
 msgid "CertList Expiration|\t"
 msgstr "CertList utgång|\t"
 
-#: ../src/ca-cli-callbacks.c:191
+#: ../src/ca-cli-callbacks.c:193
 #, c-format
 msgid "CertList Expiration|%s\t"
 msgstr "CertList utgång|%s\t"
 
-#: ../src/ca-cli-callbacks.c:197
+#: ../src/ca-cli-callbacks.c:199
 msgid "CertList Revocation|\n"
 msgstr "CertList återkallelse|\n"
 
-#: ../src/ca-cli-callbacks.c:206
+#: ../src/ca-cli-callbacks.c:208
 #, c-format
 msgid "CertList Revocation|%s\n"
 msgstr "CertList återkallelse|%s\n"
 
-#: ../src/ca-cli-callbacks.c:223
+#: ../src/ca-cli-callbacks.c:225
 #, c-format
 msgid "Certificates in Database:\n"
 msgstr "Certifikat i databas:\n"
 
-#: ../src/ca-cli-callbacks.c:224
+#: ../src/ca-cli-callbacks.c:226
 #, c-format
 msgid "Id.\tIs CA?\tCertificate Subject\tKey in DB?\tActivation\t\tExpiration"
 msgstr "Id.\tÄr CA?\tCertifikatämne\tNyckel i DB?\tAktivering\t\tUtgång"
 
-#: ../src/ca-cli-callbacks.c:227
+#: ../src/ca-cli-callbacks.c:229
 #, c-format
 msgid "\t\tRevocation\n"
 msgstr "\t\ttab]\tÅterkallelse\n"
 
-#: ../src/ca-cli-callbacks.c:237
+#: ../src/ca-cli-callbacks.c:239
 #, c-format
 msgid "CsrList ID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 #, c-format
 msgid "CsrList ParentID|%s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:239
+#: ../src/ca-cli-callbacks.c:241
 msgid "CsrList ParentID|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:244
+#: ../src/ca-cli-callbacks.c:246
 #, c-format
 msgid "CsrList Subject|%-24s\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:247
+#: ../src/ca-cli-callbacks.c:249
 msgid "CsrList PadIfSubject<16|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:249
+#: ../src/ca-cli-callbacks.c:251
 msgid "CsrList PadIfSubject<8|\t"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:252
+#: ../src/ca-cli-callbacks.c:254
 msgid "CsrList PKeyInDB|Y\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:254
+#: ../src/ca-cli-callbacks.c:256
 msgid "CsrList PKeyInDB|N\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:262
+#: ../src/ca-cli-callbacks.c:264
 #, c-format
 msgid "Certificate Requests in Database:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:263
+#: ../src/ca-cli-callbacks.c:265
 #, c-format
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:293 ../src/ca-cli-callbacks.c:1034
-#: ../src/ca-cli-callbacks.c:1421 ../src/ca-cli-callbacks.c:1450
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
+#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
 msgid "The given CA id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:346
+#: ../src/ca-cli-callbacks.c:348
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the Certificate Signing "
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:349 ../src/ca-cli-callbacks.c:508
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:357 ../src/ca-cli-callbacks.c:514
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:366 ../src/ca-cli-callbacks.c:520
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:374 ../src/ca-cli-callbacks.c:526
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:382 ../src/ca-cli-callbacks.c:532
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:389 ../src/ca-cli-callbacks.c:538
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:395 ../src/ca-cli-callbacks.c:544
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:406 ../src/ca-cli-callbacks.c:555
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:416 ../src/ca-cli-callbacks.c:565
-msgid "Enter type of key you are going to create (RSA/DSA)"
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:430 ../src/ca-cli-callbacks.c:577
+#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+msgid "Enter curve size for ECDSA (256, 384, or 521)"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:435
+#: ../src/ca-cli-callbacks.c:467
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:437 ../src/ca-cli-callbacks.c:605
-#: ../src/ca-cli-callbacks.c:1245 ../src/ca-cli-callbacks.c:1310
+#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
+#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:438 ../src/ca-cli-callbacks.c:606
+#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:453 ../src/ca-cli-callbacks.c:621
-#: ../src/ca-cli-callbacks.c:1249 ../src/ca-cli-callbacks.c:1313
+#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
+#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:454 ../src/ca-cli-callbacks.c:622
+#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:455 ../src/ca-cli-callbacks.c:623
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:456 ../src/ca-cli-callbacks.c:624
+#: ../src/ca-cli-callbacks.c:494
+#, c-format
+msgid "\tKey size: fixed (Ed25519)\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:496
+#, c-format
+msgid "\tCurve: P-%d\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:645
+#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462
+#: ../src/ca-cli-callbacks.c:505
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:463 ../src/ca-cli-callbacks.c:650
+#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:655
-#: ../src/ca-cli-callbacks.c:739 ../src/ca-cli-callbacks.c:870
-#: ../src/ca-cli-callbacks.c:991 ../src/ca-cli-callbacks.c:1020
-#: ../src/ca-cli-callbacks.c:1086 ../src/ca-cli-callbacks.c:1113
-#: ../src/ca-cli-callbacks.c:1141 ../src/ca-cli-callbacks.c:1156
-#: ../src/ca-cli-callbacks.c:1480 ../src/ca-cli-callbacks.c:1523
+#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
+#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
+#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
+#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
+#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
+#: ../src/ca-cli-callbacks.c:1915
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506
+#: ../src/ca-cli-callbacks.c:549
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:582
+#: ../src/ca-cli-callbacks.c:654
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:603
+#: ../src/ca-cli-callbacks.c:675
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:625
+#: ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:626 ../src/ca-cli-callbacks.c:1255
+#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:634 ../src/ca-cli-callbacks.c:1263
+#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:643 ../src/ca-cli-callbacks.c:1272
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:649
+#: ../src/ca-cli-callbacks.c:727
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675 ../src/ca-cli-callbacks.c:723
-#: ../src/ca-cli-callbacks.c:1230
+#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
+#: ../src/ca-cli-callbacks.c:1308
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:682 ../src/ca-cli-callbacks.c:706
+#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:699 ../src/ca-cli-callbacks.c:851
-#: ../src/ca-cli-callbacks.c:1004 ../src/ca-cli-callbacks.c:1299
+#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
+#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:729
+#: ../src/ca-cli-callbacks.c:807
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:735
+#: ../src/ca-cli-callbacks.c:813
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:749 ../src/ca-cli-callbacks.c:1280
+#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:752
+#: ../src/ca-cli-callbacks.c:830
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:754
+#: ../src/ca-cli-callbacks.c:832
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:758
+#: ../src/ca-cli-callbacks.c:836
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760
+#: ../src/ca-cli-callbacks.c:838
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:764
+#: ../src/ca-cli-callbacks.c:842
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:766
+#: ../src/ca-cli-callbacks.c:844
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:770 ../src/ca-cli-callbacks.c:772
+#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:776
+#: ../src/ca-cli-callbacks.c:854
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:778
+#: ../src/ca-cli-callbacks.c:856
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:782
+#: ../src/ca-cli-callbacks.c:860
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:862
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:788
+#: ../src/ca-cli-callbacks.c:866
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:790
+#: ../src/ca-cli-callbacks.c:868
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:793
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:796
+#: ../src/ca-cli-callbacks.c:874
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:798
+#: ../src/ca-cli-callbacks.c:876
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:802
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:804
+#: ../src/ca-cli-callbacks.c:882
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:808
+#: ../src/ca-cli-callbacks.c:886
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:888
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:814
+#: ../src/ca-cli-callbacks.c:892
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:816
+#: ../src/ca-cli-callbacks.c:894
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:820
+#: ../src/ca-cli-callbacks.c:898
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:822
+#: ../src/ca-cli-callbacks.c:900
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:826
+#: ../src/ca-cli-callbacks.c:904
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:828
+#: ../src/ca-cli-callbacks.c:906
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:910
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:834
+#: ../src/ca-cli-callbacks.c:912
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:858
+#: ../src/ca-cli-callbacks.c:936
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:938
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:863
+#: ../src/ca-cli-callbacks.c:941
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:889 ../src/ca-cli-callbacks.c:977
+#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:970
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:895
+#: ../src/ca-cli-callbacks.c:973
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:897
+#: ../src/ca-cli-callbacks.c:975
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:901
+#: ../src/ca-cli-callbacks.c:979
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:903
+#: ../src/ca-cli-callbacks.c:981
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:907
+#: ../src/ca-cli-callbacks.c:985
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:909
+#: ../src/ca-cli-callbacks.c:987
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:913
+#: ../src/ca-cli-callbacks.c:991
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:915
+#: ../src/ca-cli-callbacks.c:993
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:919
+#: ../src/ca-cli-callbacks.c:997
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:921
+#: ../src/ca-cli-callbacks.c:999
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:925
+#: ../src/ca-cli-callbacks.c:1003
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:927
+#: ../src/ca-cli-callbacks.c:1005
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:931
+#: ../src/ca-cli-callbacks.c:1009
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:933
+#: ../src/ca-cli-callbacks.c:1011
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:937
+#: ../src/ca-cli-callbacks.c:1015
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:939
+#: ../src/ca-cli-callbacks.c:1017
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:943
+#: ../src/ca-cli-callbacks.c:1021
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:945
+#: ../src/ca-cli-callbacks.c:1023
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:949
+#: ../src/ca-cli-callbacks.c:1027
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:951
+#: ../src/ca-cli-callbacks.c:1029
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:955
+#: ../src/ca-cli-callbacks.c:1033
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1035
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:961
+#: ../src/ca-cli-callbacks.c:1039
 msgid "Enable Time Stamping purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:963
-#, c-format
-msgid "* Time Stamping purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:967
-msgid "Enable OCSP Signing purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:968
-#, c-format
-msgid "* OCSP Signing purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:972
-msgid "Enable any purpose? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:974
-#, c-format
-msgid "* Any purpose disabled by policy\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid ""
-"All the mandatory data for the certificate generation has been gathered."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:982
-msgid "Do you want to proceed with the signing? [Yes]/No "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:988
-#, c-format
-msgid "Certificate signed.\n"
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This Certificate Signing Request will be deleted."
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1010
-msgid "This operation cannot be undone. Are you sure? Yes/[No] "
-msgstr ""
-
-#: ../src/ca-cli-callbacks.c:1016
-#, c-format
-msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:1041
 #, c-format
+msgid "* Time Stamping purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1045
+msgid "Enable OCSP Signing purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1046
+#, c-format
+msgid "* OCSP Signing purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1050
+msgid "Enable any purpose? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1052
+#, c-format
+msgid "* Any purpose disabled by policy\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid ""
+"All the mandatory data for the certificate generation has been gathered."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1060
+msgid "Do you want to proceed with the signing? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1066
+#, c-format
+msgid "Certificate signed.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This Certificate Signing Request will be deleted."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1088
+msgid "This operation cannot be undone. Are you sure? Yes/[No] "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1094
+#, c-format
+msgid "Certificate Signing Request deleted.\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1119
+#, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1058
+#: ../src/ca-cli-callbacks.c:1136
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1067
+#: ../src/ca-cli-callbacks.c:1145
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1079
+#: ../src/ca-cli-callbacks.c:1157
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1080
+#: ../src/ca-cli-callbacks.c:1158
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1083
+#: ../src/ca-cli-callbacks.c:1161
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1084 ../src/ca-cli-callbacks.c:1154
+#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1095
+#: ../src/ca-cli-callbacks.c:1173
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1102
+#: ../src/ca-cli-callbacks.c:1180
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1106
+#: ../src/ca-cli-callbacks.c:1184
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1110
+#: ../src/ca-cli-callbacks.c:1188
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1111 ../src/ca-cli-callbacks.c:1139
+#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1118 ../src/ca-cli-callbacks.c:1146
+#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1123
+#: ../src/ca-cli-callbacks.c:1201
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1128
+#: ../src/ca-cli-callbacks.c:1206
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1138
+#: ../src/ca-cli-callbacks.c:1216
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1150
+#: ../src/ca-cli-callbacks.c:1228
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1549,275 +1612,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1153
+#: ../src/ca-cli-callbacks.c:1231
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162
+#: ../src/ca-cli-callbacks.c:1240
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1168
+#: ../src/ca-cli-callbacks.c:1246
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1186
+#: ../src/ca-cli-callbacks.c:1264
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189
+#: ../src/ca-cli-callbacks.c:1267
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1205
+#: ../src/ca-cli-callbacks.c:1283
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1238
+#: ../src/ca-cli-callbacks.c:1316
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1242
+#: ../src/ca-cli-callbacks.c:1320
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1252
-#: ../src/ca-cli-callbacks.c:1311
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
+#: ../src/ca-cli-callbacks.c:1389
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246 ../src/ca-cli-callbacks.c:1247
-#: ../src/ca-cli-callbacks.c:1252 ../src/ca-cli-callbacks.c:1253
+#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
+#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1247 ../src/ca-cli-callbacks.c:1253
-#: ../src/ca-cli-callbacks.c:1315
+#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1393
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1251
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1274
+#: ../src/ca-cli-callbacks.c:1352
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1275
+#: ../src/ca-cli-callbacks.c:1353
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1276
+#: ../src/ca-cli-callbacks.c:1354
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1277
+#: ../src/ca-cli-callbacks.c:1355
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "SHA1-fingeravtryck"
 
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:1386
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1385
+#: ../src/ca-cli-callbacks.c:1463
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1464
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1387
+#: ../src/ca-cli-callbacks.c:1465
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:1466
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1467
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1390
+#: ../src/ca-cli-callbacks.c:1468
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:1469
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1392
+#: ../src/ca-cli-callbacks.c:1470
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1471
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1394
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1395
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1396
+#: ../src/ca-cli-callbacks.c:1474
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1397
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1398
+#: ../src/ca-cli-callbacks.c:1476
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1399
+#: ../src/ca-cli-callbacks.c:1477
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1400
+#: ../src/ca-cli-callbacks.c:1478
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1401
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1402
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1403
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1404
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1405
+#: ../src/ca-cli-callbacks.c:1483
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1406
+#: ../src/ca-cli-callbacks.c:1484
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1407
+#: ../src/ca-cli-callbacks.c:1485
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1408
+#: ../src/ca-cli-callbacks.c:1486
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1409
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1410
+#: ../src/ca-cli-callbacks.c:1488
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1411
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1425
+#: ../src/ca-cli-callbacks.c:1503
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1427
+#: ../src/ca-cli-callbacks.c:1505
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1429
+#: ../src/ca-cli-callbacks.c:1507
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1455
+#: ../src/ca-cli-callbacks.c:1533
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1545
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471 ../src/ca-cli-callbacks.c:1515
+#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1490
+#: ../src/ca-cli-callbacks.c:1568
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1492
+#: ../src/ca-cli-callbacks.c:1570
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1493
+#: ../src/ca-cli-callbacks.c:1571
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1583
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1511
+#: ../src/ca-cli-callbacks.c:1589
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1611
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1534
+#: ../src/ca-cli-callbacks.c:1612
 #, c-format
 msgid ""
 "\n"
@@ -1826,7 +1889,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1535 ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1834,14 +1897,14 @@ msgstr ""
 "  Daniel Nylander https://launchpad.net/~yeager\n"
 "  Marcus E https://launchpad.net/~marcus+e"
 
-#: ../src/ca-cli-callbacks.c:1536
+#: ../src/ca-cli-callbacks.c:1614
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1543
+#: ../src/ca-cli-callbacks.c:1621
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1859,7 +1922,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1561
+#: ../src/ca-cli-callbacks.c:1639
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1876,97 +1939,161 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1576
+#: ../src/ca-cli-callbacks.c:1654
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1585
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1586
+#: ../src/ca-cli-callbacks.c:1664
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1596
+#: ../src/ca-cli-callbacks.c:1674
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1637
+#: ../src/ca-cli-callbacks.c:1715
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1649
+#: ../src/ca-cli-callbacks.c:1727
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1655
+#: ../src/ca-cli-callbacks.c:1733
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1659
+#: ../src/ca-cli-callbacks.c:1737
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Skapar CA-rotcertifikat"
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1660
+#: ../src/ca-cli-callbacks.c:1738
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1736
+#: ../src/ca-cli-callbacks.c:1814
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Nyckelgenerering misslyckades"
 
-#: ../src/ca-cli-callbacks.c:1744
+#: ../src/ca-cli-callbacks.c:1822
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "CSR-generering misslyckades"
 
-#: ../src/ca-cli-callbacks.c:1753
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1764
+#: ../src/ca-cli-callbacks.c:1842
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1778
+#: ../src/ca-cli-callbacks.c:1856
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1802
+#: ../src/ca-cli-callbacks.c:1880
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1809
+#: ../src/ca-cli-callbacks.c:1887
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "_Certifikat"
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1810
+#: ../src/ca-cli-callbacks.c:1888
 msgid "Email Server"
 msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1902
+msgid "Usage: renewcert <cert-id>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+msgid "The given certificate id is not valid"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1911
+msgid ""
+"gnoMint will issue a new certificate with the same subject and SAN as this "
+"one, signed by the same CA, with a fresh keypair. The old certificate stays "
+"in place."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1914
+msgid "Renew? [Yes]/No "
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1925
+#, fuzzy
+msgid "Certificate renewed. New certificate id: %"
+msgstr "Certifikatgenerering misslyckades"
+
+#: ../src/ca-cli-callbacks.c:1933
+msgid "Usage: exportchain <cert-id> <filename>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1944
+msgid "Cannot build chain PEM for that certificate."
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1949
+#, fuzzy
+msgid "Cannot write chain file."
+msgstr "Lägg till ett autosignerat CA-certifikat"
+
+#: ../src/ca-cli-callbacks.c:1955
+#, c-format
+msgid "Full chain (leaf → root) written to %s\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1962
+msgid "Usage: revokemany <cert-id> [cert-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:1978
+#, fuzzy, c-format
+msgid "%d certificate revoked.\n"
+msgid_plural "%d certificates revoked.\n"
+msgstr[0] "Exportera certifikat"
+msgstr[1] "Exportera certifikat"
+
+#: ../src/ca-cli-callbacks.c:1986
+msgid "Usage: deletemany <csr-id> [csr-id ...]"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2002
+#, c-format
+msgid "%d CSR deleted.\n"
+msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ gnomint_SOURCES = \
         new_req_window.c \
 	new_cert.c \
 	cert_renewal.c \
+	ca_bulk.c \
 	creation_process_window.c \
 	dialog.c \
 	ca.c \
@@ -74,6 +75,8 @@ gnomint_cli_SOURCES = \
         ca_creation.c \
 	ca_file.c \
 	ca_policy.c \
+	ca_bulk.c \
+	cert_renewal.c \
 	crl.c \
         csr_creation.c \
         import.c \
@@ -81,7 +84,7 @@ gnomint_cli_SOURCES = \
 	preferences.c \
 	pkey_manage.c \
 	tls.c \
-	uint160.c 
+	uint160.c
 
 
 gnomint_cli_LDADD = \
@@ -111,6 +114,7 @@ EXTRA_DIST = \
 	new_req_window.h \
 	new_cert.h \
 	cert_renewal.h \
+	ca_bulk.h \
 	tls.h\
 	pkey_manage.h \
 	preferences.h \

--- a/src/ca-cli-callbacks.c
+++ b/src/ca-cli-callbacks.c
@@ -37,6 +37,8 @@
 #include "preferences.h"
 #include "tls.h"
 #include "crl.h"
+#include "ca_bulk.h"
+#include "cert_renewal.h"
 
 extern CaCommand ca_commands[];
 #define CA_COMMAND_NUMBER 33
@@ -413,8 +415,17 @@ int ca_cli_callback_addcsr (int argc, char **argv)
 			if (aux)
 				g_free (aux);
 
-			aux = dialog_ask_for_string (_("Enter type of key you are going to create (RSA/DSA)"), (csr_creation_data->key_type ? "DSA" : "RSA"));
-		} while (g_ascii_strcasecmp (aux, "RSA") && g_ascii_strcasecmp (aux, "DSA"));
+			aux = dialog_ask_for_string (
+			    _("Enter type of key you are going to create "
+			      "(RSA/DSA/ECDSA/Ed25519)"),
+			    csr_creation_data->key_type == 3 ? "Ed25519" :
+			    csr_creation_data->key_type == 2 ? "ECDSA" :
+			    csr_creation_data->key_type == 1 ? "DSA" : "RSA");
+		} while (g_ascii_strcasecmp (aux, "RSA") &&
+		         g_ascii_strcasecmp (aux, "DSA") &&
+		         g_ascii_strcasecmp (aux, "ECDSA") &&
+		         g_ascii_strcasecmp (aux, "Ed25519") &&
+		         g_ascii_strcasecmp (aux, "ED25519"));
 
 		if (! g_ascii_strcasecmp (aux, "RSA")) {
 			csr_creation_data->key_type = 0;
@@ -422,15 +433,36 @@ int ca_cli_callback_addcsr (int argc, char **argv)
 		} else if (! g_ascii_strcasecmp (aux, "DSA")) {
 			csr_creation_data->key_type = 1;
 			max_key_length = 3072;
+		} else if (! g_ascii_strcasecmp (aux, "ECDSA")) {
+			csr_creation_data->key_type = 2;
+			max_key_length = 521;
+		} else {
+			csr_creation_data->key_type = 3; /* Ed25519 */
+			max_key_length = 0; /* fixed */
 		}
 		g_free (aux);
 		aux = NULL;
-		
-		do {
-				csr_creation_data->key_bitlength = dialog_ask_for_number (_("Enter bitlength for the key (it must be a whole multiple of 1024)"),
-											  1024, max_key_length, csr_creation_data->key_bitlength);
-				
-		} while (csr_creation_data->key_bitlength % 1024);
+
+		if (csr_creation_data->key_type == 2 /* ECDSA */) {
+			/* P-256 / P-384 / P-521. */
+			do {
+				csr_creation_data->key_bitlength =
+				    dialog_ask_for_number (
+				        _("Enter curve size for ECDSA (256, 384, or 521)"),
+				        256, 521, csr_creation_data->key_bitlength ?
+				                  csr_creation_data->key_bitlength : 256);
+			} while (csr_creation_data->key_bitlength != 256 &&
+			         csr_creation_data->key_bitlength != 384 &&
+			         csr_creation_data->key_bitlength != 521);
+		} else if (csr_creation_data->key_type == 3 /* Ed25519 */) {
+			csr_creation_data->key_bitlength = 0;
+		} else {
+			do {
+				csr_creation_data->key_bitlength = dialog_ask_for_number (
+				    _("Enter bitlength for the key (it must be a whole multiple of 1024)"),
+				    1024, max_key_length, csr_creation_data->key_bitlength);
+			} while (csr_creation_data->key_bitlength % 1024);
+		}
 
 		printf (_("These are the provided CSR properties:\n"));
 
@@ -452,8 +484,19 @@ int ca_cli_callback_addcsr (int argc, char **argv)
 		if (csr_creation_data->subject_alt_name && csr_creation_data->subject_alt_name[0])
 			printf (_("\tSubject Alternative Names: %s\n"), csr_creation_data->subject_alt_name);
 		printf (_("Key pair\n"));
-		printf (_("\tType: %s\n"), (csr_creation_data->key_type ? "DSA" : "RSA"));
-		printf (_("\tKey bitlength: %d\n"), csr_creation_data->key_bitlength);
+		{
+			const gchar *type_name =
+			    csr_creation_data->key_type == 3 ? "Ed25519" :
+			    csr_creation_data->key_type == 2 ? "ECDSA" :
+			    csr_creation_data->key_type == 1 ? "DSA" : "RSA";
+			printf (_("\tType: %s\n"), type_name);
+			if (csr_creation_data->key_type == 3)
+				printf (_("\tKey size: fixed (Ed25519)\n"));
+			else if (csr_creation_data->key_type == 2)
+				printf (_("\tCurve: P-%d\n"), csr_creation_data->key_bitlength);
+			else
+				printf (_("\tKey bitlength: %d\n"), csr_creation_data->key_bitlength);
+		}
 
 		change_data = dialog_ask_for_confirmation (NULL, _("Do you want to change anything? Yes/[No] "), FALSE);
 
@@ -562,21 +605,50 @@ int ca_cli_callback_addca (int argc, char **argv)
 			if (aux)
 				g_free (aux);
 
-			aux = dialog_ask_for_string (_("Enter type of key you are going to create (RSA/DSA)"), (ca_creation_data->key_type ? "DSA" : "RSA"));
-		} while (g_ascii_strcasecmp (aux, "RSA") && g_ascii_strcasecmp (aux, "DSA"));
-		
+			aux = dialog_ask_for_string (
+			    _("Enter type of key you are going to create "
+			      "(RSA/DSA/ECDSA/Ed25519)"),
+			    ca_creation_data->key_type == 3 ? "Ed25519" :
+			    ca_creation_data->key_type == 2 ? "ECDSA" :
+			    ca_creation_data->key_type == 1 ? "DSA" : "RSA");
+		} while (g_ascii_strcasecmp (aux, "RSA") &&
+		         g_ascii_strcasecmp (aux, "DSA") &&
+		         g_ascii_strcasecmp (aux, "ECDSA") &&
+		         g_ascii_strcasecmp (aux, "Ed25519") &&
+		         g_ascii_strcasecmp (aux, "ED25519"));
+
 		if (! g_ascii_strcasecmp (aux, "RSA")) {
 			ca_creation_data->key_type = 0;
 		} else if (! g_ascii_strcasecmp (aux, "DSA")) {
 			ca_creation_data->key_type = 1;
+		} else if (! g_ascii_strcasecmp (aux, "ECDSA")) {
+			ca_creation_data->key_type = 2;
+		} else {
+			ca_creation_data->key_type = 3; /* Ed25519 */
 		}
 		g_free (aux);
 		aux = NULL;
-		
-		do {
-			ca_creation_data->key_bitlength = dialog_ask_for_number (_("Enter bitlength for the key (it must be a whole multiple of 1024)"),
-									     1024,10240,ca_creation_data->key_bitlength);
-		} while (ca_creation_data->key_bitlength % 1024);
+
+		if (ca_creation_data->key_type == 2 /* ECDSA */) {
+			do {
+				ca_creation_data->key_bitlength =
+				    dialog_ask_for_number (
+				        _("Enter curve size for ECDSA (256, 384, or 521)"),
+				        256, 521, ca_creation_data->key_bitlength ?
+				                  ca_creation_data->key_bitlength : 256);
+			} while (ca_creation_data->key_bitlength != 256 &&
+			         ca_creation_data->key_bitlength != 384 &&
+			         ca_creation_data->key_bitlength != 521);
+		} else if (ca_creation_data->key_type == 3 /* Ed25519 */) {
+			ca_creation_data->key_bitlength = 0;
+		} else {
+			gint max_len = (ca_creation_data->key_type == 1) ? 3072 : 10240;
+			do {
+				ca_creation_data->key_bitlength = dialog_ask_for_number (
+				    _("Enter bitlength for the key (it must be a whole multiple of 1024)"),
+				    1024, max_len, ca_creation_data->key_bitlength);
+			} while (ca_creation_data->key_bitlength % 1024);
+		}
 
 
 		ca_creation_data->key_months_before_expiration = dialog_ask_for_number (_("Introduce number of months before expiration of the new certification authority"),
@@ -620,7 +692,13 @@ int ca_cli_callback_addca (int argc, char **argv)
 		if (ca_creation_data->subject_alt_name && ca_creation_data->subject_alt_name[0])
 			printf (_("\tSubject Alternative Names: %s\n"), ca_creation_data->subject_alt_name);
 		printf (_("Key pair\n"));
-		printf (_("\tType: %s\n"), (ca_creation_data->key_type ? "DSA" : "RSA"));
+		{
+			const gchar *type_name =
+			    ca_creation_data->key_type == 3 ? "Ed25519" :
+			    ca_creation_data->key_type == 2 ? "ECDSA" :
+			    ca_creation_data->key_type == 1 ? "DSA" : "RSA";
+			printf (_("\tType: %s\n"), type_name);
+		}
 		printf (_("\tKey bitlength: %d\n"), ca_creation_data->key_bitlength);
 		printf (_("Validity\n"));
 		printf (_("Validity:\n"));
@@ -1809,5 +1887,119 @@ int ca_cli_callback_addservercert (int argc, char **argv)
 	printf(_("Certificate generated successfully for: %s\n"), server_name);
 	printf(_("Certificate type: %s\n"), is_web_server ? _("Web Server") : _("Email Server"));
 
+	return 0;
+}
+
+
+/* ------------------------------------------------------------------ */
+/*  Renew, exportchain, revokemany, deletemany — CLI parity for the   */
+/*  GUI features added in #49 / #50 / #52 / #54.                      */
+/* ------------------------------------------------------------------ */
+
+int ca_cli_callback_renew (int argc, char **argv)
+{
+	if (argc < 2) {
+		dialog_error (_("Usage: renewcert <cert-id>"));
+		return -1;
+	}
+	guint64 id = atoll (argv[1]);
+	if (! ca_file_check_if_is_cert_id (id)) {
+		dialog_error (_("The given certificate id is not valid"));
+		return -1;
+	}
+	if (! dialog_ask_for_confirmation (
+	        _("gnoMint will issue a new certificate with the same subject "
+	          "and SAN as this one, signed by the same CA, with a fresh "
+	          "keypair. The old certificate stays in place."),
+	        _("Renew? [Yes]/No "), TRUE)) {
+		printf (_("Operation cancelled.\n"));
+		return 0;
+	}
+	guint64 new_id = 0;
+	gchar *err = cert_renewal_renew (id, &new_id);
+	if (err) {
+		dialog_error (err);
+		g_free (err);
+		return -1;
+	}
+	printf (_("Certificate renewed. New certificate id: %" G_GUINT64_FORMAT "\n"),
+	        new_id);
+	return 0;
+}
+
+int ca_cli_callback_exportchain (int argc, char **argv)
+{
+	if (argc < 3) {
+		dialog_error (_("Usage: exportchain <cert-id> <filename>"));
+		return -1;
+	}
+	guint64 id = atoll (argv[1]);
+	if (! ca_file_check_if_is_cert_id (id)) {
+		dialog_error (_("The given certificate id is not valid"));
+		return -1;
+	}
+	gchar *chain = ca_file_get_chain_pem_from_id (id);
+	if (!chain || !*chain) {
+		g_free (chain);
+		dialog_error (_("Cannot build chain PEM for that certificate."));
+		return -1;
+	}
+	GError *gerr = NULL;
+	if (! g_file_set_contents (argv[2], chain, -1, &gerr)) {
+		dialog_error (gerr ? gerr->message : _("Cannot write chain file."));
+		g_clear_error (&gerr);
+		g_free (chain);
+		return -1;
+	}
+	g_free (chain);
+	printf (_("Full chain (leaf → root) written to %s\n"), argv[2]);
+	return 0;
+}
+
+int ca_cli_callback_revokemany (int argc, char **argv)
+{
+	if (argc < 2) {
+		dialog_error (_("Usage: revokemany <cert-id> [cert-id ...]"));
+		return -1;
+	}
+	GSList *ids = NULL;
+	for (int i = 1; i < argc; i++) {
+		guint64 id = atoll (argv[i]);
+		if (id != 0)
+			ids = g_slist_prepend (ids, GUINT_TO_POINTER ((guint) id));
+	}
+	gchar *err = NULL;
+	gint done = ca_bulk_revoke_ids (ids, &err);
+	g_slist_free (ids);
+	if (err) {
+		dialog_error (err);
+		g_free (err);
+	}
+	printf (ngettext ("%d certificate revoked.\n",
+	                  "%d certificates revoked.\n", done), done);
+	return 0;
+}
+
+int ca_cli_callback_deletemany (int argc, char **argv)
+{
+	if (argc < 2) {
+		dialog_error (_("Usage: deletemany <csr-id> [csr-id ...]"));
+		return -1;
+	}
+	GSList *ids = NULL;
+	for (int i = 1; i < argc; i++) {
+		guint64 id = atoll (argv[i]);
+		if (id != 0)
+			ids = g_slist_prepend (ids, GUINT_TO_POINTER ((guint) id));
+	}
+	gchar *err = NULL;
+	gint done = ca_bulk_delete_csr_ids (ids, &err);
+	g_slist_free (ids);
+	if (err) {
+		dialog_error (err);
+		g_free (err);
+	}
+	printf (ngettext ("%d CSR deleted.\n",
+	                  "%d CSRs deleted.\n", done), done);
 	return 0;
 }

--- a/src/ca-cli-callbacks.h
+++ b/src/ca-cli-callbacks.h
@@ -48,3 +48,7 @@ int ca_cli_callback_version  (int argc, char **argv);
 int ca_cli_callback_help  (int argc, char **argv);
 int ca_cli_callback_exit (int argc, char **argv);
 int ca_cli_callback_addservercert (int argc, char **argv);
+int ca_cli_callback_renew (int argc, char **argv);
+int ca_cli_callback_exportchain (int argc, char **argv);
+int ca_cli_callback_revokemany (int argc, char **argv);
+int ca_cli_callback_deletemany (int argc, char **argv);

--- a/src/ca-cli.c
+++ b/src/ca-cli.c
@@ -28,8 +28,11 @@
 #include <readline/history.h>
 #include <unistd.h>
 
+#include <time.h>
+
 #include "ca-cli.h"
 #include "ca_file.h"
+#include "preferences.h"
 #include "ca-cli-callbacks.h"
 
 
@@ -64,6 +67,10 @@ CaCommand ca_commands[] = {
 	{"showpreferences", 0, 0, "showpreferences", N_("Show program preferences"), ca_cli_callback_showpreferences}, // 22
 	{"setpreference", 2, 2, N_("setpreference <preference-id> <value>"), N_("Set the given program preference"), ca_cli_callback_setpreference}, // 23
 	{"addservercert", 3, 3, N_("addservercert <ca-id> <cert-type> <server-name>"), N_("Quick server certificate generation (cert-type: 'web' or 'email')"), ca_cli_callback_addservercert}, // 24
+	{"renewcert", 1, 1, N_("renewcert <cert-id>"), N_("Reissue a certificate with the same subject + SAN and a fresh keypair. The old certificate remains in the database."), ca_cli_callback_renew},
+	{"exportchain", 2, 2, N_("exportchain <cert-id> <filename>"), N_("Export the full certificate chain (leaf → root) for the given certificate as a PEM bundle."), ca_cli_callback_exportchain},
+	{"revokemany", 1, 64, N_("revokemany <cert-id> [cert-id ...]"), N_("Revoke many certificates at once. Non-cert ids are silently skipped."), ca_cli_callback_revokemany},
+	{"deletemany", 1, 64, N_("deletemany <csr-id> [csr-id ...]"), N_("Delete many CSRs at once. Non-CSR ids are silently skipped."), ca_cli_callback_deletemany},
 	{"about", 0, 0, "about", N_("Show about message"), ca_cli_callback_about}, // 25
 	{"warranty", 0, 0, "warranty", N_("Show warranty information"), ca_cli_callback_warranty}, // 26
 	{"distribution", 0, 0, "distribution", N_("Show distribution information"), ca_cli_callback_distribution}, // 27
@@ -73,7 +80,7 @@ CaCommand ca_commands[] = {
 	{"exit", 0, 0, "exit", N_("Close database and exit program"), ca_cli_callback_exit}, // 31
 	{"bye", 0, 0, "bye", N_("Close database and exit program"), ca_cli_callback_exit} // 32
 };
-#define CA_COMMAND_NUMBER 33
+#define CA_COMMAND_NUMBER 37
 
 
 
@@ -89,17 +96,64 @@ gboolean ca_refresh_model (void)
 
 
 
-gboolean ca_open (gchar *filename, gboolean create) 
+/* Walked over ca_file_foreach_crt to count certs whose own notAfter is
+ * within the configured warning window. CLI-only; the GUI does the
+ * same accounting with cascade-aware expiration via ca.c. */
+typedef struct {
+	time_t now;
+	time_t threshold;
+	gint   count;
+} ExpiringCountCtx;
+
+static int
+__ca_cli_count_expiring (void *pArg, int argc, char **argv, char **columnNames)
+{
+	ExpiringCountCtx *ctx = (ExpiringCountCtx *) pArg;
+	if (argc <= CA_FILE_CERT_COLUMN_EXPIRATION) return 0;
+	if (argv[CA_FILE_CERT_COLUMN_REVOCATION] &&
+	    argv[CA_FILE_CERT_COLUMN_REVOCATION][0])
+		return 0;  /* revoked — skip */
+	if (!argv[CA_FILE_CERT_COLUMN_EXPIRATION]) return 0;
+	time_t exp = (time_t) atoll (argv[CA_FILE_CERT_COLUMN_EXPIRATION]);
+	if (exp <= 0) return 0;
+	if (exp >= ctx->now && exp < ctx->threshold)
+		ctx->count++;
+	return 0;
+}
+
+gboolean ca_open (gchar *filename, gboolean create)
 {
         gboolean result;
 
         fprintf (stderr, _("Opening database %s..."), filename);
-        result = ca_file_open (filename, create); 
-        
+        result = ca_file_open (filename, create);
+
         if (result)
                 fprintf (stderr, _(" OK.\n"));
         else
                 fprintf (stderr, _(" Error.\n"));
+
+	if (result) {
+		/* Mirror of the GUI banner (#56). Count certs whose
+		 * notAfter is within `expire-warning-days` and print a
+		 * notice on stderr. */
+		gint warn_days = preferences_get_expire_warning_days ();
+		if (warn_days > 0) {
+			ExpiringCountCtx ctx;
+			ctx.now = time (NULL);
+			ctx.threshold = ctx.now + (time_t) warn_days * 86400;
+			ctx.count = 0;
+			ca_file_foreach_crt (__ca_cli_count_expiring, FALSE, &ctx);
+			if (ctx.count > 0) {
+				fprintf (stderr, ngettext (
+				    "Notice: %d certificate expires within the "
+				    "next %d days. Use `renewcert <id>` to reissue.\n",
+				    "Notice: %d certificates expire within the "
+				    "next %d days. Use `renewcert <id>` to reissue.\n",
+				    ctx.count), ctx.count, warn_days);
+			}
+		}
+	}
 
 	return result;
 }

--- a/src/ca.c
+++ b/src/ca.c
@@ -32,6 +32,7 @@
 
 
 #include "ca.h"
+#include "ca_bulk.h"
 #include "ca_file.h"
 #include "certificate_properties.h"
 #include "crl.h"
@@ -1498,61 +1499,8 @@ G_MODULE_EXPORT void ca_on_export_chain_activate (GtkMenuItem *menuitem G_GNUC_U
 /*  Bulk operations (issue #54)                                       */
 /* ------------------------------------------------------------------ */
 
-/* Revoke every certificate whose id is in `cert_ids`. Skips entries
- * that aren't certs or are already revoked. Returns the count of
- * actually-revoked entries; if `error_out` is non-NULL, the first
- * underlying error is stored there (caller frees with g_free). */
-gint
-ca_bulk_revoke_ids (GSList *cert_ids, gchar **error_out)
-{
-	gint count = 0;
-	if (error_out)
-		*error_out = NULL;
-	for (GSList *l = cert_ids; l; l = l->next) {
-		guint64 id = GPOINTER_TO_UINT (l->data);
-		if (id == 0)
-			continue;
-		if (! ca_file_check_if_is_cert_id (id))
-			continue;
-		gchar *err = ca_file_revoke_crt (id);
-		if (err) {
-			if (error_out && ! *error_out)
-				*error_out = err;
-			else
-				g_free (err);
-			continue;
-		}
-		count++;
-	}
-	return count;
-}
-
-/* Delete every CSR whose id is in `csr_ids`. Skips entries that aren't
- * CSRs. Returns the count of actually-deleted entries. */
-gint
-ca_bulk_delete_csr_ids (GSList *csr_ids, gchar **error_out)
-{
-	gint count = 0;
-	if (error_out)
-		*error_out = NULL;
-	for (GSList *l = csr_ids; l; l = l->next) {
-		guint64 id = GPOINTER_TO_UINT (l->data);
-		if (id == 0)
-			continue;
-		if (! ca_file_check_if_is_csr_id (id))
-			continue;
-		gchar *err = ca_file_remove_csr (id);
-		if (err) {
-			if (error_out && ! *error_out)
-				*error_out = err;
-			else
-				g_free (err);
-			continue;
-		}
-		count++;
-	}
-	return count;
-}
+/* The actual ca_bulk_revoke_ids / ca_bulk_delete_csr_ids implementations
+ * live in ca_bulk.c so the CLI can link them too. */
 
 /* Helper: walk the tree selection, partitioning selected rows into a
  * list of cert ids and a list of CSR ids. The returned GSLists are

--- a/src/ca_bulk.c
+++ b/src/ca_bulk.c
@@ -1,0 +1,54 @@
+/* Bulk certificate / CSR operations. See ca_bulk.h. */
+
+#include "ca_bulk.h"
+#include "ca_file.h"
+
+gint
+ca_bulk_revoke_ids (GSList *cert_ids, gchar **error_out)
+{
+	gint count = 0;
+	if (error_out)
+		*error_out = NULL;
+	for (GSList *l = cert_ids; l; l = l->next) {
+		guint64 id = GPOINTER_TO_UINT (l->data);
+		if (id == 0)
+			continue;
+		if (! ca_file_check_if_is_cert_id (id))
+			continue;
+		gchar *err = ca_file_revoke_crt (id);
+		if (err) {
+			if (error_out && ! *error_out)
+				*error_out = err;
+			else
+				g_free (err);
+			continue;
+		}
+		count++;
+	}
+	return count;
+}
+
+gint
+ca_bulk_delete_csr_ids (GSList *csr_ids, gchar **error_out)
+{
+	gint count = 0;
+	if (error_out)
+		*error_out = NULL;
+	for (GSList *l = csr_ids; l; l = l->next) {
+		guint64 id = GPOINTER_TO_UINT (l->data);
+		if (id == 0)
+			continue;
+		if (! ca_file_check_if_is_csr_id (id))
+			continue;
+		gchar *err = ca_file_remove_csr (id);
+		if (err) {
+			if (error_out && ! *error_out)
+				*error_out = err;
+			else
+				g_free (err);
+			continue;
+		}
+		count++;
+	}
+	return count;
+}

--- a/src/ca_bulk.h
+++ b/src/ca_bulk.h
@@ -1,0 +1,20 @@
+/* Bulk certificate / CSR operations.
+ * Pure DB-layer helpers shared by the GUI (ca.c) and the CLI
+ * (ca-cli-callbacks.c). No GTK / readline dependencies. */
+
+#ifndef _CA_BULK_H_
+#define _CA_BULK_H_
+
+#include <glib.h>
+
+/* Revoke every certificate whose id is in `cert_ids`. Skips entries
+ * that aren't certs or are already revoked. Returns the count of
+ * actually-revoked entries. If `error_out` is non-NULL, the first
+ * underlying error is stored there (caller frees with g_free). */
+gint ca_bulk_revoke_ids (GSList *cert_ids, gchar **error_out);
+
+/* Delete every CSR whose id is in `csr_ids`. Skips entries that aren't
+ * CSRs. Returns the count of actually-deleted entries. */
+gint ca_bulk_delete_csr_ids (GSList *csr_ids, gchar **error_out);
+
+#endif

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -43,6 +43,13 @@ void preferences_set_gnome_keyring_export (gboolean new_value)
         g_settings_set_boolean (preferences_settings, "gnome-keyring-export", new_value);
 }
 
+gint preferences_get_expire_warning_days (void)
+{
+        if (!preferences_settings)
+                return 30;  /* default if uninitialised */
+        return g_settings_get_int (preferences_settings, "expire-warning-days");
+}
+
 
 void preferences_deinit ()
 {

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -25,6 +25,8 @@ void preferences_init (int, char**);
 gboolean preferences_get_gnome_keyring_export (void);
 void preferences_set_gnome_keyring_export (gboolean new_value);
 
+gint preferences_get_expire_warning_days (void);
+
 void preferences_deinit (void);
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,7 +11,7 @@
 ##                           user environment is Wayland.
 
 TESTS = check_y2k38 check_ui_consistency check_workflows \
-        check_cli_email.sh check_cli_wizard.sh
+        check_cli_email.sh check_cli_wizard.sh check_cli_parity.sh
 check_PROGRAMS = check_y2k38 check_ui_consistency check_workflows
 
 # Per-test wrapper: only check_workflows runs under a headless Wayland
@@ -19,7 +19,7 @@ check_PROGRAMS = check_y2k38 check_ui_consistency check_workflows
 # spawn gnomint-cli directly so they need no display either.
 check_workflows_LOG_COMPILER = $(srcdir)/run-headless.sh
 
-EXTRA_DIST = run-headless.sh check_cli_email.sh check_cli_wizard.sh
+EXTRA_DIST = run-headless.sh check_cli_email.sh check_cli_wizard.sh check_cli_parity.sh
 
 # ---------------------------------------------------------------
 # Y2K38 verification — no GUI dependencies, just stdio + time.h.
@@ -55,6 +55,7 @@ check_ui_consistency_SOURCES = \
 	$(top_srcdir)/src/new_req_window.c \
 	$(top_srcdir)/src/new_cert.c \
 	$(top_srcdir)/src/cert_renewal.c \
+	$(top_srcdir)/src/ca_bulk.c \
 	$(top_srcdir)/src/creation_process_window.c \
 	$(top_srcdir)/src/dialog.c \
 	$(top_srcdir)/src/ca.c \
@@ -115,6 +116,7 @@ check_workflows_SOURCES = \
 	$(top_srcdir)/src/new_req_window.c \
 	$(top_srcdir)/src/new_cert.c \
 	$(top_srcdir)/src/cert_renewal.c \
+	$(top_srcdir)/src/ca_bulk.c \
 	$(top_srcdir)/src/creation_process_window.c \
 	$(top_srcdir)/src/dialog.c \
 	$(top_srcdir)/src/ca.c \

--- a/tests/check_cli_parity.sh
+++ b/tests/check_cli_parity.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# tests/check_cli_parity.sh — exercises the CLI commands added in the
+# GUI/CLI parity pass: renewcert, exportchain, revokemany, deletemany.
+# Pinned to LC_ALL=C so prompts accept the literal "Yes" string.
+set -euo pipefail
+
+GNOMINT_CLI=${GNOMINT_CLI:-../src/gnomint-cli}
+SRCDIR="${srcdir:-.}"
+FIXTURE="${FIXTURE:-${SRCDIR}/../certs/example-ca.gnomint}"
+
+CLI="$GNOMINT_CLI"
+if [ ! -x "$CLI" ]; then
+    echo "SKIP: $CLI not built or not executable" >&2
+    exit 77
+fi
+if [ ! -r "$FIXTURE" ]; then
+    echo "SKIP: fixture $FIXTURE not readable" >&2
+    exit 77
+fi
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+DB="$TMPDIR/cli-parity.gnomint"
+CHAIN="$TMPDIR/chain.pem"
+
+cp "$FIXTURE" "$DB"
+
+LC_ALL=C "$CLI" "$DB" >"$TMPDIR/out.txt" 2>&1 <<EOF
+renewcert 2
+Yes
+exportchain 2 $CHAIN
+revokemany 5 6
+deletemany 1
+quit
+EOF
+
+grep -q "Certificate renewed" "$TMPDIR/out.txt"
+grep -q "Full chain.*written to $CHAIN" "$TMPDIR/out.txt"
+grep -q "2 certificates revoked" "$TMPDIR/out.txt"
+grep -q "CSR deleted" "$TMPDIR/out.txt"
+
+# Confirm chain has at least 2 BEGIN markers (leaf + root for a level-1 cert)
+BEGIN=$(grep -c "BEGIN CERTIFICATE" "$CHAIN")
+if [ "$BEGIN" -lt 2 ]; then
+    echo "FAIL: chain has only $BEGIN BEGIN markers (expected >= 2)"
+    exit 1
+fi
+
+echo "PASS: renewcert / exportchain / revokemany / deletemany all work end-to-end"


### PR DESCRIPTION
## Summary
Backfills \`gnomint-cli\` with every feature merged into the GUI in #61, #62, #63, #64, #65. Every GUI menu item now has a matching CLI verb, and the existing \`addca\`/\`addcsr\` prompts accept the new key algorithms.

| Feature | New CLI surface |
|---|---|
| #49 ECDSA / Ed25519 | \`addca\` / \`addcsr\` prompts: RSA / DSA / ECDSA / Ed25519. ECDSA asks for curve size; Ed25519 skips bit-length. |
| #50 Renewal | \`renewcert <id>\` reissues with fresh keypair |
| #52 Chain export | \`exportchain <id> <filename>\` writes leaf→root PEM bundle |
| #54 Bulk revoke | \`revokemany <id1> [id2 …]\` |
| #54 Bulk delete CSRs | \`deletemany <id1> [id2 …]\` |
| #56 Startup banner | \`ca_open\` prints a "Notice: N expire within D days" line on stderr |

## Plumbing
- Extracted \`ca_bulk_revoke_ids\` / \`ca_bulk_delete_csr_ids\` from \`ca.c\` into \`src/ca_bulk.{c,h}\` so both binaries can link them.
- \`cert_renewal.c\` is now compiled into both binaries.
- \`preferences.{c,h}\` (CLI variant) gains \`preferences_get_expire_warning_days\` mirroring the GUI helper.

## Test plan
- [x] \`make\` clean (no warnings)
- [x] \`make -C tests check\` — 6 suites pass, including the new \`check_cli_parity.sh\` which:
  - renews fixture cert id 2
  - asserts a chain PEM with ≥ 2 BEGIN markers
  - bulk-revokes 5 + 6 (asserts "2 certificates revoked")
  - bulk-deletes CSR id 1
- [x] Hand-pipe smoke: all four commands return the expected text.

## Note
The CLI's startup expiry notice uses each cert's own \`notAfter\` without cascade. The GUI applies RFC 5280 cascade-from-issuer logic via \`ca_effective_expiration\` in \`ca.c\`; lifting that into a shared module is a follow-up so the CLI count exactly matches the GUI count. Pragmatic for now since the difference only matters when an intermediate CA is itself expiring sooner than its leaves.