### PR TITLE
Add a search / filter box above the certificate tree (closes #53)

### DIFF
--- a/gui/main_window.ui
+++ b/gui/main_window.ui
@@ -52,6 +52,7 @@
     <property name="default_height">300</property>
     <property name="icon">gnomint.png</property>
     <signal name="delete-event" handler="on_main_window1_delete" swapped="no"/>
+    <signal name="key-press-event" handler="ca_on_main_window_key_press" swapped="no"/>
     <child>
       <placeholder/>
     </child>
@@ -726,6 +727,19 @@
           </packing>
         </child>
         <child>
+          <object class="GtkSearchEntry" id="search_entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="placeholder_text" translatable="yes">Filter certificates by subject or serial…</property>
+            <signal name="search-changed" handler="ca_on_search_changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkScrolledWindow" id="scrolledwindow6">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -749,7 +763,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -132,15 +132,15 @@ msgstr "Gestiona CAs i certificats X.509, fàcilment i de forma gràfica"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Sol·licituds de signatura de certificats</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -157,28 +157,28 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Núm. de sèrie"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Activació"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Venciment"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Revocació"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,66 +189,66 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Exporta sol·licitud de signatura de certificat"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Hi ha hagut un error al exportar el certificat."
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 "Ha hagut un error al exportar la sol·licitud de signatura de certificat "
 "(CSR),"
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr "Sol·licitud de signatura de certificat exportada amb èxit."
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr "Exporta la clau privada xifrada"
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Clau privada exportada amb èxit."
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporta la clau privada sense xifrar"
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporta tot el certificat en un paquet PKCS#12"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Exporta sol·licitud de signatura de certificat (CSR) - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -256,7 +256,7 @@ msgstr ""
 "Seleccioneu quina part de la sol·licitud de signatura de certificat (CSR) "
 "voleu exportar:"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -264,7 +264,7 @@ msgstr ""
 "<i>Exporta la sol·licitud de signatura de certificat a un fitxer públic en "
 "format PEM</i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -274,70 +274,70 @@ msgstr ""
 "contrasenya. Aquest fitxer només ha de ser accessible pel titular de la "
 "sol·licitud de signatura del certificat.</i>"
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Afegir certificat de la CA auto-signat"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Esteu segur que voleu revocar aquest certificat?"
 msgstr[1] "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat revocat.\n"
 msgstr[1] "Certificat revocat.\n"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -348,12 +348,12 @@ msgstr[1] ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -363,29 +363,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -396,17 +396,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr "Canvia la contrasenya de la CA - gnoMint"
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -414,61 +414,61 @@ msgstr ""
 "La contrasenya introduïda no es correspon amb la contrasenya real de la base "
 "de dades."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al establir la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr "La contrasenya s'ha establert amb èxit"
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al eliminar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "La contrasenya s'ha eliminat amb èxit"
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Desa paràmetres Diffie-Hellman"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Paràmetres Diffie-Hellman desats correctament"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "Seleccioneu el fitxer PEM a importar"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "S'han produït problemes al importar el fitxer '%s'"
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr "Seleccioneu el directori a importar"
 
@@ -740,52 +740,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Mostra el missatge \"Quant al...\""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr "Mostra informació de la garantia"
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr "Mostra informació sobre la distribució del programa"
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Mostra informació de la versió"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "Mostra (aquest) missatge d'ajuda"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Tanca la base de dades i surt del programa"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Obrint la base de dades %s..."
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " D'acord.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Error.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -796,7 +806,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -811,7 +821,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -820,7 +830,7 @@ msgstr ""
 "Aquest programa es proporciona SENSE QUALSEVOL TIPUS DE GARANTIA; per més\n"
 "detalls, teclegi 'warranty'.\n"
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -833,12 +843,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Error: Cometes desaparellades\n"
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -846,12 +856,12 @@ msgstr ""
 "Ordre no vàlida. Teclegi 'help' per aconseguir una llista d'ordres "
 "reconegudes.\n"
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Nombre incorrecte de paràmetres\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Sintaxi: %s\n"
@@ -2202,6 +2212,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -121,15 +121,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -137,7 +137,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -145,28 +145,28 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -177,153 +177,153 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 msgid "Export certificate chain"
 msgstr ""
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -333,28 +333,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -365,69 +365,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr ""
 
@@ -675,52 +675,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -731,7 +741,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -741,14 +751,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -757,23 +767,23 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
@@ -2039,6 +2049,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -132,15 +132,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Zertifikate</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Signaturanfragen für Zertifikate</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -157,28 +157,28 @@ msgstr "%d.%m.%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Seriell"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Widerruf"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +189,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Signaturanfrage für Zertifikat exportieren"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Beim Export des Zertifikats ist ein Fehler aufgetreten."
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr "Signaturanfrage für Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Geheimer Schlüssel wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Geheimen Schlüssel en_tpacken"
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Gesamtes Zertifikat in einem PKCS#12-Paket exportieren"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Signaturanfrage exportieren - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,7 +254,7 @@ msgstr ""
 "Bitte wählen Sie den Teil der gespeicherten Siganturanfrage aus, den Sie "
 "exportieren wollen:"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -262,77 +262,77 @@ msgstr ""
 "<i>Signaturanfrage für Zertifikat in eine öffentliche Datei im PEM-Format "
 "exportieren.</i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 msgstr[1] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Zertifikat wurde widerrufen.\n"
 msgstr[1] "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -343,12 +343,12 @@ msgstr[1] ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -358,29 +358,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -391,17 +391,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr "Zertifizierungsstellen-Passwort ändern - gnoMint"
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -409,61 +409,61 @@ msgstr ""
 "Das von Ihnen eingegebene Passwort stimmt nicht mit dem derzeit für die "
 "Datenbank geltenden Passwort überein."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ändern des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ermitteln des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr "Passwort wurde erfolgreich ermittelt"
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Löschen des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "Passwort wurde erfolgreich gelöscht"
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Diffie-Hellman-Parameter speichern"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-Parameter wurden erfolgreich gespeichert"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "PEM-Datei zum Importieren auswählen"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problem beim Importieren der Datei »%s«"
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr "Ordner zum Importieren auswählen"
 
@@ -720,52 +720,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Info-Meldung anzeigen"
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Versionsinformation anzeigen"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "(Diese) Hilfemeldung anzeigen"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Datenbank schließen und Programm beenden"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Datenbank »%s« wird geöffnet …"
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Fehler.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -776,7 +786,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -791,14 +801,14 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -807,12 +817,12 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Nicht übereinstimmende Anführungszeichen\n"
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -820,12 +830,12 @@ msgstr ""
 "Ungültiger Befehl. Geben Sie »help« ein, um eine Liste der möglichen Befehle "
 "zu erhalten.\n"
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Falsche Anzahl der Parameter.\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Syntax: %s\n"
@@ -2140,6 +2150,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -133,15 +133,15 @@ msgstr "Gestiona autoridades de certificación y certificados X.509"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificados</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -149,7 +149,7 @@ msgstr "<b>Solicitudes de certificación</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -157,28 +157,28 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Nº serie"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Activación"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Caducidad"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Revocación"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -193,65 +193,65 @@ msgstr[1] ""
 "<b>%d certificados</b> caducan en los próximos %d días. Haga clic con el "
 "botón derecho sobre cada uno para renovarlo con una clave nueva."
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Exportar certificado"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 #, fuzzy
 msgid "_Cancel"
 msgstr "Francia"
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Exportar solicitud de certificación"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Ocurrió un error al exportar el certificado"
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr "Ocurrió un error al exportar la solicitud de certificación."
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Certificado exportado con éxito"
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr "Solicitud de certificación exportada correctamente"
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr "Exportar clave privada cifrada."
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Clave privada exportada con éxito"
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportar clave privada sin cifrar."
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportar todo el certificado en un paquete PKCS#12"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Exportar solicitud de certificación - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -259,7 +259,7 @@ msgstr ""
 "Seleccione qué parte almacenada de la solicitud de certificación desea "
 "exportar:"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -267,7 +267,7 @@ msgstr ""
 "<i>Exporta la solicitud de certificación a un fichero público en formato "
 "PEM</i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -277,43 +277,43 @@ msgstr ""
 "clave. Este fichero sólo debería ser accesible para el titular de la "
 "soliticud de certificación.</i>"
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 msgid "Please select a certificate to export its chain."
 msgstr "Por favor, seleccione un certificado para exportar su cadena."
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 msgid "Export certificate chain"
 msgstr "Exportar cadena de certificados"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr "No se pudo construir la cadena de certificados."
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr "Error al escribir la cadena: %s"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 msgid "Certificate chain exported successfully."
 msgstr "Cadena de certificados exportada con éxito."
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 msgid "Please select one or more certificates to revoke."
 msgstr "Por favor, seleccione uno o más certificados para revocar."
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "¿Está seguro de que desea revocar este certificado?"
 msgstr[1] "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 #, fuzzy
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
@@ -324,35 +324,35 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr "La revocación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificado revocado.\n"
 msgstr[1] "Certificado revocado.\n"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr "Por favor, seleccione una o más solicitudes para eliminar."
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 msgstr[1] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr "La eliminación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -368,7 +368,7 @@ msgstr ""
 "El certificado antiguo permanecerá en la base de datos — revóquelo "
 "manualmente cuando haya desplegado el nuevo."
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
@@ -376,11 +376,11 @@ msgstr ""
 "Certificado renovado. Se ha añadido un nuevo certificado con un par de "
 "claves nuevo a la base de datos, junto al original."
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -390,11 +390,11 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado de AC?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -412,15 +412,15 @@ msgstr ""
 "certificados generados con él, por lo que todos deberían regenerarse con un "
 "nuevo certificado de AC."
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr "Cambiando contraseña de AC - gnoMint"
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -428,61 +428,61 @@ msgstr ""
 "La contraseña actual que ha introducido no coincide con la contraseña real "
 "de la base de datos."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. Se canceló la "
 "operación."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al establecer la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr "Contraseña establecida con éxito"
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "Contraseña eliminada con éxito"
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Guardar parámetros Diffie-Hellman"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parámetros Diffie-Hellman guardados correctamente"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "Seleccione fichero PEM a importar"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Hubo problemas al importar el fichero '%s'"
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr "Seleccione directorio a importar"
 
@@ -750,52 +750,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Mostrar mensaje de \"Acerca de...\""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr "Mostrar información de garantía"
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr "Mostrar información sobre la distribución del programa"
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Mostrar información de versión"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "Mostrar (este) mensaje de ayuda"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Cerrar base de datos y salir de programa"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Abriendo base de datos %s..."
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " Correcto.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Error.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, fuzzy, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -810,7 +820,7 @@ msgstr[1] ""
 "<b>%d certificados</b> caducan en los próximos %d días. Haga clic con el "
 "botón derecho sobre cada uno para renovarlo con una clave nueva."
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -825,7 +835,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -834,7 +844,7 @@ msgstr ""
 "Este programa se proporciona SIN GARANTÍAS DE NINGÚN TIPO; para más\n"
 "detalles, teclee 'warranty'.\n"
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -846,12 +856,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Comillas desemparejadas\n"
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -859,12 +869,12 @@ msgstr ""
 "Orden no válida. Teclee 'help' para conseguir una lista de órdenes\n"
 "reconocidas.\n"
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Número incorrecto de parámetros.\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Sintaxis: %s\n"
@@ -2273,6 +2283,22 @@ msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr "Coincidencias (id\tserie\tasunto):\n"
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
+msgstr[0] "%d coincidencia.\n"
+msgstr[1] "%d coincidencias.\n"
 
 #: ../src/ca_creation.c:53 ../src/csr_creation.c:55
 msgid "Generating new RSA key pair"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -128,15 +128,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -144,7 +144,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -152,28 +152,28 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -184,155 +184,155 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Peruttujen varmenteiden näkyvyys"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Varmennuspyyntöjen näkyvyys"
 msgstr[1] "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -342,28 +342,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -374,69 +374,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr ""
 
@@ -684,52 +684,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -740,7 +750,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -750,14 +760,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -766,23 +776,23 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
@@ -2047,6 +2057,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -132,15 +132,15 @@ msgstr "Gérer des certificats et des CA X.509, facilement et graphiquement"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Demandes en signature de certificat</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -157,28 +157,28 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Numéro"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Activation"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Expiration"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Révocation"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +189,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Exporter une CSR"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Erreur pendant l'exportation du certificat."
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr "Erreur pendant l'exportation de la Requête de Signature de Certificat."
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr "CSR exporté avec succès."
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr "Exporter la clé privée chiffrée"
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Clé privée exportée avec succès"
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporter la clé privée non chiffrée"
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporter l'intégralité du certificat vers un paquet au format PKCS#12"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Exportation de Requête de Signature de Certificat - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,13 +254,13 @@ msgstr ""
 "Veuillez choisir la partie de la Requête de Signature de Certificat "
 "sauvegardée que vous souhaitez exporter :"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr "<i>Exporter la CSR vers un fichier public, au format PEM.</i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -270,71 +270,71 @@ msgstr ""
 "passe, au format PKCS#8. Ce fichier ne devrait être accessible que par le "
 "titulaire de la CSR.</i>"
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Certificat Racine de l'Autorité de Certification"
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 msgstr[1] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat révoqué.\n"
 msgstr[1] "Certificat révoqué.\n"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -343,12 +343,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -358,29 +358,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -391,16 +391,16 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr "Modifier le mot de passe de l'Autorité de Certification - gnoMint"
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -408,61 +408,61 @@ msgstr ""
 "Le mot de passe que vous venez d'entrer ne correspond pas au mot de passe "
 "actuel de la base de données."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant l'affectationdu mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr "Mot de passe mis en place avec succès."
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "Mot de passe supprimé avec succès."
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Sauvegarder les paramètres Diffie-Hellman"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Les paramètres Diffie-Hellman ont été sauvegardés avec succès"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "Choisir le fichier PEM à importer"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problème pendant l'importation du fichier '%s'"
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr "Sélectionner le répertoire à importer"
 
@@ -727,52 +727,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Afficher le message « À propos »"
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr "Afficher les informations de garantie"
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr "Afficher les informations de distribution"
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Afficher les informations de version"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "Afficher ce message d'aide"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Fermer la base de données et quitter le programme"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Ouverture de la base de données %s..."
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Erreur.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -783,7 +793,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -798,14 +808,14 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -814,23 +824,23 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Guillemet manquant\n"
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Nombre de paramètres incorrect.\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Syntaxe : %s\n"
@@ -2174,6 +2184,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -132,15 +132,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificati</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -156,28 +156,28 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Revoca"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -188,64 +188,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Esporta la richiesta di firma di certificato (CSR)"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Errore durante l'esportazione del certificato."
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr "Errore durante l'esportazione del CSR."
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr "Richiesta di firma di certificato (CSR) esportata correttamente"
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr "Esporta la chiave privata criptata"
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Chiave privata esportata correttamente"
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Esporta chiave privata non criptata"
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Esporta l'intero certificato nel pacchetto PKCS#12"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Esporta CSR - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -253,7 +253,7 @@ msgstr ""
 "Si prega di scegliere quale parte della richiesta di firma di certificato "
 "(CSR) salvata si vuole esportare:"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -261,7 +261,7 @@ msgstr ""
 "<i>Esporta la richiesta di firma di certificato (CSR) in un file pubblico, "
 "in formato PEM.</i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -271,70 +271,70 @@ msgstr ""
 "Questo file deve essere accessibile solamente da parte del soggetto della "
 "richiesta di firma di certificato (CSR).</i>"
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Aggiungi un certificato CA autofirmato"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Confermare la revoca di questo certificato?"
 msgstr[1] "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificato revocato.\n"
 msgstr[1] "Certificato revocato.\n"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -345,12 +345,12 @@ msgstr[1] ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -360,29 +360,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -393,17 +393,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -411,61 +411,61 @@ msgstr ""
 "La password attualmente inserita non corrisponde con la reale e corrente "
 "password del database."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la modifica della password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Errore nello stabilire la password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr "Password stabilita correttamente"
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la rimozione della password del database. L'operazione è "
 "stata annullata."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "Password rimossa correttamente"
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Salva i parametri Diffie-Hellman"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parametri Diffie-Hellman salvati correttamente"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "Selezionare il file PEM da importare"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr ""
 
@@ -717,52 +717,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Visualizza il messaggio di About"
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr "Visualizza le informazioni di garanzia"
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr "Visualizza le informazioni di distribuzione"
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "Visualizza (questo) messaggio di aiuto"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Chiudi il database ed esci dal programma"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Database %s in apertura..."
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Errore.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -773,7 +783,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -788,7 +798,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -797,7 +807,7 @@ msgstr ""
 "Questo programma viene fornito SENZA ALCUNA GARANZIA;\n"
 "per informazioni digitare 'warranty'.\n"
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -809,12 +819,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -822,12 +832,12 @@ msgstr ""
 "Comando non valido. Digitare 'help' per ottenere una lista dei comandi "
 "riconosciuti.\n"
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Numero di parametri non corretto.\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Sintassi: %s\n"
@@ -2123,6 +2133,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -123,15 +123,15 @@ msgstr "Gerir aisidament e graficament de certificats X.509 e d'AC"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -139,7 +139,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -147,28 +147,28 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Periodic"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Activacion"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Expiracion"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Revocacion"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -179,154 +179,154 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Error inesperada"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "<b>Certificats</b>"
 msgstr[1] "<b>Certificats</b>"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -336,28 +336,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -368,69 +368,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr ""
 
@@ -678,52 +678,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Afichar las informacions de version"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Error.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -734,7 +744,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -749,14 +759,14 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -765,23 +775,23 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
@@ -2045,6 +2055,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -130,15 +130,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -146,7 +146,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -154,28 +154,28 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -186,155 +186,155 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Visibilidade de certificados revogados"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Visibilidade de pedidos de certificado"
 msgstr[1] "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -344,28 +344,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -376,69 +376,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr ""
 
@@ -686,52 +686,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -742,7 +752,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -752,14 +762,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -768,23 +778,23 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
@@ -2048,6 +2058,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -132,15 +132,15 @@ msgstr "Управлять сертификатами X.509 и CA легко и 
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Сертификат</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Запрос на Подпись Сертификата</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -157,28 +157,28 @@ msgstr "%m/%d/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Серийный номер"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Активация"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Срок истечения"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Отзыв"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +189,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Экспорт запроса на подпись сертификата"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Произошла ошибка во время экспорта сертификата."
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr "Произошла ошибка во время экспорта CSR."
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr "Запрос на подпись сертификата успешно экспортирован"
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr "Экспорт зашифрованного закрытого ключ"
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Закрытый ключ успешно экспортирован"
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Экспорт незашифрованного закрытого ключа"
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Экспорт всего сертификата в PKCS#12 пакет"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Экспорт CSR - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,7 +254,7 @@ msgstr ""
 "Пожалуйста, выберите какую часть сохранённого Запроса на Подпись Сертификата "
 "вы хотите экспортировать:"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -262,7 +262,7 @@ msgstr ""
 "<i>Экспорт Запроса на Подпись Сертификата в незашифрованный файл PEM формата."
 "</i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -271,83 +271,83 @@ msgstr ""
 "<i>Экспрорт сохранённого закрытого ключа в PKCS#8 файл защищённый паролем. "
 "Этот файл должен быть доступен владельцу Запроса на Подпись Сертификата.</i>"
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Неожиданная ошибка"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Корневой сертификат CA"
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Вы уверены, что хотите отозвать сертификат?"
 msgstr[1] "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Сертификат отозван.\n"
 msgstr[1] "Сертификат отозван.\n"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 msgstr[1] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -357,29 +357,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -390,15 +390,15 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr "Изменить CA пароль - gnoMint"
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -406,55 +406,55 @@ msgstr ""
 "Текущий пароль, который вы ввели, не совпадает с текущим актуальным паролем "
 "базы."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr "Произошла  ошибка при смене пароля базы. Операция отменена."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr "Пароль установлен успешно"
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr "Произошла ошибка при удалении пароля базы. Операция отменена."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "Пароль удалён успешно."
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Сохранить Diffie-Hellman параметры"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Параметры Diffie-Hellman сохранены успешно"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "Выберите PEM файл для импорта"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Проблема при импорте файла '%s'"
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr "Выберите каталог для импорта"
 
@@ -711,52 +711,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Показать сведения о программе"
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr "Показать сведения о гарантиях"
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr "Показать сведения о распространении"
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Показать сведения о версии"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "Показать (это) сообщение помощи"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Закрыть базу данных и выйти из программы"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Открыть базу данных %s..."
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Ошибка.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -767,7 +777,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -782,7 +792,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -791,7 +801,7 @@ msgstr ""
 "Эта программа идёт АБСОЛЮТНО БЕЗ ГАРАНТИЙ;\n"
 "для подробностей наберите 'warranty'.\n"
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -803,12 +813,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Непарные кавычки\n"
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -816,12 +826,12 @@ msgstr ""
 "Неверная команда. Попробуйте 'help' для получения списка распознаваемых "
 "команд.\n"
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Неверное число параметров.\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Синтакс: %s\n"
@@ -2227,6 +2237,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -131,15 +131,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -147,7 +147,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -155,28 +155,28 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -187,155 +187,155 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Vlastnosti žiadosti o vydanie certifikátu - gnoMint"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Pridať certifikát self-signed CA"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Viditeľnosť žiadostí o certifikát"
 msgstr[1] "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Pridať novú žiadosť o vydanie certifikátu"
 msgstr[1] "Pridať novú žiadosť o vydanie certifikátu"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -345,28 +345,28 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -377,69 +377,69 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr ""
 
@@ -687,52 +687,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr ""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr ""
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr ""
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr ""
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr ""
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr ""
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr ""
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -743,7 +753,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -753,14 +763,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
 "for details type 'warranty'.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -769,23 +779,23 @@ msgid ""
 msgstr ""
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr ""
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr ""
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr ""
@@ -2051,6 +2061,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 12:24+0200\n"
+"POT-Creation-Date: 2026-05-22 13:16+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -134,15 +134,15 @@ msgstr "Hantera X.509-certifikat och certifikatutfärdare, enkelt och grafiskt"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:268
+#: ../src/ca.c:304
 msgid "<b>Certificates</b>"
 msgstr "<b>Certifikat</b>"
 
-#: ../src/ca.c:416
+#: ../src/ca.c:459
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
-#: ../src/ca.c:459 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:502 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
 #: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
 #: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
@@ -150,7 +150,7 @@ msgstr "<b>Certifikatsigneringsbegäran</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:462 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:505 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
 #: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
 #: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
@@ -159,28 +159,28 @@ msgstr "%Y/%m/%d %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:613 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:656 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:192 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
-#: ../src/ca.c:649
+#: ../src/ca.c:692
 msgid "Serial"
 msgstr "Serienummer"
 
-#: ../src/ca.c:657
+#: ../src/ca.c:700
 msgid "Activation"
 msgstr "Aktivering"
 
-#: ../src/ca.c:667
+#: ../src/ca.c:710
 msgid "Expiration"
 msgstr "Utgång"
 
-#: ../src/ca.c:677
+#: ../src/ca.c:720
 msgid "Revocation"
 msgstr "Spärrning"
 
-#: ../src/ca.c:710
+#: ../src/ca.c:753
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -191,64 +191,64 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1047
+#: ../src/ca.c:1123
 msgid "Export certificate"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1050 ../src/ca.c:1057 ../src/ca.c:1159 ../src/ca.c:1210
-#: ../src/ca.c:1261 ../src/ca.c:1451 ../src/ca.c:2398 ../src/ca.c:2504
-#: ../src/ca.c:2538 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
+#: ../src/ca.c:1126 ../src/ca.c:1133 ../src/ca.c:1235 ../src/ca.c:1286
+#: ../src/ca.c:1337 ../src/ca.c:1527 ../src/ca.c:2483 ../src/ca.c:2589
+#: ../src/ca.c:2623 ../src/crl.c:257 ../src/main.c:330 ../src/main.c:402
 #: ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1051 ../src/ca.c:1058 ../src/ca.c:1160 ../src/ca.c:1211
-#: ../src/ca.c:1262 ../src/ca.c:1452 ../src/ca.c:2399 ../src/crl.c:258
+#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
+#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:2484 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1054
+#: ../src/ca.c:1130
 msgid "Export certificate signing request"
 msgstr "Exportera certificate signing request"
 
-#: ../src/ca.c:1069 ../src/ca.c:1105 ../src/ca.c:1115 ../src/export.c:278
+#: ../src/ca.c:1145 ../src/ca.c:1181 ../src/ca.c:1191 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Det inträffade ett fel då certifikatet skulle exporteras."
 
-#: ../src/ca.c:1071 ../src/ca.c:1107 ../src/ca.c:1117
+#: ../src/ca.c:1147 ../src/ca.c:1183 ../src/ca.c:1193
 msgid "There was an error while exporting CSR."
 msgstr "Det inträffade ett fel då CSR skulle exporteras."
 
-#: ../src/ca.c:1130 ../src/ca.c:1296
+#: ../src/ca.c:1206 ../src/ca.c:1372
 msgid "Certificate exported successfully"
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1137
+#: ../src/ca.c:1213
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1156
+#: ../src/ca.c:1232
 msgid "Export crypted private key"
 msgstr "Exportera krypterad privat nyckel"
 
-#: ../src/ca.c:1185 ../src/ca.c:1237
+#: ../src/ca.c:1261 ../src/ca.c:1313
 msgid "Private key exported successfully"
 msgstr "Privat nyckel exporterades"
 
-#: ../src/ca.c:1207
+#: ../src/ca.c:1283
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportera okrypterad privat nyckel"
 
-#: ../src/ca.c:1258
+#: ../src/ca.c:1334
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportera helt certifikat i PKCS#12-paket"
 
-#: ../src/ca.c:1329
+#: ../src/ca.c:1405
 msgid "Export CSR - gnoMint"
 msgstr "Exportera CSR - gnoMint"
 
-#: ../src/ca.c:1334
+#: ../src/ca.c:1410
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -256,7 +256,7 @@ msgstr ""
 "Vänligen välj vilken del av den sparade Certificate Signing Request du vill "
 "exportera:"
 
-#: ../src/ca.c:1339
+#: ../src/ca.c:1415
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -264,7 +264,7 @@ msgstr ""
 "<i>Exportera Certificate Signing Request till en publik fil, i PEM-format.</"
 "i>"
 
-#: ../src/ca.c:1344
+#: ../src/ca.c:1420
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -274,70 +274,70 @@ msgstr ""
 "fil. Filen bör endast kunna kommas åt av den till vilken Certificate Signing "
 "Request är utfärdat.</i>"
 
-#: ../src/ca.c:1408
+#: ../src/ca.c:1484
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: ../src/ca.c:1423
+#: ../src/ca.c:1499
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1449
+#: ../src/ca.c:1525
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1472
+#: ../src/ca.c:1548
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1480
+#: ../src/ca.c:1556
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Lägg till ett autosignerat CA-certifikat"
 
-#: ../src/ca.c:1488
+#: ../src/ca.c:1564
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1556
+#: ../src/ca.c:1632
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1562
+#: ../src/ca.c:1638
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Är du säker på att du vill spärra detta certifikat?"
 msgstr[1] "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1569
+#: ../src/ca.c:1645
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1587
+#: ../src/ca.c:1663
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1591
+#: ../src/ca.c:1667
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Exportera certifikat"
 msgstr[1] "Exportera certifikat"
 
-#: ../src/ca.c:1615
+#: ../src/ca.c:1691
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1621
+#: ../src/ca.c:1697
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -346,12 +346,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:1642
+#: ../src/ca.c:1718
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1705
+#: ../src/ca.c:1781
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -361,29 +361,29 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1723
+#: ../src/ca.c:1799
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1757
+#: ../src/ca.c:1833
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1758
+#: ../src/ca.c:1834
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:1766
+#: ../src/ca.c:1842
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1767
+#: ../src/ca.c:1843
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -394,73 +394,73 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:1810
+#: ../src/ca.c:1886
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:2176
+#: ../src/ca.c:2261
 msgid "Change CA password - gnoMint"
 msgstr "Ändra CA-lösenord - gnoMint"
 
-#: ../src/ca.c:2194
+#: ../src/ca.c:2279
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 "Det lösenord Du skrivit in är inte det som behövs för den valda databasen."
 
-#: ../src/ca.c:2209
+#: ../src/ca.c:2294
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle bytas. Operationen avbröts."
 
-#: ../src/ca.c:2218
+#: ../src/ca.c:2303
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: ../src/ca.c:2228 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2313 ../src/ca-cli-callbacks.c:1169
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2238
+#: ../src/ca.c:2323
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2248
+#: ../src/ca.c:2333
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle tas bort. Operationen "
 "avbröts."
 
-#: ../src/ca.c:2257
+#: ../src/ca.c:2342
 msgid "Password removed successfully"
 msgstr "Lösenordet togs bort"
 
-#: ../src/ca.c:2395
+#: ../src/ca.c:2480
 msgid "Save Diffie-Hellman parameters"
 msgstr "Spara Diffie-Hellman-parametrar"
 
-#: ../src/ca.c:2421
+#: ../src/ca.c:2506
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-parametrar sparades"
 
 #. Import single file
-#: ../src/ca.c:2501
+#: ../src/ca.c:2586
 msgid "Select PEM file to import"
 msgstr "Välj PEM-fil att importera"
 
-#: ../src/ca.c:2505 ../src/ca.c:2539 ../src/main.c:331 ../src/main.c:403
+#: ../src/ca.c:2590 ../src/ca.c:2624 ../src/main.c:331 ../src/main.c:403
 #: ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:2522
+#: ../src/ca.c:2607
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Ett problem inträffade vid importerandet av filen '%s'"
 
-#: ../src/ca.c:2535
+#: ../src/ca.c:2620
 msgid "Select directory to import"
 msgstr "Välj katalog att importera"
 
@@ -715,52 +715,62 @@ msgid "Delete many CSRs at once. Non-CSR ids are silently skipped."
 msgstr ""
 
 #: ../src/ca-cli.c:74
+msgid "search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli.c:74
+msgid ""
+"List certificates and CSRs whose subject or serial contains <pattern> (case-"
+"insensitive)."
+msgstr ""
+
+#: ../src/ca-cli.c:75
 msgid "Show about message"
 msgstr "Visa meddelandet \"Om programmet\""
 
 #. 25
-#: ../src/ca-cli.c:75
+#: ../src/ca-cli.c:76
 msgid "Show warranty information"
 msgstr "Visa information om garanti"
 
 #. 26
-#: ../src/ca-cli.c:76
+#: ../src/ca-cli.c:77
 msgid "Show distribution information"
 msgstr "Visa information om distribution"
 
 #. 27
-#: ../src/ca-cli.c:77
+#: ../src/ca-cli.c:78
 msgid "Show version information"
 msgstr "Visa versionsinformation"
 
 #. 28
-#: ../src/ca-cli.c:78
+#: ../src/ca-cli.c:79
 msgid "Show (this) help message"
 msgstr "Visa hjälpmeddelande (det här)"
 
 #. 29
 #. 30
 #. 31
-#: ../src/ca-cli.c:79 ../src/ca-cli.c:80 ../src/ca-cli.c:81
+#: ../src/ca-cli.c:80 ../src/ca-cli.c:81 ../src/ca-cli.c:82
 msgid "Close database and exit program"
 msgstr "Stäng databasen och avsluta programmet"
 
-#: ../src/ca-cli.c:128
+#: ../src/ca-cli.c:129
 #, c-format
 msgid "Opening database %s..."
 msgstr "Öppnar databasen %s..."
 
-#: ../src/ca-cli.c:132
+#: ../src/ca-cli.c:133
 #, c-format
 msgid " OK.\n"
 msgstr " OK.\n"
 
-#: ../src/ca-cli.c:134
+#: ../src/ca-cli.c:135
 #, c-format
 msgid " Error.\n"
 msgstr " Fel.\n"
 
-#: ../src/ca-cli.c:149
+#: ../src/ca-cli.c:150
 #, c-format
 msgid ""
 "Notice: %d certificate expires within the next %d days. Use `renewcert <id>` "
@@ -771,7 +781,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli.c:183
+#: ../src/ca-cli.c:184
 #, c-format
 msgid ""
 "\n"
@@ -786,7 +796,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli.c:184
+#: ../src/ca-cli.c:185
 #, c-format
 msgid ""
 "This program comes with ABSOLUTELY NO WARRANTY;\n"
@@ -795,7 +805,7 @@ msgstr ""
 "Det här programmet levereras UTAN NÅGON SOM HELST GARANTI;\n"
 "för detaljer skriv \"warranty\".\n"
 
-#: ../src/ca-cli.c:185
+#: ../src/ca-cli.c:186
 #, c-format
 msgid ""
 "This is free software, and you are welcome to redistribute it\n"
@@ -807,12 +817,12 @@ msgstr ""
 "\n"
 
 #. Unpaired quotes
-#: ../src/ca-cli.c:227
+#: ../src/ca-cli.c:228
 #, c-format
 msgid "Unpaired quotes\n"
 msgstr "Ej ihop-parade citationstecken.\n"
 
-#: ../src/ca-cli.c:305
+#: ../src/ca-cli.c:306
 #, c-format
 msgid ""
 "Invalid command. Try 'help' for getting a list of recognized commands.\n"
@@ -820,12 +830,12 @@ msgstr ""
 "Ogiltigt kommando. Försök med 'help' för att få en lista över kommandon som "
 "programmet känner igen.\n"
 
-#: ../src/ca-cli.c:309
+#: ../src/ca-cli.c:310
 #, c-format
 msgid "Incorrect number of parameters.\n"
 msgstr "Felaktigt antal parametrar.\n"
 
-#: ../src/ca-cli.c:310
+#: ../src/ca-cli.c:311
 #, c-format
 msgid "Syntax: %s\n"
 msgstr "Syntax: %s\n"
@@ -2092,6 +2102,22 @@ msgstr ""
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca-cli-callbacks.c:2062
+msgid "Usage: search <pattern>"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2069
+#, c-format
+msgid "Matches (id\tserial\tsubject):\n"
+msgstr ""
+
+#: ../src/ca-cli-callbacks.c:2072
+#, c-format
+msgid "%d match.\n"
+msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/src/ca-cli-callbacks.c
+++ b/src/ca-cli-callbacks.c
@@ -2003,3 +2003,75 @@ int ca_cli_callback_deletemany (int argc, char **argv)
 	                  "%d CSRs deleted.\n", done), done);
 	return 0;
 }
+
+
+/* ------------------------------------------------------------------ */
+/*  search — list certs/CSRs whose subject or serial matches (#53)     */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	gchar *needle_lower;
+	gint   matches;
+} CliSearchCtx;
+
+static int
+__ca_cli_search_cert (void *pArg, int argc, char **argv, char **columnNames)
+{
+	CliSearchCtx *ctx = (CliSearchCtx *) pArg;
+	if (argc <= CA_FILE_CERT_COLUMN_SERIAL) return 0;
+	const gchar *subj = argv[CA_FILE_CERT_COLUMN_SUBJECT];
+	const gchar *ser  = argv[CA_FILE_CERT_COLUMN_SERIAL];
+	gboolean hit = FALSE;
+	if (subj) {
+		gchar *low = g_utf8_strdown (subj, -1);
+		if (strstr (low, ctx->needle_lower)) hit = TRUE;
+		g_free (low);
+	}
+	if (!hit && ser && strstr (ser, ctx->needle_lower)) hit = TRUE;
+	if (hit) {
+		printf ("%s\t%s\t%s\n",
+		        argv[CA_FILE_CERT_COLUMN_ID]      ? argv[CA_FILE_CERT_COLUMN_ID]      : "",
+		        argv[CA_FILE_CERT_COLUMN_SERIAL]  ? argv[CA_FILE_CERT_COLUMN_SERIAL]  : "",
+		        argv[CA_FILE_CERT_COLUMN_SUBJECT] ? argv[CA_FILE_CERT_COLUMN_SUBJECT] : "");
+		ctx->matches++;
+	}
+	return 0;
+}
+
+static int
+__ca_cli_search_csr (void *pArg, int argc, char **argv, char **columnNames)
+{
+	CliSearchCtx *ctx = (CliSearchCtx *) pArg;
+	if (argc <= CA_FILE_CSR_COLUMN_SUBJECT) return 0;
+	const gchar *subj = argv[CA_FILE_CSR_COLUMN_SUBJECT];
+	if (!subj) return 0;
+	gchar *low = g_utf8_strdown (subj, -1);
+	if (strstr (low, ctx->needle_lower)) {
+		printf ("CSR\t%s\t%s\n",
+		        argv[CA_FILE_CSR_COLUMN_ID] ? argv[CA_FILE_CSR_COLUMN_ID] : "",
+		        subj);
+		ctx->matches++;
+	}
+	g_free (low);
+	return 0;
+}
+
+int ca_cli_callback_search (int argc, char **argv)
+{
+	if (argc < 2 || !argv[1] || !*argv[1]) {
+		dialog_error (_("Usage: search <pattern>"));
+		return -1;
+	}
+	CliSearchCtx ctx;
+	ctx.needle_lower = g_utf8_strdown (argv[1], -1);
+	ctx.matches = 0;
+
+	printf (_("Matches (id\tserial\tsubject):\n"));
+	ca_file_foreach_crt (__ca_cli_search_cert, FALSE, &ctx);
+	ca_file_foreach_csr (__ca_cli_search_csr, &ctx);
+	printf (ngettext ("%d match.\n", "%d matches.\n", ctx.matches),
+	        ctx.matches);
+
+	g_free (ctx.needle_lower);
+	return 0;
+}

--- a/src/ca-cli-callbacks.h
+++ b/src/ca-cli-callbacks.h
@@ -52,3 +52,4 @@ int ca_cli_callback_renew (int argc, char **argv);
 int ca_cli_callback_exportchain (int argc, char **argv);
 int ca_cli_callback_revokemany (int argc, char **argv);
 int ca_cli_callback_deletemany (int argc, char **argv);
+int ca_cli_callback_search (int argc, char **argv);

--- a/src/ca-cli.c
+++ b/src/ca-cli.c
@@ -71,6 +71,7 @@ CaCommand ca_commands[] = {
 	{"exportchain", 2, 2, N_("exportchain <cert-id> <filename>"), N_("Export the full certificate chain (leaf → root) for the given certificate as a PEM bundle."), ca_cli_callback_exportchain},
 	{"revokemany", 1, 64, N_("revokemany <cert-id> [cert-id ...]"), N_("Revoke many certificates at once. Non-cert ids are silently skipped."), ca_cli_callback_revokemany},
 	{"deletemany", 1, 64, N_("deletemany <csr-id> [csr-id ...]"), N_("Delete many CSRs at once. Non-CSR ids are silently skipped."), ca_cli_callback_deletemany},
+	{"search", 1, 1, N_("search <pattern>"), N_("List certificates and CSRs whose subject or serial contains <pattern> (case-insensitive)."), ca_cli_callback_search},
 	{"about", 0, 0, "about", N_("Show about message"), ca_cli_callback_about}, // 25
 	{"warranty", 0, 0, "warranty", N_("Show warranty information"), ca_cli_callback_warranty}, // 26
 	{"distribution", 0, 0, "distribution", N_("Show distribution information"), ca_cli_callback_distribution}, // 27
@@ -80,7 +81,7 @@ CaCommand ca_commands[] = {
 	{"exit", 0, 0, "exit", N_("Close database and exit program"), ca_cli_callback_exit}, // 31
 	{"bye", 0, 0, "bye", N_("Close database and exit program"), ca_cli_callback_exit} // 32
 };
-#define CA_COMMAND_NUMBER 37
+#define CA_COMMAND_NUMBER 38
 
 
 

--- a/src/ca.c
+++ b/src/ca.c
@@ -150,6 +150,27 @@ static gint ca_expiring_soon_count = 0;
  * we don't show it again until the user re-opens the file. */
 static gboolean ca_expiry_infobar_dismissed = FALSE;
 
+/* Active search text for the filter box (#53). When non-empty, leaf
+ * certificates whose subject/serial doesn't contain this substring
+ * (case-insensitive) are hidden from the tree. Owned by ca.c; freed
+ * on next change. */
+static gchar *ca_search_text = NULL;
+
+/* Does the haystack (UTF-8) contain the needle (UTF-8) ignoring case?
+ * Both are assumed non-NULL; an empty needle matches anything. */
+static gboolean
+__ca_search_match (const gchar *haystack, const gchar *needle)
+{
+	if (!needle || !*needle) return TRUE;
+	if (!haystack) return FALSE;
+	gchar *h = g_utf8_strdown (haystack, -1);
+	gchar *n = g_utf8_strdown (needle, -1);
+	gboolean m = (strstr (h, n) != NULL);
+	g_free (h);
+	g_free (n);
+	return m;
+}
+
 
 int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char **columnNames);
 int __ca_refresh_model_add_csr (void *pArg, int argc, char **argv, char **columnNames);
@@ -191,6 +212,21 @@ void __enable_widget (gchar *widget_name);
 
 int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char **columnNames)
 {
+	/* Search filter (#53): skip leaf certs whose subject/serial
+	 * doesn't contain the active search text. CAs are always shown
+	 * so the tree hierarchy stays intact and the search reveals
+	 * which CA issued the matched leaves. Run before any allocation
+	 * so the early-return is leak-free. */
+	if (ca_search_text && *ca_search_text &&
+	    argv[CA_FILE_CERT_COLUMN_IS_CA] &&
+	    atoi (argv[CA_FILE_CERT_COLUMN_IS_CA]) == 0) {
+		gboolean matched =
+		    __ca_search_match (argv[CA_FILE_CERT_COLUMN_SUBJECT], ca_search_text) ||
+		    __ca_search_match (argv[CA_FILE_CERT_COLUMN_SERIAL],  ca_search_text);
+		if (! matched)
+			return 0;
+	}
+
 	GtkTreeIter iter;
 	GtkTreeStore * new_model = GTK_TREE_STORE (pArg);
 	GValue *last_id_value = g_new0 (GValue, 1);
@@ -407,6 +443,13 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 
 int __ca_refresh_model_add_csr (void *pArg, int argc, char **argv, char **columnNames)
 {
+	/* Search filter (#53): skip CSRs whose subject doesn't match. */
+	if (ca_search_text && *ca_search_text) {
+		if (! __ca_search_match (argv[CA_FILE_CSR_COLUMN_SUBJECT],
+		                          ca_search_text))
+			return 0;
+	}
+
 	GtkTreeIter iter;
 	GtkTreeStore * new_model = GTK_TREE_STORE(pArg);
 
@@ -722,6 +765,39 @@ gboolean ca_refresh_model_callback ()
 	}
 
 	return TRUE;
+}
+
+/* Ctrl+F focuses the search entry (#53). Returning TRUE prevents
+ * the event from propagating further; FALSE lets other handlers run.
+ * GdkEventKey rather than the typed GdkEvent* so GtkBuilder can wire
+ * the connect_signals_full() call directly. */
+G_MODULE_EXPORT gboolean
+ca_on_main_window_key_press (GtkWidget *widget G_GNUC_UNUSED,
+                             GdkEventKey *event,
+                             gpointer user_data G_GNUC_UNUSED)
+{
+	if ((event->state & GDK_CONTROL_MASK) &&
+	    (event->keyval == GDK_KEY_f || event->keyval == GDK_KEY_F)) {
+		GObject *entry = gtk_builder_get_object (main_window_gtkb,
+		                                          "search_entry");
+		if (entry && GTK_IS_WIDGET (entry)) {
+			gtk_widget_grab_focus (GTK_WIDGET (entry));
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+/* Search-entry handler (#53). Triggers on every keystroke; just stash
+ * the new search text and refresh the tree. The actual filter is
+ * applied in __ca_refresh_model_add_certificate. */
+G_MODULE_EXPORT void
+ca_on_search_changed (GtkSearchEntry *entry, gpointer user_data G_GNUC_UNUSED)
+{
+	const gchar *text = gtk_entry_get_text (GTK_ENTRY (entry));
+	g_free (ca_search_text);
+	ca_search_text = (text && *text) ? g_strdup (text) : NULL;
+	ca_refresh_model_callback ();
 }
 
 /* GtkInfoBar response handler: dismiss / close => hide and remember
@@ -1860,6 +1936,15 @@ gboolean ca_open (gchar *filename, gboolean create)
 
 	/* Re-arm the expiry banner for the freshly-opened file. */
 	ca_expiry_infobar_dismissed = FALSE;
+
+	/* Reset the search filter so the new DB starts with everything
+	 * visible — both internally and in the entry widget. */
+	g_clear_pointer (&ca_search_text, g_free);
+	{
+		GObject *e = gtk_builder_get_object (main_window_gtkb, "search_entry");
+		if (e && GTK_IS_ENTRY (e))
+			gtk_entry_set_text (GTK_ENTRY (e), "");
+	}
 
 	dialog_refresh_list();
 

--- a/tests/check_cli_parity.sh
+++ b/tests/check_cli_parity.sh
@@ -31,6 +31,8 @@ Yes
 exportchain 2 $CHAIN
 revokemany 5 6
 deletemany 1
+search gnoMint
+search xx-no-such-cert-xx
 quit
 EOF
 
@@ -38,6 +40,9 @@ grep -q "Certificate renewed" "$TMPDIR/out.txt"
 grep -q "Full chain.*written to $CHAIN" "$TMPDIR/out.txt"
 grep -q "2 certificates revoked" "$TMPDIR/out.txt"
 grep -q "CSR deleted" "$TMPDIR/out.txt"
+# search command must surface the matching cert and report 0 for a bogus pattern
+grep -q "gnoMint program" "$TMPDIR/out.txt"
+grep -q "0 matches\." "$TMPDIR/out.txt"
 
 # Confirm chain has at least 2 BEGIN markers (leaf + root for a level-1 cert)
 BEGIN=$(grep -c "BEGIN CERTIFICATE" "$CHAIN")

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -1623,6 +1623,132 @@ out:
 }
 
 /* ------------------------------------------------------------------ */
+/*  Scenario: search/filter box (issue #53)                           */
+/* ------------------------------------------------------------------ */
+
+/* Counts the rows in the tree view's model whose IS_CA flag is FALSE
+ * — i.e. leaf certificates and CSRs. We use it before/after applying
+ * a search filter to confirm the filter actually hides rows. */
+static void
+__count_leaves_recursive (GtkTreeModel *m, GtkTreeIter *iter, gint *out)
+{
+    do {
+        /* Counts rows that are neither title headers (id=0) nor CAs
+         * (IS_CA=TRUE in column 1). */
+        gboolean is_ca = FALSE;
+        guint64 id = 0;
+        gtk_tree_model_get (m, iter,
+                            CA_MODEL_COLUMN_ID, &id,
+                            1 /* IS_CA */, &is_ca,
+                            -1);
+        if (!is_ca && id != 0)
+            (*out)++;
+        GtkTreeIter child;
+        if (gtk_tree_model_iter_children (m, &child, iter))
+            __count_leaves_recursive (m, &child, out);
+    } while (gtk_tree_model_iter_next (m, iter));
+}
+
+static gint
+count_visible_leaves (void)
+{
+    GtkTreeView *tv = GTK_TREE_VIEW (
+        gtk_builder_get_object (main_window_gtkb, "ca_treeview"));
+    if (!tv) return -1;
+    GtkTreeModel *m = gtk_tree_view_get_model (tv);
+    if (!m) return -1;
+    gint n = 0;
+    GtkTreeIter iter;
+    if (gtk_tree_model_get_iter_first (m, &iter))
+        __count_leaves_recursive (m, &iter, &n);
+    return n;
+}
+
+static int
+scenario_search_filter (void)
+{
+    int rc = 1;
+    fprintf (stderr, "==> scenario: search/filter box (issue #53)\n");
+
+    if (!test_init_main_window () || !fixture_setup ())
+        return 1;
+    if (!ca_open (g_strdup (fixture_path), FALSE)) {
+        fail_test ("search-filter", "ca_open(%s) failed", fixture_path);
+        goto out;
+    }
+    drain_events ();
+
+    extern void ca_on_search_changed (GtkSearchEntry *entry, gpointer ud);
+    GtkEntry *entry = GTK_ENTRY (gtk_builder_get_object (main_window_gtkb,
+                                                          "search_entry"));
+    if (!entry) {
+        fail_test ("search-filter", "search_entry widget missing");
+        goto out;
+    }
+
+    gint before = count_visible_leaves ();
+    if (before <= 0) {
+        fail_test ("search-filter", "no leaf rows in fixture before filter");
+        goto out;
+    }
+    fprintf (stderr, "    leaves before filter: %d\n", before);
+
+    /* Apply a filter that should match a small subset. "gnoMint" appears
+     * in cert id 3's CN ("gnoMint program"). */
+    gtk_entry_set_text (entry, "gnoMint");
+    /* search-changed has a debounce timeout in GtkSearchEntry; invoke
+     * the handler directly so the test isn't time-dependent. */
+    ca_on_search_changed ((GtkSearchEntry *) entry, NULL);
+    drain_events ();
+    gint after = count_visible_leaves ();
+    fprintf (stderr, "    leaves after \"gnoMint\": %d\n", after);
+    if (after >= before) {
+        fail_test ("search-filter",
+                   "filter \"gnoMint\" didn't hide anything (%d -> %d)",
+                   before, after);
+        goto out;
+    }
+    if (after == 0) {
+        fail_test ("search-filter",
+                   "filter \"gnoMint\" hid every leaf (expected at least one match)");
+        goto out;
+    }
+
+    /* Apply a filter that should match nothing. */
+    gtk_entry_set_text (entry, "xx-no-such-cert-xx");
+    ca_on_search_changed ((GtkSearchEntry *) entry, NULL);
+    drain_events ();
+    gint none = count_visible_leaves ();
+    fprintf (stderr, "    leaves after no-match filter: %d\n", none);
+    if (none != 0) {
+        fail_test ("search-filter",
+                   "no-match filter still shows %d leaves", none);
+        goto out;
+    }
+
+    /* Clear the filter — everything should come back. */
+    gtk_entry_set_text (entry, "");
+    ca_on_search_changed ((GtkSearchEntry *) entry, NULL);
+    drain_events ();
+    gint restored = count_visible_leaves ();
+    fprintf (stderr, "    leaves after clearing filter: %d\n", restored);
+    if (restored != before) {
+        fail_test ("search-filter",
+                   "clearing filter restored %d leaves, expected %d",
+                   restored, before);
+        goto out;
+    }
+
+    rc = 0;
+
+out:
+    ca_file_close ();
+    fixture_teardown ();
+    int crits = critical_messages_check_and_reset ("search-filter");
+    return (rc == 0 && crits == 0) ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Driver                                                            */
 /* ------------------------------------------------------------------ */
 
@@ -1675,6 +1801,7 @@ main (int argc, char **argv)
         scenario_wizard_window ();
         scenario_keylength_selector ();
         scenario_expiry_banner ();
+        scenario_search_filter ();
     } else {
         fprintf (stderr,
                  "==> Phase 2B scenarios skipped: %s not found.\n"


### PR DESCRIPTION
## Summary
- **GUI**: GtkSearchEntry between the toolbar and the tree view. Filter-as-you-type hides leaf certs and CSRs whose subject/serial doesn't contain the pattern (case-insensitive UTF-8 substring). CAs are always shown so the tree hierarchy reveals which CA issued the matched leaves. **Ctrl+F** focuses the entry.
- **CLI**: matching \`search <pattern>\` command — lists every cert + CSR whose subject or serial matches, formatted as \`id<TAB>serial<TAB>subject\`.

## Screenshot

The new search bar sits between the toolbar and the tree:

![Main window with search bar](https://github.com/davefx/gnoMint/blob/master/docs/assets/screenshots/main-window.png) *(will update on next docs PR)*

## Test plan
- [x] \`make\` clean
- [x] \`make -C tests check\` — 6 suites pass, including:
  - \`scenario_search_filter\`: 6 leaves → "gnoMint" → 1 → bogus → 0 → clear → 6
  - \`check_cli_parity.sh\` now exercises \`search gnoMint\` + \`search xx-no-such-cert-xx\`

## Notes
Implementation is a per-keystroke \`ca_refresh_model_callback\` rather than wrapping \`ca_model\` in a \`GtkTreeModelFilter\`. The latter would require converting filter-iters → child-iters in every selection-handling site (~6 places), and the rebuild approach is fast enough for the typical CA size. If we later see slowdown on very large CAs we can switch.