### PR TITLE
Comprehensive gnomint-cli test coverage + two bug fixes the tests caught

### DIFF
--- a/src/ca-cli-callbacks.c
+++ b/src/ca-cli-callbacks.c
@@ -444,13 +444,19 @@ int ca_cli_callback_addcsr (int argc, char **argv)
 		aux = NULL;
 
 		if (csr_creation_data->key_type == 2 /* ECDSA */) {
-			/* P-256 / P-384 / P-521. */
+			/* P-256 / P-384 / P-521. The default lands at 256
+			 * unless a previous prompt left a valid curve in
+			 * key_bitlength; an RSA-sized default (e.g. 2048)
+			 * would trip dialog_ask_for_number's assertion. */
+			gint ecdsa_default =
+			    (csr_creation_data->key_bitlength == 384 ||
+			     csr_creation_data->key_bitlength == 521)
+			        ? csr_creation_data->key_bitlength : 256;
 			do {
 				csr_creation_data->key_bitlength =
 				    dialog_ask_for_number (
 				        _("Enter curve size for ECDSA (256, 384, or 521)"),
-				        256, 521, csr_creation_data->key_bitlength ?
-				                  csr_creation_data->key_bitlength : 256);
+				        256, 521, ecdsa_default);
 			} while (csr_creation_data->key_bitlength != 256 &&
 			         csr_creation_data->key_bitlength != 384 &&
 			         csr_creation_data->key_bitlength != 521);
@@ -630,12 +636,15 @@ int ca_cli_callback_addca (int argc, char **argv)
 		aux = NULL;
 
 		if (ca_creation_data->key_type == 2 /* ECDSA */) {
+			gint ecdsa_default =
+			    (ca_creation_data->key_bitlength == 384 ||
+			     ca_creation_data->key_bitlength == 521)
+			        ? ca_creation_data->key_bitlength : 256;
 			do {
 				ca_creation_data->key_bitlength =
 				    dialog_ask_for_number (
 				        _("Enter curve size for ECDSA (256, 384, or 521)"),
-				        256, 521, ca_creation_data->key_bitlength ?
-				                  ca_creation_data->key_bitlength : 256);
+				        256, 521, ecdsa_default);
 			} while (ca_creation_data->key_bitlength != 256 &&
 			         ca_creation_data->key_bitlength != 384 &&
 			         ca_creation_data->key_bitlength != 521);

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -59,6 +59,11 @@ void dialog_establish_refresh_function (DialogRefreshCallback callback)
 
 gboolean dialog_refresh_list (void)
 {
+	/* The CLI doesn't register a refresh callback — calling through a
+	 * NULL function pointer would segfault. The GUI registers via
+	 * dialog_establish_refresh_function in main.c. */
+	if (!dialog_refresh_callback)
+		return TRUE;
 	return dialog_refresh_callback();
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,9 @@
 
 TESTS = check_y2k38 check_ui_consistency check_workflows \
         check_cli_email.sh check_cli_wizard.sh check_cli_parity.sh \
-        check_cli_info.sh check_cli_lifecycle.sh
+        check_cli_info.sh check_cli_lifecycle.sh \
+        check_cli_keys.sh check_cli_banner.sh check_cli_import.sh \
+        check_cli_dhgen.sh check_cli_passphrase.py
 check_PROGRAMS = check_y2k38 check_ui_consistency check_workflows
 
 # Per-test wrapper: only check_workflows runs under a headless Wayland
@@ -21,7 +23,9 @@ check_PROGRAMS = check_y2k38 check_ui_consistency check_workflows
 check_workflows_LOG_COMPILER = $(srcdir)/run-headless.sh
 
 EXTRA_DIST = run-headless.sh check_cli_email.sh check_cli_wizard.sh \
-             check_cli_parity.sh check_cli_info.sh check_cli_lifecycle.sh
+             check_cli_parity.sh check_cli_info.sh check_cli_lifecycle.sh \
+             check_cli_keys.sh check_cli_banner.sh check_cli_import.sh \
+             check_cli_dhgen.sh check_cli_passphrase.py
 
 # ---------------------------------------------------------------
 # Y2K38 verification — no GUI dependencies, just stdio + time.h.

--- a/tests/check_cli_banner.sh
+++ b/tests/check_cli_banner.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# check_cli_banner.sh - verify that gnomint-cli prints the "Notice: N
+# certificates expire within..." line (issue #56) when opening a
+# database that contains soon-to-expire certs.
+
+set -eu
+
+GNOMINT_CLI=${GNOMINT_CLI:-../src/gnomint-cli}
+if [ ! -x "$GNOMINT_CLI" ]; then
+    echo "SKIP: $GNOMINT_CLI not built or not executable" >&2
+    exit 77
+fi
+
+TMPDIR_HERE=$(mktemp -d /tmp/gnomint-cli-banner-XXXXXX)
+PREV_WARN=$(gsettings get org.gnome.gnomint expire-warning-days 2>/dev/null || echo 30)
+gsettings set org.gnome.gnomint expire-warning-days 90 || true
+cleanup() {
+    rm -rf "$TMPDIR_HERE"
+    gsettings set org.gnome.gnomint expire-warning-days "$PREV_WARN" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+DB="$TMPDIR_HERE/banner.gnomint"
+CREATE_OUT="$TMPDIR_HERE/create.out"
+REOPEN_OUT="$TMPDIR_HERE/reopen.out"
+
+LC_ALL=C "$GNOMINT_CLI" "$DB" >"$CREATE_OUT" 2>&1 <<'INNER' || true
+addca
+
+
+
+
+
+Soon To Expire CA
+
+
+RSA
+1024
+1
+no
+yes
+quit
+INNER
+
+if ! grep -q "CA generated successfully" "$CREATE_OUT"; then
+    echo "FAIL: setup - CA creation did not complete" >&2
+    cat "$CREATE_OUT" >&2
+    exit 1
+fi
+
+LC_ALL=C "$GNOMINT_CLI" "$DB" >"$REOPEN_OUT" 2>&1 <<'INNER' || true
+quit
+INNER
+
+if ! grep -qE "Notice: [0-9]+ certificates? expires? within" "$REOPEN_OUT"; then
+    echo "FAIL: expected expiry notice missing from reopen output" >&2
+    echo "--- captured ---" >&2
+    cat "$REOPEN_OUT" >&2
+    echo "--- end ---" >&2
+    exit 1
+fi
+
+echo "PASS: gnomint-cli prints the expiry notice (#56) on database open"

--- a/tests/check_cli_dhgen.sh
+++ b/tests/check_cli_dhgen.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# check_cli_dhgen.sh - exercise gnomint-cli `dhgen`. Generation is slow
+# because GnuTLS has to find a safe prime; we use the minimum acceptable
+# size and gate behind GNOMINT_TEST_DHGEN=1 so `make check` stays fast
+# by default. To run: GNOMINT_TEST_DHGEN=1 make -C tests check.
+
+set -eu
+
+if [ "${GNOMINT_TEST_DHGEN:-0}" != "1" ]; then
+    echo "SKIP: set GNOMINT_TEST_DHGEN=1 to run this test (it takes 30s+)" >&2
+    exit 77
+fi
+
+GNOMINT_CLI=${GNOMINT_CLI:-../src/gnomint-cli}
+if [ ! -x "$GNOMINT_CLI" ]; then
+    echo "SKIP: $GNOMINT_CLI not built or not executable" >&2
+    exit 77
+fi
+
+TMPDIR_HERE=$(mktemp -d /tmp/gnomint-cli-dhgen-XXXXXX)
+trap 'rm -rf "$TMPDIR_HERE"' EXIT
+
+DB="$TMPDIR_HERE/dh.gnomint"
+PFILE="$TMPDIR_HERE/dh.pem"
+OUT="$TMPDIR_HERE/out.txt"
+
+LC_ALL=C "$GNOMINT_CLI" "$DB" >"$OUT" 2>&1 <<INNER || true
+dhgen 1024 $PFILE
+quit
+INNER
+
+if [ ! -s "$PFILE" ]; then
+    echo "FAIL: dhgen didn't create $PFILE" >&2
+    cat "$OUT" >&2
+    exit 1
+fi
+if ! grep -q "DH PARAMETERS" "$PFILE"; then
+    echo "FAIL: $PFILE doesn't contain DH PARAMETERS marker" >&2
+    head -5 "$PFILE" >&2
+    exit 1
+fi
+
+echo "PASS: gnomint-cli dhgen wrote a valid PKCS#3 DH parameter file"

--- a/tests/check_cli_import.sh
+++ b/tests/check_cli_import.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# check_cli_import.sh - verify gnomint-cli `importfile` ingests a PEM
+# certificate. We generate a small self-signed cert with OpenSSL, then
+# import it and check that listcert sees the new entry.
+
+set -eu
+
+GNOMINT_CLI=${GNOMINT_CLI:-../src/gnomint-cli}
+if [ ! -x "$GNOMINT_CLI" ]; then
+    echo "SKIP: $GNOMINT_CLI not built or not executable" >&2
+    exit 77
+fi
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "SKIP: openssl not available to generate fixture PEM" >&2
+    exit 77
+fi
+
+TMPDIR_HERE=$(mktemp -d /tmp/gnomint-cli-import-XXXXXX)
+trap 'rm -rf "$TMPDIR_HERE"' EXIT
+
+PEM="$TMPDIR_HERE/imported.pem"
+DB="$TMPDIR_HERE/import.gnomint"
+OUT="$TMPDIR_HERE/out.txt"
+
+# Generate a small self-signed cert. -nodes => key is unencrypted, so
+# importfile won't need a passphrase.
+openssl req -x509 -newkey rsa:1024 -nodes \
+    -days 30 \
+    -subj "/CN=Imported External Cert" \
+    -keyout "$TMPDIR_HERE/key.pem" \
+    -out "$PEM" 2>/dev/null
+
+LC_ALL=C "$GNOMINT_CLI" "$DB" >"$OUT" 2>&1 <<INNER || true
+importfile $PEM
+listcert
+quit
+INNER
+
+if ! grep -q "File imported successfully" "$OUT"; then
+    echo "FAIL: import didn't report success" >&2
+    cat "$OUT" >&2
+    exit 1
+fi
+# listcert truncates the subject to ~14 chars in the table view; look for
+# the prefix that survives the truncation.
+if ! grep -q "Imported Extern" "$OUT"; then
+    echo "FAIL: imported cert not visible in listcert output" >&2
+    echo "--- captured ---" >&2
+    cat "$OUT" >&2
+    echo "--- end ---" >&2
+    exit 1
+fi
+
+echo "PASS: gnomint-cli importfile absorbs an external PEM certificate"

--- a/tests/check_cli_keys.sh
+++ b/tests/check_cli_keys.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# check_cli_keys.sh — verify the gnomint-cli addca prompt accepts every
+# key algorithm gnoMint supports (RSA, DSA, ECDSA, Ed25519) and emits a
+# certificate that reflects the chosen algorithm.
+#
+# Companion to issue #49 (ECDSA/Ed25519 support); the CLI prompt was
+# updated in the parity PR but never tested directly.
+
+set -eu
+
+GNOMINT_CLI=${GNOMINT_CLI:-../src/gnomint-cli}
+if [ ! -x "$GNOMINT_CLI" ]; then
+    echo "SKIP: $GNOMINT_CLI not built or not executable" >&2
+    exit 77
+fi
+
+TMPDIR_HERE=$(mktemp -d /tmp/gnomint-cli-keys-XXXXXX)
+trap 'rm -rf "$TMPDIR_HERE"' EXIT
+
+run_addca() {
+    algo=$1
+    bits_or_curve=$2
+    months=$3
+    db="$TMPDIR_HERE/${algo}.gnomint"
+    out="$TMPDIR_HERE/${algo}.out"
+    # 13-line driver: command + 5 subject + CN + email + SAN + key + size + months + change + confirm
+    LC_ALL=C "$GNOMINT_CLI" "$db" >"$out" 2>&1 <<EOF || true
+addca
+
+
+
+
+
+Test ${algo} CA
+
+
+${algo}
+${bits_or_curve}
+${months}
+no
+yes
+showcert 1
+quit
+EOF
+}
+
+# Ed25519 ignores bit length so we still must answer the prompt for
+# consistency: 0 or any number, but the prompt is suppressed because the
+# new ECDSA/Ed25519 dispatch skips the bitlength question for Ed25519.
+# We provide the value anyway so the driver isn't algorithm-dependent;
+# unused values are ignored.
+
+fail=0
+
+check_session() {
+    algo=$1; out=$2; expected_marker=$3
+    if ! grep -q "CA generated successfully" "$out"; then
+        echo "FAIL: $algo — CA generation didn't complete" >&2
+        echo "--- captured session ---" >&2
+        cat "$out" >&2
+        fail=1
+        return
+    fi
+    if ! grep -qE "$expected_marker" "$out"; then
+        echo "FAIL: $algo — expected marker /$expected_marker/ in showcert output" >&2
+        echo "--- captured session ---" >&2
+        cat "$out" >&2
+        fail=1
+    fi
+}
+
+# RSA 1024
+run_addca RSA 1024 12
+check_session RSA "$TMPDIR_HERE/RSA.out" "Test RSA CA"
+
+# DSA 1024
+run_addca DSA 1024 12
+check_session DSA "$TMPDIR_HERE/DSA.out" "Test DSA CA"
+
+# ECDSA P-256
+run_addca ECDSA 256 12
+check_session ECDSA "$TMPDIR_HERE/ECDSA.out" "Test ECDSA CA"
+
+# Ed25519 (the size field is ignored — pass 0)
+run_addca Ed25519 0 12
+check_session Ed25519 "$TMPDIR_HERE/Ed25519.out" "Test Ed25519 CA"
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: gnomint-cli addca accepts RSA / DSA / ECDSA / Ed25519"
+    exit 0
+else
+    exit 1
+fi

--- a/tests/check_cli_passphrase.py
+++ b/tests/check_cli_passphrase.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+check_cli_passphrase.py - drive gnomint-cli under a pty so we can feed
+passphrases through getpass() (which reads from /dev/tty, not stdin).
+
+Covers commands the other CLI tests can't exercise via stdin:
+  - extractcertpkey
+  - changepassword
+
+The trick: getpass() writes its "Insert passphrase:" prompt to
+/dev/tty AFTER putting the terminal into no-echo mode, and the
+no-echo mode also seems to defer the write through the pty master
+until input is received. Surrounding `printf` messages DO come
+through, so we trigger on the intro text and then blind-write the
+password twice (entry + confirm).
+"""
+
+import errno
+import os
+import pty
+import re
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+CLI = os.environ.get("GNOMINT_CLI", "../src/gnomint-cli")
+PASSPHRASE = "the-correct-horse-staple-passphrase"
+
+
+def spawn_cli(db_path):
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ["LC_ALL"] = "C"
+        try:
+            os.execv(CLI, [CLI, db_path])
+        except FileNotFoundError:
+            os.write(2, b"SKIP: cli not found\n")
+            os._exit(77)
+        except OSError as e:
+            os.write(2, f"FAIL: exec: {e}\n".encode())
+            os._exit(1)
+    # Give the child a tick to start producing output before any expect().
+    # Without this the first select() can return spuriously before exec
+    # has completed inside the child, leaving expect() running its loop
+    # over a pty whose buffer is still empty.
+    time.sleep(0.3)
+    return pid, fd
+
+
+# expect() and expect_any() share a per-fd leftover buffer so bytes
+# that arrive AFTER the matched pattern aren't lost between calls.
+# Without this, "CA generated successfully\n[?2004hgnoMint > " arrives
+# as one chunk, the first expect("CA generated successfully") returns,
+# and the trailing "gnoMint > " is discarded — so the next expect()
+# waits forever for a prompt the child already emitted.
+_expect_leftover = {}  # fd -> bytes left in our buffer after last match
+
+
+def expect(fd, pattern, timeout=15):
+    """Read until `pattern` (string substring) appears. Returns the
+    bytes consumed up to and including the match. Any bytes after the
+    match are stashed for the next expect call on the same fd."""
+    needle = pattern.encode() if isinstance(pattern, str) else pattern
+    buf = _expect_leftover.pop(fd, b"")
+    deadline = time.time() + timeout
+    while True:
+        idx = buf.find(needle)
+        if idx >= 0:
+            cut = idx + len(needle)
+            _expect_leftover[fd] = buf[cut:]
+            return buf[:cut]
+        if time.time() >= deadline:
+            break
+        r, _, _ = select.select([fd], [], [], 0.2)
+        if r:
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError as e:
+                if e.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            buf += chunk
+    _expect_leftover[fd] = buf
+    raise TimeoutError(
+        f"timeout waiting for {needle!r}; got {len(buf)} bytes:\n"
+        + buf.decode("utf-8", errors="replace")
+    )
+
+
+def expect_any(fd, patterns, timeout=15):
+    """Like expect, but waits for the first of multiple needles."""
+    needles = [p.encode() if isinstance(p, str) else p for p in patterns]
+    buf = _expect_leftover.pop(fd, b"")
+    deadline = time.time() + timeout
+    while True:
+        for n in needles:
+            idx = buf.find(n)
+            if idx >= 0:
+                cut = idx + len(n)
+                _expect_leftover[fd] = buf[cut:]
+                return n, buf[:cut]
+        if time.time() >= deadline:
+            break
+        r, _, _ = select.select([fd], [], [], 0.2)
+        if r:
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError as e:
+                if e.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            buf += chunk
+    _expect_leftover[fd] = buf
+    raise TimeoutError(
+        f"timeout waiting for any of {needles!r}; got {len(buf)} bytes:\n"
+        + buf.decode("utf-8", errors="replace")
+    )
+
+
+def send(fd, line):
+    os.write(fd, (line + "\n").encode())
+
+
+def send_passphrase(fd, passphrase):
+    """Blind-write a passphrase twice (entry + confirm). The
+    surrounding getpass() prompts won't reach the master until
+    after we type, but the underlying code is waiting for them."""
+    time.sleep(0.3)
+    os.write(fd, (passphrase + "\n").encode())
+    time.sleep(0.3)
+    os.write(fd, (passphrase + "\n").encode())
+
+
+def bootstrap_ca(fd, cn):
+    """Drive addca to create a single CA. Assumes we're at the prompt."""
+    send(fd, "addca")
+    for _ in range(5):
+        expect(fd, ": ")
+        send(fd, "")           # blank C/ST/L/O/OU
+    expect(fd, ": ")
+    send(fd, cn)               # CN
+    expect(fd, ": ")
+    send(fd, "")               # email
+    expect(fd, ": ")
+    send(fd, "")               # SAN
+    expect(fd, "[RSA]")
+    send(fd, "RSA")
+    expect(fd, "Enter bitlength")
+    send(fd, "1024")
+    expect(fd, "number of months")
+    send(fd, "12")
+    expect(fd, "change anything")
+    send(fd, "no")
+    expect(fd, "Are you sure")
+    send(fd, "yes")
+    expect(fd, "CA generated successfully")
+    expect(fd, "gnoMint > ")
+
+
+def scenario_extractcertpkey(tmpdir):
+    db = os.path.join(tmpdir, "ec.gnomint")
+    key_out = os.path.join(tmpdir, "ec.key.pem")
+
+    pid, fd = spawn_cli(db)
+    try:
+        expect(fd, "gnoMint > ")
+        bootstrap_ca(fd, "Extract CA")
+
+        send(fd, f"extractcertpkey 1 {key_out}")
+        # The intro printf reaches the master before the getpass prompts.
+        expect(fd, "supply a passphrase")
+        send_passphrase(fd, PASSPHRASE)
+        expect(fd, "extracted successfully")
+        expect(fd, "gnoMint > ")
+        send(fd, "quit")
+        time.sleep(0.3)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+
+    if not os.path.isfile(key_out):
+        raise AssertionError(f"extractcertpkey didn't create {key_out}")
+    with open(key_out) as f:
+        data = f.read()
+    expected_markers = (
+        "BEGIN ENCRYPTED PRIVATE KEY",
+        "BEGIN PRIVATE KEY",
+        "BEGIN EC PRIVATE KEY",
+        "BEGIN RSA PRIVATE KEY",
+    )
+    if not any(m in data for m in expected_markers):
+        raise AssertionError(
+            f"extracted key lacks PEM markers (got: {data[:80]!r})"
+        )
+    print("  scenario_extractcertpkey OK")
+
+
+def scenario_changepassword(tmpdir):
+    db = os.path.join(tmpdir, "cp.gnomint")
+    new_password = "new-db-password-12345"
+
+    pid, fd = spawn_cli(db)
+    try:
+        expect(fd, "gnoMint > ")
+        bootstrap_ca(fd, "CP Test CA")
+
+        send(fd, "changepassword")
+        # First, gnomint-cli asks "Do you want to password protect it?
+        # [Yes]/No". Just hit Enter to accept the default Yes.
+        expect(fd, "password protect")
+        send(fd, "")
+        # Then the dialog_get_password intro printf, then two getpass()
+        # calls (entry + confirm). The intro phrase is the trigger.
+        expect(fd, "supply a password")
+        send_passphrase(fd, new_password)
+        # Success: returns to the prompt without an error line.
+        n, buf = expect_any(fd, ["gnoMint > ", "Error"])
+        if b"Error" in buf:
+            raise AssertionError(
+                "changepassword reported an error:\n"
+                + buf.decode("utf-8", errors="replace")
+            )
+        send(fd, "quit")
+        time.sleep(0.3)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+
+    print("  scenario_changepassword OK")
+
+
+def main():
+    if not (shutil.which(CLI) or os.path.isfile(CLI)):
+        print(f"SKIP: {CLI} not found", file=sys.stderr)
+        return 77
+
+    tmpdir = tempfile.mkdtemp(prefix="gnomint-pty-")
+    try:
+        scenario_extractcertpkey(tmpdir)
+        scenario_changepassword(tmpdir)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    print("PASS: extractcertpkey + changepassword exercised under a pty")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except TimeoutError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)
+    except AssertionError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
Closes the GUI / CLI coverage gap: every state-mutating CLI verb in \`ca_commands[]\` now has a test. **13 tests total, 12 PASS / 1 SKIP** (the SKIP is \`dhgen\`, gated behind \`GNOMINT_TEST_DHGEN=1\` because prime search is slow).

## New tests
| File | Covers |
|---|---|
| \`check_cli_keys.sh\` | RSA / DSA / ECDSA / Ed25519 via \`addca\` |
| \`check_cli_banner.sh\` | startup expiry notice (#56) |
| \`check_cli_import.sh\` | \`importfile\` against an OpenSSL-generated PEM |
| \`check_cli_dhgen.sh\` | \`dhgen\` (env-gated) |
| \`check_cli_passphrase.py\` | \`extractcertpkey\` + \`changepassword\` via pty |

The pty driver in \`check_cli_passphrase.py\` was the awkward one: \`getpass()\` writes its prompt to \`/dev/tty\` *after* disabling echo, and the no-echo state seems to defer the prompt-write through the pty master until input arrives. We trigger on the surrounding \`printf\` intro and blind-write the password twice (entry + confirm). The expect helper uses a per-fd \`_expect_leftover\` buffer so bytes that arrive after a matched pattern aren't lost between calls.

## Bugs fixed (caught by the new tests)
1. **\`addca\` / \`addcsr\` crashed picking ECDSA after #61** — pre-set \`key_bitlength = 2048\`, then ECDSA branch called \`dialog_ask_for_number(min=256, max=521, default=2048)\` and asserted. Clamp the default to a valid curve size before the prompt.
2. **\`gnomint-cli importfile\` segfaulted** — \`dialog_refresh_list()\` dereferenced a NULL callback (CLI never registers one). Added a null guard.

## Test plan
- [x] \`make -C tests check\` — 12 PASS, 1 SKIP
- [x] \`GNOMINT_TEST_DHGEN=1 ./check_cli_dhgen.sh\` — PASS (~30s)
- [x] Manual: \`gnomint-cli\` ECDSA addca + importfile work end-to-end