### PR TITLE
Bump copyright to 2026 and drop dead sourceforge URLs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -113,6 +113,6 @@ Then update the `Dockerfile` to include them permanently.
 ## Additional Resources
 
 - [VS Code Dev Containers Documentation](https://code.visualstudio.com/docs/devcontainers/containers)
-- [gnoMint Project Website](http://gnomint.sourceforge.net)
+- [gnoMint on GitHub](https://github.com/davefx/gnoMint)
 - [GTK+ Documentation](https://docs.gtk.org/)
 - [GnuTLS Documentation](https://www.gnutls.org/documentation.html)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 gnoMint is a GTK+ 3 graphical (and readline-driven CLI) Certification Authority manager written in C. It uses GnuTLS for crypto, libgcrypt for low-level primitives, and SQLite 3 as the on-disk format for CA databases (`*.gnomint` files). Builds produce two binaries from a shared source tree: `gnomint` (GTK GUI) and `gnomint-cli` (readline CLI).
 
-Project home: http://gnomint.sourceforge.net — upstream repo: https://github.com/davefx/gnoMint.
+Upstream repo: https://github.com/davefx/gnoMint. The legacy gnomint.sourceforge.net site is gone; its content has been archived into docs/ in the repo.
 
 ## Build
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@ AC_PREREQ([2.69])
 
 AC_INIT([gnoMint],[1.4.0],[<davefx@gmail.com>],[gnomint])
 
-PACKAGE_COPYRIGHT="(c) 2006-2016 David Marín Carreño <davefx@gmail.com>"
-PACKAGE_WEBSITE="http://gnomint.sourceforge.net"
+PACKAGE_COPYRIGHT="(c) 2006-2026 David Marín Carreño <davefx@gmail.com>"
+PACKAGE_WEBSITE="https://github.com/davefx/gnoMint"
 PACKAGE_AUTHORS=$(cat AUTHORS | tr '\n' ',' | sed 's/,/\\n/g')
 AC_DEFINE_UNQUOTED(PACKAGE_COPYRIGHT, "$PACKAGE_COPYRIGHT")
 AC_DEFINE_UNQUOTED(PACKAGE_WEBSITE, "$PACKAGE_WEBSITE")

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,9 @@ description: >-
   A graphical Certification Authority manager for GTK 3, GnuTLS, and SQLite.
   Bootstrap CAs, sign CSRs, issue and revoke certificates, all from a
   desktop app — or driven from the readline CLI.
-baseurl: "/gnomint"
+# Pages serves the repo at /<repo>/ with the GitHub case preserved.
+# This repo is davefx/gnoMint (capital M), so baseurl is /gnoMint.
+baseurl: "/gnoMint"
 url: "https://davefx.github.io"
 
 remote_theme: pages-themes/minimal@v0.2.0

--- a/gui/gnomint.appdata.xml.in
+++ b/gui/gnomint.appdata.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2006-2016 David Marín Carreño <davefx@gmail.com> -->
+<!-- Copyright 2006-2026 David Marín Carreño <davefx@gmail.com> -->
 <component type="desktop-application">
   <id>net.sourceforge.gnomint</id>
   <metadata_license>CC0-1.0</metadata_license>
@@ -36,11 +36,11 @@
   <screenshots>
     <screenshot type="default">
       <_caption>Main window showing certificate list</_caption>
-      <image>https://gnomint.sourceforge.net/images/main_window_thumb.png</image>
+      <image>https://raw.githubusercontent.com/davefx/gnoMint/master/docs/assets/screenshots/main-window.png</image>
     </screenshot>
   </screenshots>
   
-  <url type="homepage">https://gnomint.sourceforge.net</url>
+  <url type="homepage">https://github.com/davefx/gnoMint</url>
   <url type="bugtracker">https://github.com/davefx/gnoMint/issues</url>
   
   <developer id="com.gmail.davefx">


### PR DESCRIPTION
## Summary
- \`configure.ac\` — \`PACKAGE_COPYRIGHT\` bumped to **2006-2026** (was stuck at 2016) and \`PACKAGE_WEBSITE\` points at the GitHub repo. The CLI banner and the GUI About box pull from these.
- \`gui/gnomint.appdata.xml.in\` — copyright year, homepage URL, and the lone screenshot URL all switched away from \`gnomint.sourceforge.net\`. The screenshot now resolves against the in-repo \`docs/assets/screenshots/main-window.png\`.
- \`docs/_config.yml\` — \`baseurl\` corrected to \`/gnoMint\` (capital M); the repo name is case-sensitive when forming Pages paths.
- \`CLAUDE.md\`, \`.devcontainer/README.md\` — dead sourceforge links replaced with the GitHub repo.

Before:
\`\`\`
gnoMint version 1.4.0
(c) 2006-2016 David Marín Carreño <davefx@gmail.com>
\`\`\`

After:
\`\`\`
gnoMint version 1.4.0
(c) 2006-2026 David Marín Carreño <davefx@gmail.com>
\`\`\`

## Test plan
- [x] Verified the new strings are embedded in the freshly-built binary
- [x] No code changes, no test impact