### PR TITLE
Embed SAN editor in the sign-CSR dialog (closes #40)

### DIFF
--- a/gui/new_cert_window.ui
+++ b/gui/new_cert_window.ui
@@ -245,14 +245,12 @@ Common Name (CN):</property>
                     </packing>
                   </child>
                   <child>
-                    <object class="GtkLabel" id="san_label">
+                    <object class="GtkBox" id="san_alignment">
                       <property name="visible">True</property>
                       <property name="can_focus">False</property>
-                      <property name="label" translatable="yes">None</property>
-                      <property name="wrap">True</property>
-                      <property name="selectable">True</property>
-                      <property name="xalign">0</property>
-                      <property name="yalign">0</property>
+                      <child>
+                        <placeholder/>
+                      </child>
                     </object>
                     <packing>
                       <property name="left_attach">1</property>

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -141,24 +141,24 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
@@ -402,7 +402,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Afegir certificat de la CA auto-signat"
@@ -466,7 +466,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -919,7 +919,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "El fitxer ja existeix, se sobreescriurà."
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr "Esteu segur? Sí/[No] "
 
@@ -1074,8 +1074,8 @@ msgstr "Sol·licituds de certificat a la base de dades:\n"
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr "Id.\tId. pare\tTitular de la CSR\t\tClau en BD?\n"
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr "L'identificador de la CA proporcionat no és vàlid"
 
@@ -1088,127 +1088,127 @@ msgstr ""
 "Introduïu les dades corresponents al titular de la sol·licitud de signatura "
 "del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr "Introduïu el país (C)"
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr "Introduïu el nom de l'estat o la província (ST)"
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr "Introduïu la localitat o la ciutat (L)"
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr "Introduïu l'organització (O)"
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr "Introduïu la Unitat organitzativa (OU)"
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr "Introduïu Nom habitual (CN)"
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 #, fuzzy
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Introduïu el tipus de clau que es crearà (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Introduïu la mida de la clau en bits (múltiple de 1024)"
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr "Aquestes són les propietats de la CSR proporcionada:\n"
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr "Titular:\n"
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tNom distintiu: "
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr "Parella de claus\n"
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tTipus: %s\n"
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tLongitud en bits: %d\n"
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Voleu canviar quelcom? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Ara es crearà una petició de signatura del certificat (CSR) amb aquestes "
 "propietats."
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr "Esteu segur [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operació cancel·lada\n"
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1217,7 +1217,7 @@ msgstr ""
 "Introduïu les dades corresponents al titular de la nova Entitat "
 "Certificadora (CA):\n"
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1225,216 +1225,216 @@ msgstr ""
 "Introduïu el nombre de mesos abans la caducitat de la nova Entitat "
 "certificadora"
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Aquestes són les propietats proporcionades per a la nova CA:\n"
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr "Validesa\n"
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr "Validesa:\n"
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tCaduca el: %s\n"
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr "Es crearà una nova Entitat certificadora (CA) amb aquestes propietats."
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr "L'identificador de certificat proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Clau privada extreta amb èxit al fitxer: '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr "L'identificador de la CSR proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr "Aquest certificat serà revocat."
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificat revocat.\n"
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Usos del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Ús com a entitat certificadora habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Ús com a entitat certificadora deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr "* Ús per a la firma de CRLs habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr "* Ús per a la firma de CRLs deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Ús per a la signatura digital habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Ús per a la signatura digital deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "Ús per al xifrat de dades habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "Ús per al xifrat de claus habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "Ús per al xifrat de claus deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "Ús per al no repudi habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "Ús per al no repudi deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "Ús per a la negociació de claus habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "Ús per a la negociació de claus deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Finalitats del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Finalitat per a la protecció del correu electrònic habilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Finalitat per a la protecció del correu electrònic deshabilitat.\n"
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Finalitat per a la firma de codi  habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Finalitat per a la firma de codi deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Finalitat de client web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Finalitat de client web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Finalitat de servidor web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Finalitat de servidor web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Finalitat de marca horària habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Finalitat de marca horària deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "* Finalitat de signatura OCSP habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "* Finalitat de signatura OCSP deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Qualsevol finalitat habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Qualsevol finalitat deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr "Ara es signarà la següent petició de signatura de certificat (CSR):\n"
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr "amb el certificat corresponent a aquesta CA:\n"
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1442,199 +1442,199 @@ msgstr ""
 "Màxim nombre de mesos abans de la caducitat del nou certificat (0 per a "
 "cancel·lar):"
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr "El nou certificat es validarà per als següents usos i finalitats:\n"
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr "Desitgeu canviar alguna propietat del nou certificat? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* Habilitar ús com Entitat certificadora? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Ús com a Entitat certificadora deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* Habilitar ús per a la signatura de CRL? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Ús per a la signatura de CRL deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Habilitar l'ús per a la signatura digital? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Ús per a la signatura digital deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Habilitar l'ús per al xifratge de dades? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Ús per al xifratge de dades deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Habilitar l'ús per al xifrat de claus? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Ús per al xifratge de claus deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr "Habilitar l'ús per al no repudi? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr "* Ús per al no repudi deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "Habilitar l'ús per a negociació de claus? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "* Ús per a la negociació de claus deshabilitat per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de protecció de correu electrònic? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 "* Finalitat de protecció del correu electrònic deshabilitada per una "
 "directiva.\n"
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de signatura de codi? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Finalitat de signatura de codi deshabilitada per una directiva.\n"
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de client web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Finalitat de client web TLS deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "Habilitar la finalitat de servidor web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Finalitat de servidor web TLS deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "Habilitat la finalitat de marcatge temporal? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "Finalitat de marcatge temporal deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "Habilitar la finalitat per a la signatura d'OCSP? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 "* Finalitat per a la signatura d'OCSP deshabilitada per una directiva\n"
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr "Habilitar l'ús per a qualsevol finalitat? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 "* L'ús per a qualsevol finalitat s'ha deshabilitat amb una directiva.\n"
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 "S'ha obtingut tota la informació necessària per la generació del certificat."
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "Voleu continuar amb la signatura i generació del certificat? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificat signat.\n"
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr "La sol·licitud de signatura de certificat (CSR) s'esborrarà."
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr "Aquesta operació no pot desfer-se. Esteu segur? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Sol·licitud de signatura de certificat esborrada.\n"
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "CRL generada amb èxit i desada al fitxer '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "La longitud en bits del nombre primer ha de ser múltiple enter de 1024"
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Els paràmetres Diffie-Hellman s'han creat i s'han desat correctament al "
 "fitxer '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr "Actualment la base de dades no es troba protegida per contrasenya."
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "Desitgeu protegir-la amb contrasenya? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1647,37 +1647,37 @@ msgstr ""
 "faci ús de\n"
 "qualsevol clau privada a la base de dades."
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr "Introduïu la contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr "Torneu a introduir la contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr "Les contrasenyes introduïdes són diferents."
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Contrasenya establerta amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr "No s'ha fet res.\n"
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr "Actualment la base de dades ESTÀ protegida amb contrasenya."
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "Desitgeu eliminar aquesta protecció amb contrasenya? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1686,13 +1686,13 @@ msgstr ""
 "Per eliminar la protecció amb contrasenya, heu de proporcionar la \n"
 "contrasenya actual.\n"
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Introduïu la contrasenya actual de la base de dades (Buida per a "
 "cancel·lar): "
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1700,7 +1700,7 @@ msgstr ""
 "La contrasenya actual introduïda\n"
 "no coincideix amb la contrasenya real de la base de dades."
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1708,12 +1708,12 @@ msgstr ""
 "S'ha produït un error al eliminar la contrasenya de\n"
 "la base de dades. S'ha cancel·lat l'operació."
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Contrasenya eliminada amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
@@ -1721,7 +1721,7 @@ msgstr ""
 "Ha de proporcionar la contrasenya actual de la base de dades abans de "
 "canviar-la.\n"
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1735,15 +1735,15 @@ msgstr ""
 "Aquesta contrasenya es demanarà sempre que gnoMint faci ús d'alguna clau\n"
 "privada a la base de dades."
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr "Introduïu la nova contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr "Torneu a introduïr la contrasenya:"
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1751,296 +1751,296 @@ msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. \n"
 "S'ha cancel·lat la operació"
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "La contrasenya s'ha canviat amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr "S'han produït problemes en importar el fitxer indicat."
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Fitxer importat amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Directori importat amb èxit.\n"
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr "Certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tNúm. de sèrie: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr "\tNom distintiu (DN): %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr "Cap."
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tIdentificador únic: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr "Emissor:\n"
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Empremtes digitals:\n"
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tEmpremta digital SHA1: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tEmpremta digital MD5: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tEmpremta digital SHA1: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Sol·licitud de signatura de certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 "Els certificats generats hereten el país de la CA                           "
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 "Els certificats generats hereten l'estat/província de la "
 "CA                             "
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 "Els certificats generats hereten localitat o ciutat de la "
 "CA                          "
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 "Els certificats generats hereten l'Organització de la "
 "CA                      "
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 "Els certificats generats hereten la unitat organitzacional de la "
 "CA               "
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 "El país dels certificats generats ha de coincidir amb la CA            "
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 "L'Estat o província dels cert. generats ha de coincidir amb la "
 "CA              "
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 "La localitat o ciutat dels cert. generats ha de coincidir amb la "
 "CA           "
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 "L'organització dels cert. generats ha de coincidir amb la de la CA       "
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr "La Unitat Organitzativa dels cert. generats ha de coincidir amb la CA"
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Nombre màxim d'hores entre actualitzacions de CRLs                       "
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 "Num. màxim de mesos abans de la caducitat dels nous certificats           "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Habilitar l'ús com a CA en els certificats "
 "generats                                 "
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Habilitar l'ús per a signatura de CRLs en els certificats "
 "generats                           "
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Habilitar l'ús per al no repudi en els certificats "
 "generats                     "
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Habilita l'ús per a la signatura digital en els cert. "
 "generats                  "
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Habilita l'ús per al xifratge de claus en els cert. "
 "generats                   "
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Habilita l'ús per a la negociació de claus en els cert. "
 "generats                      "
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Habilita l'ús per al xifratge de dades en els cert. "
 "generats                  "
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Habilita la finalitat de servidor web TLS per als cert. "
 "generats                 "
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Habilita la finalitat de client web TLS per als cert. "
 "generats                 "
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -2049,7 +2049,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -2057,14 +2057,14 @@ msgstr ""
 "  David Marín https://launchpad.net/~davefx\n"
 "  Sergio Oller https://launchpad.net/~zeehio"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2082,7 +2082,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2099,204 +2099,204 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s versió %s\n"
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr "Ordres disponibles:\n"
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "L'identificador de la CA proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Creant un certificat arrel de la CA"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "web server"
 msgstr "Servidor web TLS"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "email server"
 msgstr "Servidor web TLS"
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Nombre de CSRs en el fitxer: %d\n"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "S'ha produït un error signant el certificat"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Usos del certificat:\n"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy
 msgid "Web Server"
 msgstr "Servidor web TLS"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 #, fuzzy
 msgid "Usage: renewcert <cert-id>"
 msgstr "showcert <id del certificat>"
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 #, fuzzy
 msgid "The given certificate id is not valid"
 msgstr "L'identificador de certificat proporcionat no és vàlid"
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 #, fuzzy
 msgid "Renew? [Yes]/No "
 msgstr "Esteu segur [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 msgid "Certificate renewed. New certificate id: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 #, fuzzy
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr "extractcertpkey <id. del certificat> <nom del fitxer>"
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Afegir certificat de la CA auto-signat"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Certificat revocat.\n"
 msgstr[1] "Certificat revocat.\n"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "_Obre una base de dades de certificats"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 #, fuzzy
 msgid "None"
 msgstr "Cap."
@@ -2734,22 +2734,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -3031,37 +3031,37 @@ msgstr "Mida en bits de la clau privada:"
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -3070,7 +3070,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -130,23 +130,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
@@ -371,7 +371,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 msgid "Cannot read file."
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -839,7 +839,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
@@ -994,8 +994,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1006,608 +1006,608 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1615,275 +1615,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1892,7 +1892,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1901,14 +1901,14 @@ msgstr ""
 "  Kuvaly [LCT] https://launchpad.net/~kuvaly\n"
 "  Luboš Staněk https://launchpad.net/~lubek"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1926,7 +1926,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1943,195 +1943,195 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, c-format
 msgid "Certificate type: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 msgid "The given certificate id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 msgid "Renew? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 msgid "Certificate renewed. New certificate id: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 msgid "Cannot write chain file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2567,22 +2567,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2859,37 +2859,37 @@ msgstr ""
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -2898,7 +2898,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -141,24 +141,24 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -893,7 +893,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "Die Datei existiert bereits und wird überschrieben werden."
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
@@ -1048,8 +1048,8 @@ msgstr "Zertifikatanfragen in Datenbank:\n"
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr "Die angegebene Kennung der Zertifizierungsstelle ist ungültig"
 
@@ -1060,136 +1060,136 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr "Land eingeben (C)"
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr "Bundesland oder Kanton eingeben (ST)"
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr "Ort oder Stadt eingeben (L)"
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr "Organisation eingeben (O)"
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr "Organisationseinheit eingeben (OU)"
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 #, fuzzy
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Typ des zu erzeugenden Schlüssels eingeben (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 "Bitlänge des Schlüssels eingeben (muss ein ganzzahliges Vielfaches von 1024 "
 "sein)"
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr "Schlüsselpaar\n"
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tTyp: %s\n"
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tBitlänge des Schlüssels: %d\n"
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Wollen Sie noch etwas ändern? Ja/[Nein] "
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Sie sind dabei, eine Signaturanfrage für ein Zertifikat mit den folgenden "
 "Parametern zu erstellen."
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr "Sind Sie sicher? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Vorgang wurde abgebrochen.\n"
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1197,218 +1197,218 @@ msgstr ""
 "Geben Sie die Anzahl der Monate bis zum Ablauf der neuen "
 "Zertifizierungsstelle an"
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Dies sind die Eigenschaften der neuen Zertifizierungsstelle:\n"
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr "Gültigkeit\n"
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr "Gültigkeit:\n"
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tAktiviert am: %s\n"
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tLäuft ab am: %s\n"
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Sie sind dabei, eine neue Zertfizierungsstelle mit den folgenden "
 "Eigenschaften zu erstellen:"
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr "Die angegebene Zertifikatkennung ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Geheimer Schlüssel wurde erfolgreich in Datei »%s« entpackt\n"
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr "Die angegebene Kennung der Siganturanfrage ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr "Dieses Zertifikat wird widerrufen werden."
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Zertifikat benutzt:\n"
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Zertifikatzwecke:\n"
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1416,197 +1416,197 @@ msgstr ""
 "Geben Sie die Anzahl der Monate bis zum Ablauf des neuen Zertifikats ein (0 "
 "für abbrechen)"
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 "Wollen Sie irgeneine Eigenschaft des neuen Zertifikats ändern? Ja/[Nein] "
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "Wollen Sie das Signieren fortsetzen? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Zertifikat wurde signiert.\n"
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr "Diese Signaturanfrage für ein Zertifikat wird gelöscht werden."
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 "Dieser Vorgang kann nicht rückgängig gemacht werden. Sind Sie sicher? Ja/"
 "[Nein] "
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Signaturanfrage wurde gelöscht.\n"
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Diffie-Hellman-Parameter wurden erstellt und erfolgreich in Datei »%s« "
 "gespeichert.\n"
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr "Gegenwärtig ist die Datenbank nicht durch ein Passwort geschützt."
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "Wollen Sie sie durch ein Passwort schützen? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1617,37 +1617,37 @@ msgstr ""
 "diese benutzen können. Dieses Passwort wird jedesmal abgefragt,\n"
 "wenn gnoMint einen geheimen Schlüssel in der Datenbank benutzen will."
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr "Passwort eingeben:"
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr "Passwort eingeben (Bestätigung):"
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr "Die eingegebenen Passwörter sind unterschiedlich."
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Passwort wurde erfolgreich festgelegt.\n"
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr "Gegenwärtig IST die Datenbank durchein Passwort geschützt."
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "Wollen Sie diesen Passwortschutz entfernen? Ja/[Nein] "
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1656,13 +1656,13 @@ msgstr ""
 "Zum Entfernen des Passwortschutzes muss das aktuelle Passwort\n"
 "der Datenbank eingegeben werden.\n"
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Bitte geben Sie das aktuelle Passwort der Datenbank ein (leer lassen, um "
 "abzubrechen): "
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1670,7 +1670,7 @@ msgstr ""
 "Das aktuell eingebene Passwort stimmt nicht mit dem\n"
 "aktuellen Passwort der Datenbank überein."
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1678,12 +1678,12 @@ msgstr ""
 "Fehler beim Entfernen des Datenbank-Passworts. \n"
 "Vorgang wurde abgebrochen."
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Passwort wurde erfolgreich entfernt.\n"
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
@@ -1691,7 +1691,7 @@ msgstr ""
 "Sie müssen das aktuelle Datenbank-Passwort eingeben, bevor das Passwort "
 "geändert werden kann.\n"
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1699,15 +1699,15 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr "Neues Passwort eingeben:"
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr "Neues Passwort eingeben (Bestätigung):"
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1715,254 +1715,254 @@ msgstr ""
 "Fehler beim Ändern des Datenbank-Passworts. \n"
 "Vorgang wurde abgebrochen."
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Passwort wurde erfolgreich geändert.\n"
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr "Problem beim Importieren der angegebenen Datei."
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Datei wurde erfolgreich importiert.\n"
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Ordner wurde erfolgreich importiert.\n"
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr "Zertifikat:\n"
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tSeriennummer: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr "Nichts."
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tEindeutige Kennung: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Fingerabdrücke:\n"
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tSHA1-Fingerabdruck: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tMD5-Fingerabdruck: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tSHA1-Fingerabdruck: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Signaturanfrage für Zertifikat:\n"
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr "Sind Sie sicher? Ja/[Nein] : "
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr "Id.\tName\t\t\tWert\n"
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr "0\tUnterstützung für Gnome-Schlüsselbund\t%d\n"
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr "Die angegebene Einstellungskennung ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -1971,7 +1971,7 @@ msgstr ""
 "%s Version %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1984,7 +1984,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1994,7 +1994,7 @@ msgstr ""
 "  Mario Blättermann https://launchpad.net/~mariobl-freenet\n"
 "  Michael Honsel https://launchpad.net/~lesnoh"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
@@ -2003,7 +2003,7 @@ msgstr ""
 "Übersetzer:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2021,7 +2021,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2038,203 +2038,203 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s-Version %s\n"
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr "Verfügbare Befehle:\n"
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "Die angegebene Kennung der Zertifizierungsstelle ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Fehler beim Setzen der Version des Zertifikats"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "web server"
 msgstr "TLS-Webserver"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "email server"
 msgstr "TLS-Webserver"
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Schlüsselerzeugung ist fehlgeschlagen"
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Erzeugung der Signaturanfrage ist fehlgeschlagen"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Fehler beim Signieren des Zertifikats"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Zertifikat benutzt:\n"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy
 msgid "Web Server"
 msgstr "TLS-Webserver"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 #, fuzzy
 msgid "The given certificate id is not valid"
 msgstr "Die angegebene Zertifikatkennung ist ungültig"
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 #, fuzzy
 msgid "Renew? [Yes]/No "
 msgstr "Sind Sie sicher? [Ja]/Nein "
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 #, fuzzy
 msgid "Certificate renewed. New certificate id: %"
 msgstr "Erzeugung des Zertifikats ist fehlgeschlagen"
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Zertifikat wurde widerrufen.\n"
 msgstr[1] "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "Zertifikat-Datenbank ö_ffnen"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2667,7 +2667,7 @@ msgstr "Signaturanfrage konnte nicht gespeichert werden"
 msgid "CSR generated successfully"
 msgstr "Signaturanfrage wurde erfolgreich erzeugt"
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 #, fuzzy
 msgid "None"
 msgstr "Nichts."
@@ -2680,7 +2680,7 @@ msgstr ""
 "<b>Der zugehörige geheime Schlüssel für diese Siganturanfrage wurde in einer "
 "externen Datei gespeichert.</b>"
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
@@ -2689,15 +2689,15 @@ msgstr ""
 "\n"
 "Das Passwort muss mindestens aus %d Zeichen bestehen\n"
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr "Dieses Funktionsmerkmal ist noch nicht implementiert."
 
@@ -3004,37 +3004,37 @@ msgstr "Länge des geheimen Schlüssels in Bit"
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -3043,7 +3043,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr "Fehler beim Bestätigen der Signaturanfrage für ein Zertifikat."
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -142,23 +142,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
@@ -409,7 +409,7 @@ msgstr "Comparar con un archivo PEM…"
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Error al escribir la cadena: %s"
@@ -480,7 +480,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -932,7 +932,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "El fichero ya existe, por lo que se sobreescribirá"
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr "¿Está seguro? Sí/[No] "
 
@@ -1088,8 +1088,8 @@ msgstr "Solicitudes de certificación en base de datos:\n"
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr "Id.\tId. padre\tTitular CSR\t\t¿Clave en BD?\n"
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr "El identificador de CA proporcionado no es válido"
 
@@ -1102,127 +1102,127 @@ msgstr ""
 "Por favor: introduzca los datos correspondientes al titular de la solicitud "
 "de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr "Introduzca país (C)"
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr "Introduzca nombre de estado o provincia (ST)"
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr "Introduzca ciudad o localidad (L)"
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr "Introduzca organización (O)"
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr "Introduzca Unidad organizativa (OU)"
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr "Introduzca Nombre común (CN)"
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr "Introduzca dirección de correo (deje vacío para ninguna)"
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 #, fuzzy
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Introduzca el tipo de clave que se va a crear (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Introduzca tamaño de clave en bits (múltiplo de 1024)"
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr "Estas son las propiedades proporcionadas del CSR:\n"
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr "Titular:\n"
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tNombre distintivo: "
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, fuzzy, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr "Nombre alternativo de titular"
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr "Par de claves\n"
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tTipo: %s\n"
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tLongitud en bits: %d\n"
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "¿Desea cambiar algo? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Se va a proceder a crear una solicitud de certificación con estas "
 "propiedades."
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr "¿Está seguro? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operación cancelada.\n"
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1231,7 +1231,7 @@ msgstr ""
 "Por favor: introduzca los datos correspondientes al titular de la nueva "
 "autoridad de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1239,218 +1239,218 @@ msgstr ""
 "Introduzca el número máximo de meses antes de la caducidad de lanueva "
 "autoridad de certificación"
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Estas son las propiedades proporcionadas para la nueva AC:\n"
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr "Validez\n"
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr "Validez:\n"
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tActivado el: %s\n"
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tCaduca el: %s\n"
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Se va a proceder a crear una nueva autoridad de certificación con "
 "estaspropiedades."
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr "El identificador de certificado proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Clave privada extraída con éxito al fichero '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr "El identificador de CSR proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr "Este certificado será revocado."
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificado revocado.\n"
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Usos del certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Uso como Autoridad de Certificación habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Uso como Autoridad de Certificación deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr "* Uso para firma de CRLs habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr "* Uso para firma de CRLs deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Uso para firma digital habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Uso para firma digital deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "Uso para cifrado de datos habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Uso para cifrado de claves habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Uso para cifrado de claves deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "* Uso para no repudio habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "* Uso para no repudio deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "* Uso para negociación de claves habilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "* Uso para negociación de claves deshabilitado.\n"
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Finalidades del certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Finalidad para protección de correo electrónico habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Finalidad para protección de correo electrónico deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Finalidad de firma de código habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Finalidad de firma de código deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Finalidad de cliente web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Finalidad de cliente web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Finalidad de servidor web TLS habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Finalidad de servidor web TLS deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Finalidad de sellado de tiempo habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Finalidad de sellado de tiempo deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "* Finalidad de firma de OCSP habilitada\n"
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "* Finalidad de firma de OCSP deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Cualquier finalidad habilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Cualquier finalidad deshabilitada.\n"
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr "Se va a proceder a firmar la siguiente solicitud de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr "con el certificado correspondiente a esta AC:\n"
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1458,197 +1458,197 @@ msgstr ""
 "Máximo número de meses antes de la caducidad del nuevo certificado (0 para "
 "cancelar):"
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 "El nuevo certificado se validará para los siguientes usos y finalidades:\n"
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr "¿Desea cambiar alguna propiedad del nuevo certificado? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* ¿Habilitar uso como Autoridad de certificación? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Uso como Autoridad de Certificación deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* ¿Habilitar uso para firma de CRL? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Uso para firmado de CRL deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* ¿Habilitar uso para firma digital? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Uso para firma digital deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "¿Habilitar uso para cifrado de datos? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Uso para cifrado de datos deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "¿Habilitar uso para cifrado de claves? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Uso para cifrado de claves deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr "¿Habilitar uso para no repudio? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr "* Uso para no repudio deshabilitado por política\n"
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "¿Habilitar uso para negociación de claves? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "Uso para negociación de claves deshabilitado por politica\n"
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de protección de correo electrónico? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 "* Finalidad de protección de correo electrónico deshabilitada por política.\n"
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de firma de código? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Finalidad de firma de código deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de cliente web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Finalidad de cliente web TLS deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de servidor web TLS? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Finalidad de servidor web TLS deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad de sellado de tiempo? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "* Finalidad de sellado de tiempo deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "¿Habilitar finalidad para firma de OCSP? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr "* Finalidad para firma de OCSP deshabilitada por política\n"
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr "¿Habilitar uso para cualquier finalidad? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr "* Uso para cualquier finalidad deshabilitado por política.\n"
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 "Ya se cuenta con todos los datos necesarios para la generación del "
 "certificado."
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "¿Desea continuar con la firma y generación del certificado? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificado firmado.\n"
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr "Se borrará esta solicitud de certificación."
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr "Esta operación no puede deshacerse. ¿Está seguro? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Solicitud de certificación borrada.\n"
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "CRL generada con éxito y guardada en fichero '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "La longitud en bits del número primo debe ser múltiplo entero de 1024"
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Parámetros Diffie-Hellman creados y guardados correctamente en fichero '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr "En estos momentos, la base de datos no está protegida con clave."
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "¿Desea protegerlo con contraseña? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1659,37 +1659,37 @@ msgstr ""
 "hacer uso de ellas. Esta contraseña será solicitada siempre que gnoMint\n"
 "requiera emplear cualquier clave privada de la base de datos."
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr "Introduzca contraseña:"
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr "Introduzca contraseña (confirmación):"
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr "Las contraseñas introducidas son distintas."
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Contraseña establecida con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr "No se ha hecho nada.\n"
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr "En estos momentos, la base de datos ESTÁ protegida con contraseña."
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "¿Desea eliminar esta protección con contraseña? Sí/[No] "
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1698,12 +1698,12 @@ msgstr ""
 "Para eliminar la protección mediante clave, debe proporcionar la \n"
 "contraseña actual.\n"
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Introduzca la contrase_ña actual de la base de datos (Vacía para cancelar): "
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1711,7 +1711,7 @@ msgstr ""
 "La contraseña actual que ha introducido\n"
 "no coincide con la contraseña real de la base de datos."
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1719,12 +1719,12 @@ msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de \n"
 "datos. Se canceló la operación."
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Contraseña eliminada con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
@@ -1732,7 +1732,7 @@ msgstr ""
 "Debe proporcionar la contraseña actual de la base de datos antes de "
 "cambiarla.\n"
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1745,15 +1745,15 @@ msgstr ""
 "solicitada siempre que gnoMint vaya a hacer uso de cualquier\n"
 "clave privada de la base de datos."
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr "Introduzca la nueva contraseña:"
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr "Introduzca contraseña (confirmación):"
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1761,237 +1761,237 @@ msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. \n"
 "Se canceló la operación."
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Contraseña cambiada con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr "Hubo problemas al importar el fichero indicado."
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Fichero importado con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Directorio importado con éxito.\n"
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr "Certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tNº de serie: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr "\tNombre distintivo: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr "Ninguno."
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tIdentificador único: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr "Emisor:\n"
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Huellas digitales:\n"
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tHuella digital SHA1: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tHuella digital MD5: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tHuella digital SHA256: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Solicitud de certificación:\n"
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 "Los certificados generados heredan país de la AC                           "
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 "Los certificados generados heredan estado/provincia de la "
 "AC                             "
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 "Los certificados generados heredan localidad o ciudad de la "
 "AC                          "
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 "Los certificados generados heredan Organización de la "
 "AC                      "
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 "Los certificados generados heredan unidad organizacional de la "
 "AC               "
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 "El país de los certificados generados debe coincidir con la AC            "
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 "Estado o provincia de certif. generados debe coincidir con la "
 "AC              "
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 "Localidad o ciudad de certif. generados debe coincidir con la AC           "
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 "Organización de certif. generados debe coincidir con la de la AC       "
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr "Unidad organizativa de certif. debe coincidir con la de la AC"
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Número máximo de horas entre actualizaciones de CRLs                       "
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr "Punto de distribución de CRL (URL donde se publica la CRL)"
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 "Máximo nº de meses antes de caducidad de nuevos certificados           "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Habilitar uso como AC en certificados "
 "generados                                 "
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Habilitar uso para firma de CRLs en certificados "
 "generados                           "
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Habilitar uso para no repudio en certificados generados                     "
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Habilitar uso para firma digital en certificados generados                  "
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Habilitar uso para cifrado de claves en certificados "
 "generados                   "
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Habilitar uso para negociación de claves en certificados "
 "generados                      "
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Habilitar uso para cifrado de datos en certificados "
 "generados                  "
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Habilitar finalidad de servidor web TLS para certific. "
 "generados                 "
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Habilitar finalidad para cliente web TLS en certific. "
 "generados                 "
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 "Habilitar finalidad para sellado de tiempo en certific. "
 "generados                  "
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 "Habilitar finalidad de firma de código en certificados generados            "
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 "Habilitar finalidad para protección de correo-e en cert. "
 "generados               "
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 "Habilitar finalidad de firma de OCSP en certificados "
 "generados                   "
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 "Habilitar cualquier finalidad en certificados "
 "generados                            "
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Mostrando políticas del siguiente certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
@@ -2000,16 +2000,16 @@ msgstr ""
 "\n"
 "Políticas:\n"
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr "Id.\tDescripción\t\t\t\t\t\t\t\tValor\n"
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr "El identificador de política proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
@@ -2018,35 +2018,35 @@ msgstr ""
 "Se va a asignar a la política\n"
 "'%s' el nuevo valor '%s'."
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr "¿Está seguro? Sí/[No] : "
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr "Política establecida correctamente a '%s'.\n"
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr "Preferencias actuales de gnoMint-cli:\n"
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr "Id.\tNombre\t\t\tValor\n"
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr "0\tSoporte de gnome-keyring\t%d\n"
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr "El identificador de preferencia proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
@@ -2054,7 +2054,7 @@ msgid ""
 msgstr ""
 "Va a asignar a la preferencia 'Soporte de gnome-keyring' el nuevo valor '%d'."
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -2063,7 +2063,7 @@ msgstr ""
 "%s versión %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -2076,7 +2076,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -2088,7 +2088,7 @@ msgstr ""
 "  Sergio Oller https://launchpad.net/~zeehio\n"
 "  Victor Herrero https://launchpad.net/~victorhera"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
@@ -2097,7 +2097,7 @@ msgstr ""
 "Traductores:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2132,7 +2132,7 @@ msgstr ""
 "<http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2163,110 +2163,110 @@ msgstr ""
 "con este programa; si no es así, visite <http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s versión %s\n"
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr "Órdenes disponibles:\n"
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr "====================\n"
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr "Saliendo de gnomint-cli...\n"
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "El identificador de CA proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr "El tipo de certificado debe ser 'web' o 'email'"
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr "El nombre del servidor no puede estar vacío"
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Creando certificado raíz de la AC"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr "servidor web"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr "servidor de correo"
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Error en generación de claves"
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Error en generación de solicitud"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "Fallo al inicializar: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Error al firmar certificado"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificado exportado con éxito"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Usos del certificado:\n"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr "Servidor Web"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr "Servidor de correo"
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 #, fuzzy
 msgid "Usage: renewcert <cert-id>"
 msgstr "showcert <id de certificado>"
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 #, fuzzy
 msgid "The given certificate id is not valid"
 msgstr "El identificador de certificado proporcionado no es válido"
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 #, fuzzy
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
@@ -2280,92 +2280,92 @@ msgstr ""
 "El certificado antiguo permanecerá en la base de datos — revóquelo "
 "manualmente cuando haya desplegado el nuevo."
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 #, fuzzy
 msgid "Renew? [Yes]/No "
 msgstr "¿Está seguro? [Sí]/No "
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 #, fuzzy
 msgid "Certificate renewed. New certificate id: %"
 msgstr "Error en generación del certificado"
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 #, fuzzy
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr "extractcertpkey <id. de certificado> <nombre de fichero>"
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Error al escribir la cadena: %s"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Certificado revocado.\n"
 msgstr[1] "Certificado revocado.\n"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr "Coincidencias (id\tserie\tasunto):\n"
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] "%d coincidencia.\n"
 msgstr[1] "%d coincidencias.\n"
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "Abrir base de datos de certificados"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2806,7 +2806,7 @@ msgstr "La solicitud no se pudo guardar"
 msgid "CSR generated successfully"
 msgstr "Solicitud de certificación generada con éxito"
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 #, fuzzy
 msgid "None"
 msgstr "Ninguno."
@@ -2819,7 +2819,7 @@ msgstr ""
 "<b>La clave privada correspondiente a esta petición de certificación está "
 "almacenada en un fichero externo.</b>"
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
@@ -2828,15 +2828,15 @@ msgstr ""
 "\n"
 "La contraseña debe tener, al menos, %d caracteres\n"
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr "Sí#Si#SI#SÍ#S#s#si#sí"
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr "No#no#N#n"
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr "Por hacer. Funcionalidad aún no implementada."
 
@@ -3166,7 +3166,7 @@ msgstr "Longitud en bits de la clave privada:"
 msgid "ECDSA curve:"
 msgstr "Curva ECDSA:"
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
@@ -3174,7 +3174,7 @@ msgstr ""
 "La política de esta AC obliga a que los campos \"país\" de los certificados "
 "expedidos seanigual al del certificado de la AC."
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
@@ -3182,7 +3182,7 @@ msgstr ""
 "La política de esta AC obliga a que los campos \"estado/provincia\" de los "
 "certificados expedidos seanigual al del certificado de la AC."
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
@@ -3190,7 +3190,7 @@ msgstr ""
 "La política de esta AC obliga a que los campos \"localidad/ciudad\" de los "
 "certificados expedidos seanigual al del certificado de la AC."
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
@@ -3198,7 +3198,7 @@ msgstr ""
 "La política de esta AC obliga a que los campos \"organización\" de los "
 "certificados expedidos seanigual al del certificado de la AC."
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
@@ -3206,7 +3206,7 @@ msgstr ""
 "La política de esta AC obliga a que los campos \"unidad organizativa\" de "
 "los certificados expedidos seanigual al del certificado de la AC."
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -3221,7 +3221,7 @@ msgstr ""
 "que el nuevo certificado se creará con la misma fecha de caducidad que la "
 "del certificado de la AC."
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr "Error al firmar CSR."
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -137,23 +137,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
@@ -381,7 +381,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Virhe allekirjoitettaessa varmennetta"
@@ -438,7 +438,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -850,7 +850,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
@@ -1005,8 +1005,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1017,608 +1017,608 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1626,275 +1626,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1903,21 +1903,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Ilkka Tuohela https://launchpad.net/~hile"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1935,7 +1935,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1952,196 +1952,196 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, c-format
 msgid "Certificate type: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 msgid "The given certificate id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 msgid "Renew? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 msgid "Certificate renewed. New certificate id: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Varmennuspyyntöjen näkyvyys"
 msgstr[1] "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2567,7 +2567,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2577,22 +2577,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2869,37 +2869,37 @@ msgstr ""
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -2908,7 +2908,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -141,24 +141,24 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "L'initialisation a échoué : %s\n"
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -898,7 +898,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "Le fichier existe déjà, il va être remplacé."
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr "Êtes-vous sûr ? Oui/[Non] "
 
@@ -1053,8 +1053,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1065,135 +1065,135 @@ msgid ""
 "Request:\n"
 msgstr "Titulaire de la Requête de Signature de Certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr "Entrez la pays (C)"
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr "Entrez l'état ou la province (ST)"
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr "Entrez la localité ou la ville (L)"
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr "Entrez l'organisation (O)"
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr "Entrez l'unité d'organisation (OU)"
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr "Entrez le nom commun (CN)"
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 #, fuzzy
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Entrez le type de clé que vous allez créer (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Entrez la taille en bits de la clé (ce doit être un multiple de 1024)"
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 "Voici les propriétés de la Requête de Signature de Certificat fournie :\n"
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr "Titulaire\n"
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tNom distinct : "
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, fuzzy, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr "Nom alternatif du titulaire"
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr "Paire de clés\n"
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tType : %s\n"
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tTaille en bits de la clé : %d\n"
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Souhaitez vous modifier quelque chose ? Oui/[Non] "
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Vous êtes sur le point de créer une Requête de Signature de Certificat avec "
 "ces propriétés :"
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr "Êtes-vous sur ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Opération annulée.\n"
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr "Titulaire de la nouvelle Autorité de Certification :\n"
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1201,224 +1201,224 @@ msgstr ""
 "Entrez le nombre de mois avant l'expiration de la nouvelle Autorité de "
 "Certification"
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 "Voici les propriétés de la nouvelle Autorité de Certification fournie :\n"
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr "Validité\n"
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr "Validité :\n"
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tActivé le : %s\n"
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tExpire le : %s\n"
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Vous êtes sur le point de créer une nouvelle Autorité de Certification avec "
 "ces propriétés."
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr "L'identifiant de certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Clé privée extraite avec succès dans le fichier '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 "L'identifiant de Requête de Signature de Certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr "Ce certificat sera révoqué."
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificat révoqué.\n"
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Utilisations du certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Utilisable pour une Autorité de Certification.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Inutilisable pour une Autorité de Certification.\n"
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 "* Utilisable pour la signature de Liste de Révocation de Certificats.\n"
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 "* Inutilisable pour la signature de Liste de Révocation de Certificats.\n"
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Utilisable pour la signature numérique.\n"
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Inutilisable pour la signature numérique.\n"
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "* Utilisable pour le chiffrement de données.\n"
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Utilisable pour le chiffrement de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Inutilisable pour le chiffrement de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "* Utilisable pour la non-répudiation.\n"
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "* Inutilisable pour la non-répudiation.\n"
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "* Utilisable pour l'agrément de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "* Inutilisable pour l'agrément de clé.\n"
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Applications du certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Applicable à la protection de courriel.\n"
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Inapplicable à la protection de courriel.\n"
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Applicable à la signature de code.\n"
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Inapplicable à la signature de code.\n"
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Applicable aux clients Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Inapplicable aux clients Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Applicable aux serveurs Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Inapplicable aux serveurs Web TLS.\n"
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Applicable à l'horodatage.\n"
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Inapplicable à l'horodatage.\n"
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "* Applicable à la signature OCSP.\n"
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "* Inapplicable à la signature OCSP.\n"
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Applicable à tout.\n"
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Applicable à rien.\n"
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 "Vous êtes sur le point de signer la Requête de Signature de Certificat "
 "suivante :\n"
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1426,7 +1426,7 @@ msgstr ""
 "Donner le nombre de mois avant l'expiration du nouveau certificat (0 pour "
 "annuler)"
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
@@ -1434,249 +1434,249 @@ msgstr ""
 "Le nouveau certificat sera créé avec les utilisations et applications "
 "suivants :\n"
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 "Souhaitez-vous modifier une propriété du nouveau Certificat ? Yes/[Non] "
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* Utilisable pour une Autorité de Certification ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Inutilisable pour une Autorité de Certification, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 "* Utilisable pour la signature de Liste de Révocation de Certificats ? [Oui]/"
 "Non "
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 "* Inutilisable pour la signature de Liste de Révocation de Certificats, par "
 "stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Utilisable pour la signature numérique ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Inutilisable pour la signature numérique, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Utilisable pour le chiffrement de données ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Inutilisable pour le chiffrement de données, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Utilisable pour le chiffrement de clé ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Inutilisable pour le chiffrement de clé, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr "Utilisable pour la non-répudiation ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr "* Inutilisable pour la non-répudiation, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "Utilisable pour l'agrément de clé ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "* Inutilisable pour l'agrément de clé, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "Applicable à la protection de courriel ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr "* Inapplicable à la protection de courriel, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "Applicable à la signature de code ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Inapplicable à la signature de code, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "Applicable aux clients Web TLS ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Inapplicable aux clients Web TLS, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "Applicable aux serveurs Web TLS ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Inapplicable aux serveurs Web TLS, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "Applicable à l'horodatage ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "* Inapplicable à l'horodatage, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "Applicable à la signature OCSP ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr "* Inapplicable à la signature OCSP, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr "Applicable à tout ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr "* Applicable à tout, par stratégie\n"
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificat signé.\n"
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 "La Liste de Révocation de Certificats a été générée avec succès dans le "
 "fichier '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "La taille en bits du nombre premier doit être un multiple de 1024"
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 "Veuillez entrer le mot de passe actuel de la base de données (ne rien mettre "
 "pour annuler) : "
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1684,18 +1684,18 @@ msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. \n"
 "L'opération a été annulée."
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1703,15 +1703,15 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1719,224 +1719,224 @@ msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. \n"
 "L'opération a été annulée."
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "Empreinte numérique SHA1"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Nombre d'heures maximum entre les mises à jours de Liste de Révocation de "
 "Certificats                       "
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Utilisable pour une Autorité de Certification dans les certificats "
 "générés                                 "
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Utilisable pour la signature de Liste de Révocation de Certificats dans les "
 "certificats générés                           "
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Utilisable pour la non-répudiation dans les certificats "
 "générés                     "
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Utilisable pour la signature numérique dans les certificats "
 "générés                  "
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Utilisable pour le chiffrement de clé dans les certificats "
 "générés                   "
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Utilisable pour l'agrément de clé dans les certificats "
 "générés                      "
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Utilisable pour le chiffrement de données dans les certificats "
 "générés                  "
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Applicable aux serveurs Web TLS dans les certificats générés                 "
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Applicable aux clients Web TLS dans les certificats générés                 "
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 "Application pour l'horodatage activée dans les certificats "
 "générés                  "
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 "Application pour serveur de signature de code activée dans les certificats "
 "générés            "
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 "Application pour protection de courriel activée dans les certificats "
 "générés               "
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 "Application pour la signature OCSP activée dans les certificats "
 "générés                   "
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 "Toute application activée dans les certificats "
 "générés                            "
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Affichage des stratégies du certificat suivant :\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
@@ -1945,16 +1945,16 @@ msgstr ""
 "\n"
 "Stratégies :\n"
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr "Identifiant\tDescription\t\t\t\t\t\t\t\tValeur\n"
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr "L'identifiant de stratégie fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, fuzzy, c-format
 msgid ""
 "You are about to assign to the policy\n"
@@ -1963,35 +1963,35 @@ msgstr ""
 "Vous êtes sur le point d'assigner à la stratégie '%s'\n"
 "la nouvelle valeur '%d' ."
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
@@ -2000,14 +2000,14 @@ msgstr ""
 "Vous êtes sur le point d'assigner la nouvelle valeur '%d' à la préférence "
 "'Prise en charge de gnome-keyring'."
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -2016,7 +2016,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -2027,14 +2027,14 @@ msgstr ""
 "  gnuckx https://launchpad.net/~gnuckx\n"
 "  loquehumaine https://launchpad.net/~loquehumaine"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2052,7 +2052,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2069,206 +2069,206 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr "Commandes disponibles :\n"
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr ""
 "L'identifiant de Requête de Signature de Certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Création du certificat racine de l'Autorité de Certification"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "web server"
 msgstr "Serveur Web TLS"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "email server"
 msgstr "Serveur Web TLS"
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "La génération de la clé a échoué"
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "La génération de la Requête de Signature de Certificat a échouée"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Erreur pendant la signature du certificat"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Utilisations du certificat :\n"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy
 msgid "Web Server"
 msgstr "Serveur Web TLS"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 #, fuzzy
 msgid "Usage: renewcert <cert-id>"
 msgstr "showcert <identifiant de Certificat>"
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 #, fuzzy
 msgid "The given certificate id is not valid"
 msgstr "L'identifiant de certificat fourni est incorrect"
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 #, fuzzy
 msgid "Renew? [Yes]/No "
 msgstr "Êtes-vous sur ? [Oui]/Non "
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 #, fuzzy
 msgid "Certificate renewed. New certificate id: %"
 msgstr "La génération du certificat a échoué"
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 #, fuzzy
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr "extractcertpkey <identifiant de certificat> <nom de fichier>"
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Certificat révoqué.\n"
 msgstr[1] "Certificat révoqué.\n"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "_Ouvrir une base de données de certificats"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2699,7 +2699,7 @@ msgstr "La CSR n'a pu être sauvegardée"
 msgid "CSR generated successfully"
 msgstr "CSR générée avec succès."
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2709,22 +2709,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr "A faire. Fonctionnalité non implémentée encore."
 
@@ -3022,37 +3022,37 @@ msgstr "Taille en bits de la clé privée :"
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -3061,7 +3061,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr "Erreur pendant la signature de la Requête de Signature de Certificat"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -141,23 +141,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
@@ -399,7 +399,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Aggiungi un certificato CA autofirmato"
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -895,7 +895,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "File già esistente, verrà quindi sovrascritto."
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr "Confermare? Si/[No] "
 
@@ -1050,8 +1050,8 @@ msgstr "Richieste di certificato nel database:\n"
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1062,126 +1062,126 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tLungezza in bit della chiave: %d\n"
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Apportare modifiche? Si/[No] "
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 "Si è in procinto di creare una richiesta di firma di certificato (CSR) con "
 "queste proprietà."
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr "Confermare? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Operazione cancellata.\n"
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1190,7 +1190,7 @@ msgstr ""
 "Si prega di inserire i dati corrispondenti al soggetto della nuova autorità "
 "certificativa:\n"
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
@@ -1198,482 +1198,482 @@ msgstr ""
 "Introdurre il numero di mesi mancanti alla scadenza della nuova autorità "
 "certificativa"
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Queste sono le proprietà fornite dal nuovo CA:\n"
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr "Validità\n"
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr "Validità:\n"
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tAttivazione: %s\n"
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tScadenza: %s\n"
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 "Si è in procinto di creare una nuova autorità certificativa con queste "
 "proprietà."
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Chiave privata estratta correttamente nel file '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr "L'id. del CSR fornito non è valido"
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr "Il certificato sarà revocato."
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Certificato revocato.\n"
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Il certificato usa:\n"
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Utilizzo dell'autorità certificativa disabilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Utilizzo della firma digitale abilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Utilizzo della firma digitale disabilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "* Utilizzo della cifratura dati abilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Utilizzo della cifratura di chiave abilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Utilizzo della cifratura di chiave disabilitato.\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Scopi del certificato:\n"
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* Abilitare la firma CRL? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Utilizzo della firma CRL disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Abilitare l'utilizzo della firma digitale? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Utilizzo della firma digitale disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Abilitare l'utilizzo della cifratura dei dati? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Utilizzo della cifratura dei dati disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Abilitare l'utilizzo della cifratura di chiave? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Utilizzo della cifratura di chiave disabilitato dalla politica\n"
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Certificato firmato.\n"
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr "La richiesta di firma di certificato (CSR) sarà cancellata."
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Richiesta di firma di certificato eliminata.\n"
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "CRL generato correttamente nel file '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 "La lunghezza in bit del numero primo deve essere un multiplo intero di 1024"
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 "Parametri Diffie-Hellman creati e salvati correttamente nel file '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr "Attualmente il database non è protetto da password"
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr "Inserire la password:"
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr "Inserire la password (conferma):"
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr "Le password introdotte sono diverse."
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr "Attualmente il database IS è protetto da password."
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Password rimossa correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1681,210 +1681,210 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr "Inserire la nuova password:"
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr "Inserire la nuova password (conferma):"
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Password modificata correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr "Si è verificato un problema durante l'importazione del file fornito."
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "File importato correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Cartella importata correttamente.\n"
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr "Certificato:\n"
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tNumero di serie: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tID unico: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "Impronta digitale MD5"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Richiesta di firma di certificato (CSR):\n"
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Visualizzazione delle politiche del seguente certificato:\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
@@ -1893,58 +1893,58 @@ msgstr ""
 "\n"
 "Politiche:\n"
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr "La politica fornita non è valida"
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr "Confermare? Si/[No] "
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr "La preferenza fornita non è valida"
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -1953,7 +1953,7 @@ msgstr ""
 "%s versione %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1966,7 +1966,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1977,7 +1977,7 @@ msgstr ""
 "  Vincenzo Reale https://launchpad.net/~smart2128\n"
 "  gnuckx https://launchpad.net/~gnuckx"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
@@ -1986,7 +1986,7 @@ msgstr ""
 "Traduttori:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2004,7 +2004,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2021,203 +2021,203 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr "In uscita da gnomint-cli...\n"
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "L'id. del CSR fornito non è valido"
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Creando Certificato CA di Root"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "web server"
 msgstr "Server web TLS"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "email server"
 msgstr "Server web TLS"
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Generazione della chiave fallita"
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Generazione della chiave fallita"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Errore durante la firma del certificato"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Il certificato usa:\n"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy
 msgid "Web Server"
 msgstr "Server web TLS"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 #, fuzzy
 msgid "The given certificate id is not valid"
 msgstr "La preferenza fornita non è valida"
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 #, fuzzy
 msgid "Renew? [Yes]/No "
 msgstr "Confermare? [Si]/No "
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 #, fuzzy
 msgid "Certificate renewed. New certificate id: %"
 msgstr "Generazione del certificato fallita"
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Aggiungi un certificato CA autofirmato"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Certificato revocato.\n"
 msgstr[1] "Certificato revocato.\n"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "_Apri il database di certificato"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2646,7 +2646,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2656,22 +2656,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2963,37 +2963,37 @@ msgstr "Lunghezza in bit della chiave privata:"
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -3002,7 +3002,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -132,23 +132,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 msgid "Cannot read file."
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -847,7 +847,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
@@ -1002,8 +1002,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1014,608 +1014,608 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1623,275 +1623,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1900,21 +1900,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Cédric VALMARY (Tot en òc) https://launchpad.net/~cvalmary"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1932,7 +1932,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1949,195 +1949,195 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 msgid "The given certificate id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 msgid "Renew? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 msgid "Certificate renewed. New certificate id: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 msgid "Cannot write chain file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "<b>Certificats</b>"
 msgstr[1] "<b>Certificats</b>"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2563,7 +2563,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2573,22 +2573,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2865,37 +2865,37 @@ msgstr ""
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -2904,7 +2904,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -139,23 +139,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 msgid "Cannot read file."
 msgstr ""
 
@@ -439,7 +439,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -851,7 +851,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
@@ -1006,8 +1006,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1018,608 +1018,608 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1627,275 +1627,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1904,21 +1904,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
 "Launchpad Contributions:\n"
 "  Enrico Nicoletto https://launchpad.net/~liverig"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1936,7 +1936,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1953,195 +1953,195 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, c-format
 msgid "Certificate type: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 msgid "The given certificate id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 msgid "Renew? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 msgid "Certificate renewed. New certificate id: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 msgid "Cannot write chain file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Visibilidade de pedidos de certificado"
 msgstr[1] "Visibilidade de pedidos de certificado"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2567,7 +2567,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2577,22 +2577,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2869,37 +2869,37 @@ msgstr ""
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -2908,7 +2908,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -141,24 +141,24 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Не удалось инициализировать: %s\n"
@@ -456,7 +456,7 @@ msgstr "Произошла  ошибка при смене пароля базы
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
@@ -889,7 +889,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "Файл уже существует, поэтому он будет переписан."
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr "Вы уверены? Да/[Нет] "
 
@@ -1048,8 +1048,8 @@ msgstr "Запросы сертификата в Базе:\n"
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr "Id.\tId предка.\tCSR Заголовок\t\tКлюч в базе?\n"
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr "Заданный идентификатор CA не верен"
 
@@ -1062,125 +1062,125 @@ msgstr ""
 "Пожалуйста введите данные соответствующие заголовку Запроса на Подпись "
 "Сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr "Введите страну (C)"
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr "Введите название штата или области (ST)"
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr "Введите название местности или города (L)"
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr "Введите название организации (O)"
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr "Введите название организационной единицы (OU)"
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr "Введите обычное имя (СN)"
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 #, fuzzy
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr "Введите тип ключа, который вы будете создавать (RSA/DSA)"
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr "Введите битовую длину ключа (должно быть кратно 1024)"
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr "Предоставленные свойства CSR:\n"
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr "Заголовок:\n"
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr "\tОтличительное Имя (DN): "
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, fuzzy, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr "Заголовок Альтернативное Имя"
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr "Пара ключей\n"
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr "\tТип: %s\n"
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr "\tБитовая длина ключа: %d\n"
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr "Хотите ли вы изменить всё? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr "Вы создаёте Запрос на Подпись Сертификата с такими свойствами."
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr "Вы уверены? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr "Действие отменено.\n"
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
@@ -1189,223 +1189,223 @@ msgstr ""
 "Пожалуйста введите данные соответствующие заголовку нового Центра "
 "Авторизации:\n"
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 "Введите количество месяцев до истечения срока нового центра авторизации"
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr "Заданные свойства нового CA:\n"
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr "Годность\n"
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr "Годность:\n"
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr "\tАктивирован: %s\n"
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr "\tСрок истекает: %s\n"
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr "Вы создаёте новый Центр Авторизации со следующими свойствами."
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr "Заданный номер сертификата не верен"
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr "Закрытый ключ извлечён успешно в файл '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr "Заданный номер CSR не верен"
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr "Сертификат будет отозван."
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr "Сертификат отозван.\n"
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr "Сертификат использует:\n"
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr "* Использование Центра Сертификации включено.\n"
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr "* Использование Центра Сертификации отключено.\n"
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr "* Использование подписывания CRL включено.\n"
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr "* Использование для подписи CRL отключено.\n"
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr "* Использование для цифровой подписи разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr "* Использование для цифровой подписи запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr "* Использование для шифрования данных разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr "* Использование для шифрования ключей разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr "* Использование для шифрования ключей запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr "* Использование для удостоверения в невозможности отказа разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr "* Использование для удостоверения в невозможности отказа запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr "Использование для согласования ключей разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr "Использование для согласования ключей запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr "Назначение сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr "* Назначение для защиты эл.почты разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr "* Назначение для защиты эл.почты запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr "* Назначение для подписи кода разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr "* Назначение для подписи кода запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr "* Назначение как TLS Веб клиент разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr "* Назначение как TLS Веб клиент запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr "* Назначение как TLS Веб сервер разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr "* Назначение как TLS Веб сервер запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr "* Назначение для отметки времени разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr "* Назначение для отметки времени запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr "Назначение для подписи OCSP разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr "Назначение для подписи OCSP запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr "* Любое назначение разрешено.\n"
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr "* Любое назначение запрещено.\n"
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr "Вы собираетесь подписать следующий Запрос на подпись Сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr "с сертификатом, относящимся к следующему CA:\n"
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
@@ -1413,7 +1413,7 @@ msgstr ""
 "Введите количество месяцев до истечения нового сертификата (0 для "
 "безсрочного)"
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
@@ -1421,191 +1421,191 @@ msgstr ""
 "Новый сертификат будет сгенерирован для следующего использования и "
 "назначения:\n"
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 "Хотите ли вы изменить какое-либо свойство нового сертификата? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr "* Разрешить использование для Центра Сертификации? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr "* Использование для Центра Сертификации запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr "* Разрешить подпись CRL? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr "* Использование для подписи CRL запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr "* Разрешить использование для Цифровой Подписи? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr "* Использование для Цифровой Подписи запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr "Разрешить использование для Шифрования Данных? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr "* Использование для Шифрования Данных запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr "Разрешить использование как Ключа Шифрования? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr "* Использование как Ключа Шифрования запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 "Разрешить использование для удостоверения в невозможности отказа (Non-"
 "Repudiation)? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 "* Использование для удостоверения в невозможности отказа (Non-Repudiation) "
 "запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr "Разрешить использование для Согласования Ключа? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr "* Использование для Согласования Ключа запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr "Разрешить назначение для Защиты Эл.Почты? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr "* Назначение для Защиты Эл.Почты запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr "Разрешить назначение для Подписи Кода? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr "* Назначения для Подписи Кода запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr "Разрешить назначение как TLS веб клиент? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr "* Назначение как TLS веб клиент запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr "Разрешить назначение как TLS Веб сервер? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr "* Назначение как TLS веб сервер запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr "Разрешить назначения для Временных Меток? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr "* Назначение для Временных Меток запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr "Разрешить назначение для подписи OCSP? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr "* Назначение для подписи OCSP запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr "Разрешить любое назначение? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr "* Любое назначение запрещено политикой\n"
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr "Все обязательные данные для генерации сертификата были собраны."
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr "Хотите ли вы продолжить процедуру подписывания? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr "Сертификат подписан.\n"
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr "Этот Запрос на Подпись Сертификата будет удалён."
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr "Эта операция не может быть отменена. Вы уверены? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr "Запрос на Подпись Сертификата удалён.\n"
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr "Генерация CRL в файл '%s' прошла успешно\n"
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr "Битовая длинна основного числа должна быть кратна 1024"
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr "Параметры Diffie-Hellman созданы и успешно сохранены в файле '%s'\n"
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr "На данный момент база не защищена паролем."
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr "Хотите ли вы защитить её паролем? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
@@ -1616,37 +1616,37 @@ msgstr ""
 "будет запрошен в то время, когда gnoMint будет использовать закрытый ключ в "
 "базе."
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr "Введите пароль:"
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr "Введите пароль (подтверждение):"
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr "Введённые пароли различаются."
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr "Пароль успешно установлен.\n"
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr "Нечего делать.\n"
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr "На данный момент, база защищена паролем."
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr "Хотите ли вы удалить защиту паролем? Да/[Нет] "
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
@@ -1655,11 +1655,11 @@ msgstr ""
 "Для удаления парольной защиты необходимо ввести текущий\n"
 "пароль базы.\n"
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr "Пожалуйста, введите текущий пароль базы (Пустой ввод для отмены): "
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
@@ -1667,7 +1667,7 @@ msgstr ""
 "Текущий пароль который вы ввели\n"
 "не совпадает с фактическим паролем базы."
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
@@ -1675,18 +1675,18 @@ msgstr ""
 "Произошла ошибка во время снятия пароля базы. \n"
 "Операция была отменена."
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr "Пароль успешно удалён.\n"
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr "Вы должны ввести текущий пароль базы перед сменой пароля.\n"
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1698,15 +1698,15 @@ msgstr ""
 "будет запрашиваться каждый раз, когда gnoMint будет использовать закрытый "
 "ключ в базе."
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr "Введите новый пароль:"
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr "Введите новый пароль (подтверждение):"
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
@@ -1714,244 +1714,244 @@ msgstr ""
 "Произошла ошибка во время смены пароля. \n"
 "Операция была отменена."
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr "Пароль успешно изменён.\n"
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr "Проблема при импортировании данного файла."
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr "Файл импортирован успешно.\n"
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr "Каталог импортирован успешно.\n"
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr "Сертификат:\n"
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr "\tСерийный номер:%s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr "\tОпределяющее Имя (DN): %s\n"
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr "Нет."
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr "\tУникальный ID: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr "Поставщик:\n"
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr "Отпечатки:\n"
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr "\tSHA1 отпечаток: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr "\tMD5 отпечаток: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "\tSHA1 отпечаток: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr "Запрос на Подпись Сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 "Сгенерированные сертификаты наследуют Страну от CA                           "
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 "Сгенерированные сертификаты наследуют Область от "
 "CA                             "
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 "Сгенерированные сертификаты наследуют Местность от "
 "CA                          "
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 "Сгенерированные сертификаты наследуют Организацию от CA                      "
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 "Сгенерированные сертификаты наследуют Организационную Единицу от "
 "CA               "
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 "Страна в сгенерированных сертификатах должны быть такой же как в "
 "CA            "
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 "Область в сгенерированных сертификатах должна быть такой же как в "
 "CA              "
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 "Район в сгенерированных сертификатах должен быть таким же как в CA           "
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 "Организация в сгенерированных сертификатах должна быть такой же как в "
 "CA       "
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 "Организационная Единица в сгенерированных сертификатах должна быть такой же "
 "как в CA"
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 "Максимальное количество часов между обновлениями CRL                       "
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 "Максимальное количество месяцев до истечения срока новых "
 "сертификатов           "
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 "Использование для CA разрешено в сгенерированных "
 "сертификатах                                 "
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 "Использование для Подписи CRL разрешено в сгенерированных "
 "сертификатах                           "
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 "Использование для заверения невозможности отказа разрешено  сгенерированных "
 "сертификатах                     "
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 "Использование для цифровой подписи разрешено в сгенерированных "
 "сертификатах                  "
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 "Использование для шифрования ключей разрешено в сгенерированных "
 "сертификатах                   "
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 "Использование для согласования ключей разрешено в сгенерированных "
 "сертификатах                      "
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 "Использование для шифрования данных разрешено в сгенерированных "
 "сертификатах                  "
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 "Назначение как TLS веб-сервер разрешено в сгенерированных "
 "сертификатах                 "
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 "Назначение как TLS веб-клиент разрешено в сгенерированных "
 "сертификатах                 "
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 "Назначение для временных меток разрешено сгенерированных "
 "сертификатах                  "
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 "Назначение для подписи кода разрешено в сгенерированных "
 "сертификатах            "
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 "Назначение для защита почты разрешено в сгенерированных "
 "сертификатах               "
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 "Назначение для подписи OCSP разрешено в сгенерированных "
 "сертификатах                   "
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 "Любое назначение рарешено в сгенерированных "
 "сертификатах                            "
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr "Отображение политик следующего сертификата:\n"
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
@@ -1960,16 +1960,16 @@ msgstr ""
 "\n"
 "Политики:\n"
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr "Id.\tОписание\t\t\t\t\t\t\t\tЗначение\n"
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr "Данная политика недействительна"
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, fuzzy, c-format
 msgid ""
 "You are about to assign to the policy\n"
@@ -1978,35 +1978,35 @@ msgstr ""
 "Вы собираетесь назначить политике\n"
 "'%s' новое значение '%d'."
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr "Вы уверены? Да/[Нет]: "
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, fuzzy, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr "Политика установлена корректно в '%d'.\n"
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr "gnoMint-cli текущие настройки:\n"
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr "Id.\tИмя\t\t\tЗначение\n"
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr "0\tПоддержка Gnome keyring\t%d\n"
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr "Заданный id свойств не верный"
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
@@ -2015,7 +2015,7 @@ msgstr ""
 "Вы собираетесь назначить свойству 'Поддержка Gnome keyring' новое значение "
 "'%d'."
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -2024,7 +2024,7 @@ msgstr ""
 "%s версия %s\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -2037,7 +2037,7 @@ msgstr ""
 "%s\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -2045,7 +2045,7 @@ msgstr ""
 "  David Marín https://launchpad.net/~davefx\n"
 "  aquanaut https://launchpad.net/~thecrux"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
@@ -2054,7 +2054,7 @@ msgstr ""
 "Переводчики:\n"
 "%s\n"
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -2090,7 +2090,7 @@ msgstr ""
 "<http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -2123,205 +2123,205 @@ msgstr ""
 "<http://www.gnu.org/licenses/>.\n"
 "\n"
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr "%s версия %s\n"
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr "Доступные команды:\n"
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr "===================\n"
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr "Выход из gnomint-cli...\n"
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 #, fuzzy
 msgid "The given CA id is not valid"
 msgstr "Заданный идентификатор CA не верен"
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Создание корневого сертификата CA"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "web server"
 msgstr "TLS Веб сервер"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 #, fuzzy
 msgid "email server"
 msgstr "TLS Веб сервер"
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Создание ключей не удалось"
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "Оздание CSR не удалось"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, fuzzy, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, fuzzy, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr "Ошибка при подписи сертификата"
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Сертификат использует:\n"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy
 msgid "Web Server"
 msgstr "TLS Веб сервер"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 #, fuzzy
 msgid "Usage: renewcert <cert-id>"
 msgstr "showcert <cert-id>"
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 #, fuzzy
 msgid "The given certificate id is not valid"
 msgstr "Заданный номер сертификата не верен"
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 #, fuzzy
 msgid "Renew? [Yes]/No "
 msgstr "Вы уверены? [Да]/Нет "
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 #, fuzzy
 msgid "Certificate renewed. New certificate id: %"
 msgstr "Создание сертификата не удалось"
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 #, fuzzy
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr "extractcertpkey <cert-id> <filename>"
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Сертификат отозван.\n"
 msgstr[1] "Сертификат отозван.\n"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "_Открыть базу сертификатов"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2757,7 +2757,7 @@ msgstr "CSR не может быть сохранено"
 msgid "CSR generated successfully"
 msgstr "CSR успешно создан"
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 #, fuzzy
 msgid "None"
 msgstr "Нет."
@@ -2770,7 +2770,7 @@ msgstr ""
 "<b>Этот Запрос на Подпись Сертификата имеет соответствующий закрытый ключ, "
 "сохранённый во внешнем файле.<b>"
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
@@ -2779,15 +2779,15 @@ msgstr ""
 "\n"
 "Пароль должен содержать по крайне мере %d символов\n"
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr "Список утвердительных ответов, разделённых #|Yes#yes#Y#y"
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr "Список отрицательных ответов, разделённых #|No#no#N#n"
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr "Предстоит сделать. Возможность пока не реализована."
 
@@ -3115,7 +3115,7 @@ msgstr "Длина в битах закрытого ключа:"
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
@@ -3123,7 +3123,7 @@ msgstr ""
 "Политика данного CA требует, чтобы поле страны сертификата было таким же как "
 "в сертификате CA."
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
@@ -3131,7 +3131,7 @@ msgstr ""
 "Политика данного CA требует, чтобы поле области сертификата было таким же "
 "как в сертификате CA."
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
@@ -3139,7 +3139,7 @@ msgstr ""
 "Политика данного CA требует, чтобы поле района/города сертификата было таким "
 "же как в сертификате CA."
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
@@ -3147,7 +3147,7 @@ msgstr ""
 "Политика данного CA требует, чтобы поле организация сертификата было таким "
 "же как в сертификате CA."
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
@@ -3155,7 +3155,7 @@ msgstr ""
 "Политика данного CA требует, чтобы поле организационная единица сертификата "
 "было таким же как в сертификате CA."
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -3167,7 +3167,7 @@ msgstr ""
 "В соответствии с текущими стандартами, это не допускается. Новый сертификат "
 "будет создан с тем же сроком истечения, что и CA сертификат."
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr "Ошибка при подписи CSR."
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -140,23 +140,23 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
@@ -384,7 +384,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Pridať certifikát self-signed CA"
@@ -441,7 +441,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -853,7 +853,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr ""
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr ""
 
@@ -1008,8 +1008,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1020,608 +1020,608 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1629,275 +1629,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1906,7 +1906,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1914,14 +1914,14 @@ msgstr ""
 "  David Marín https://launchpad.net/~davefx\n"
 "  jariq https://launchpad.net/~jariq"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1939,7 +1939,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1956,196 +1956,196 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "Pridať _žiadosť o vydanie certifikátu"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 msgid "The given certificate id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 msgid "Renew? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 msgid "Certificate renewed. New certificate id: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Pridať certifikát self-signed CA"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Viditeľnosť žiadostí o certifikát"
 msgstr[1] "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2571,7 +2571,7 @@ msgstr ""
 msgid "CSR generated successfully"
 msgstr ""
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2581,22 +2581,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2873,37 +2873,37 @@ msgstr ""
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -2912,7 +2912,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-22 13:33+0200\n"
+"POT-Creation-Date: 2026-05-24 14:20+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -143,24 +143,24 @@ msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
 #: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
-#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:707
-#: ../src/ca-cli-callbacks.c:716 ../src/ca-cli-callbacks.c:1336
-#: ../src/ca-cli-callbacks.c:1345 ../src/certificate_properties.c:178
+#: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
+#: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
+#: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
 #: ../src/certificate_properties.c:188
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
 #: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
-#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:710
-#: ../src/ca-cli-callbacks.c:719 ../src/ca-cli-callbacks.c:1339
-#: ../src/ca-cli-callbacks.c:1348 ../src/certificate_properties.c:181
+#: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
+#: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
+#: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
 #: ../src/certificate_properties.c:191
 #, fuzzy
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
 #: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
-#: ../src/new_cert.c:192 ../src/new_req_window.c:192
+#: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
@@ -400,7 +400,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2111
+#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Lägg till ett autosignerat CA-certifikat"
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1169
+#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
@@ -893,7 +893,7 @@ msgid "The file already exists, so it will be overwritten."
 msgstr "Filen finns redan, så den kommer att skrivas över."
 
 #: ../src/ca-cli-callbacks.c:59 ../src/ca-cli-callbacks.c:108
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "Are you sure? Yes/[No] "
 msgstr "Är Du säker? Yes/[No] "
 
@@ -1048,8 +1048,8 @@ msgstr ""
 msgid "Id.\tParent Id.\tCSR Subject\t\tKey in DB?\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1112
-#: ../src/ca-cli-callbacks.c:1499 ../src/ca-cli-callbacks.c:1528
+#: ../src/ca-cli-callbacks.c:295 ../src/ca-cli-callbacks.c:1121
+#: ../src/ca-cli-callbacks.c:1508 ../src/ca-cli-callbacks.c:1537
 msgid "The given CA id. is not valid"
 msgstr ""
 
@@ -1060,608 +1060,608 @@ msgid ""
 "Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:551
+#: ../src/ca-cli-callbacks.c:351 ../src/ca-cli-callbacks.c:557
 msgid "Enter country (C)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:557
+#: ../src/ca-cli-callbacks.c:359 ../src/ca-cli-callbacks.c:563
 msgid "Enter state or province (ST)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:563
+#: ../src/ca-cli-callbacks.c:368 ../src/ca-cli-callbacks.c:569
 msgid "Enter locality or city (L)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:569
+#: ../src/ca-cli-callbacks.c:376 ../src/ca-cli-callbacks.c:575
 msgid "Enter organization (O)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:575
+#: ../src/ca-cli-callbacks.c:384 ../src/ca-cli-callbacks.c:581
 msgid "Enter organizational unit (OU)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:581
+#: ../src/ca-cli-callbacks.c:391 ../src/ca-cli-callbacks.c:587
 msgid "Enter common name (CN)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:587
+#: ../src/ca-cli-callbacks.c:397 ../src/ca-cli-callbacks.c:593
 msgid "Enter email address (leave blank for none)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:598
+#: ../src/ca-cli-callbacks.c:408 ../src/ca-cli-callbacks.c:604
 msgid ""
 "Enter Subject Alternative Names (SAN) [format: "
 "DNS:example.com,IP:192.168.1.1]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:609
+#: ../src/ca-cli-callbacks.c:419 ../src/ca-cli-callbacks.c:615
 msgid "Enter type of key you are going to create (RSA/DSA/ECDSA/Ed25519)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:451 ../src/ca-cli-callbacks.c:636
+#: ../src/ca-cli-callbacks.c:458 ../src/ca-cli-callbacks.c:646
 msgid "Enter curve size for ECDSA (256, 384, or 521)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:462 ../src/ca-cli-callbacks.c:648
+#: ../src/ca-cli-callbacks.c:468 ../src/ca-cli-callbacks.c:657
 msgid "Enter bitlength for the key (it must be a whole multiple of 1024)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:467
+#: ../src/ca-cli-callbacks.c:473
 #, c-format
 msgid "These are the provided CSR properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:469 ../src/ca-cli-callbacks.c:677
-#: ../src/ca-cli-callbacks.c:1323 ../src/ca-cli-callbacks.c:1388
+#: ../src/ca-cli-callbacks.c:475 ../src/ca-cli-callbacks.c:686
+#: ../src/ca-cli-callbacks.c:1332 ../src/ca-cli-callbacks.c:1397
 #, c-format
 msgid "Subject:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:470 ../src/ca-cli-callbacks.c:678
+#: ../src/ca-cli-callbacks.c:476 ../src/ca-cli-callbacks.c:687
 #, c-format
 msgid "\tDistinguished Name: "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:485 ../src/ca-cli-callbacks.c:693
-#: ../src/ca-cli-callbacks.c:1327 ../src/ca-cli-callbacks.c:1391
+#: ../src/ca-cli-callbacks.c:491 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:1336 ../src/ca-cli-callbacks.c:1400
 #, c-format
 msgid "\tSubject Alternative Names: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:486 ../src/ca-cli-callbacks.c:694
+#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:703
 #, c-format
 msgid "Key pair\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:492 ../src/ca-cli-callbacks.c:700
+#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:709
 #, c-format
 msgid "\tType: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:494
+#: ../src/ca-cli-callbacks.c:500
 #, c-format
 msgid "\tKey size: fixed (Ed25519)\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:496
+#: ../src/ca-cli-callbacks.c:502
 #, c-format
 msgid "\tCurve: P-%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:498 ../src/ca-cli-callbacks.c:702
+#: ../src/ca-cli-callbacks.c:504 ../src/ca-cli-callbacks.c:711
 #, c-format
 msgid "\tKey bitlength: %d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:501 ../src/ca-cli-callbacks.c:723
+#: ../src/ca-cli-callbacks.c:507 ../src/ca-cli-callbacks.c:732
 msgid "Do you want to change anything? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:505
+#: ../src/ca-cli-callbacks.c:511
 msgid ""
 "You are about to create a Certificate Signing Request with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:506 ../src/ca-cli-callbacks.c:728
+#: ../src/ca-cli-callbacks.c:512 ../src/ca-cli-callbacks.c:737
 msgid "Are you sure? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:511 ../src/ca-cli-callbacks.c:733
-#: ../src/ca-cli-callbacks.c:817 ../src/ca-cli-callbacks.c:948
-#: ../src/ca-cli-callbacks.c:1069 ../src/ca-cli-callbacks.c:1098
-#: ../src/ca-cli-callbacks.c:1164 ../src/ca-cli-callbacks.c:1191
-#: ../src/ca-cli-callbacks.c:1219 ../src/ca-cli-callbacks.c:1234
-#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1601
-#: ../src/ca-cli-callbacks.c:1915
+#: ../src/ca-cli-callbacks.c:517 ../src/ca-cli-callbacks.c:742
+#: ../src/ca-cli-callbacks.c:826 ../src/ca-cli-callbacks.c:957
+#: ../src/ca-cli-callbacks.c:1078 ../src/ca-cli-callbacks.c:1107
+#: ../src/ca-cli-callbacks.c:1173 ../src/ca-cli-callbacks.c:1200
+#: ../src/ca-cli-callbacks.c:1228 ../src/ca-cli-callbacks.c:1243
+#: ../src/ca-cli-callbacks.c:1567 ../src/ca-cli-callbacks.c:1610
+#: ../src/ca-cli-callbacks.c:1924
 #, c-format
 msgid "Operation cancelled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:549
+#: ../src/ca-cli-callbacks.c:555
 #, c-format
 msgid ""
 "Please enter data corresponding to subject of the new Certification "
 "Authority:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:654
+#: ../src/ca-cli-callbacks.c:663
 msgid ""
 "Introduce number of months before expiration of the new certification "
 "authority"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:675
+#: ../src/ca-cli-callbacks.c:684
 #, c-format
 msgid "These are the provided new CA properties:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:703
+#: ../src/ca-cli-callbacks.c:712
 #, c-format
 msgid "Validity\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:704 ../src/ca-cli-callbacks.c:1333
+#: ../src/ca-cli-callbacks.c:713 ../src/ca-cli-callbacks.c:1342
 #, c-format
 msgid "Validity:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:712 ../src/ca-cli-callbacks.c:1341
+#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
 #, c-format
 msgid "\tActivated on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:721 ../src/ca-cli-callbacks.c:1350
+#: ../src/ca-cli-callbacks.c:730 ../src/ca-cli-callbacks.c:1359
 #, c-format
 msgid "\tExpires on: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:727
+#: ../src/ca-cli-callbacks.c:736
 msgid ""
 "You are about to create a new Certification Authority with these properties."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:753 ../src/ca-cli-callbacks.c:801
-#: ../src/ca-cli-callbacks.c:1308
+#: ../src/ca-cli-callbacks.c:762 ../src/ca-cli-callbacks.c:810
+#: ../src/ca-cli-callbacks.c:1317
 msgid "The given certificate id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:760 ../src/ca-cli-callbacks.c:784
+#: ../src/ca-cli-callbacks.c:769 ../src/ca-cli-callbacks.c:793
 #, c-format
 msgid "Private key extracted successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:777 ../src/ca-cli-callbacks.c:929
-#: ../src/ca-cli-callbacks.c:1082 ../src/ca-cli-callbacks.c:1377
+#: ../src/ca-cli-callbacks.c:786 ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:1091 ../src/ca-cli-callbacks.c:1386
 msgid "The given CSR id. is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:807
+#: ../src/ca-cli-callbacks.c:816
 msgid "This certificate will be revoked."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:813
+#: ../src/ca-cli-callbacks.c:822
 #, c-format
 msgid "Certificate revoked.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:827 ../src/ca-cli-callbacks.c:1358
+#: ../src/ca-cli-callbacks.c:836 ../src/ca-cli-callbacks.c:1367
 #, c-format
 msgid "Certificate uses:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:830
+#: ../src/ca-cli-callbacks.c:839
 #, c-format
 msgid "* Certification Authority use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:832
+#: ../src/ca-cli-callbacks.c:841
 #, c-format
 msgid "* Certification Authority use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:836
+#: ../src/ca-cli-callbacks.c:845
 #, c-format
 msgid "* CRL signing use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:838
+#: ../src/ca-cli-callbacks.c:847
 #, c-format
 msgid "* CRL signing use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:842
+#: ../src/ca-cli-callbacks.c:851
 #, c-format
 msgid "* Digital Signature use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:844
+#: ../src/ca-cli-callbacks.c:853
 #, c-format
 msgid "* Digital Signature use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:848 ../src/ca-cli-callbacks.c:850
+#: ../src/ca-cli-callbacks.c:857 ../src/ca-cli-callbacks.c:859
 #, c-format
 msgid "* Data Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:854
+#: ../src/ca-cli-callbacks.c:863
 #, c-format
 msgid "* Key Encipherment use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:856
+#: ../src/ca-cli-callbacks.c:865
 #, c-format
 msgid "* Key Encipherment use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:860
+#: ../src/ca-cli-callbacks.c:869
 #, c-format
 msgid "* Non Repudiation use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:862
+#: ../src/ca-cli-callbacks.c:871
 #, c-format
 msgid "* Non Repudiation use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:866
+#: ../src/ca-cli-callbacks.c:875
 #, c-format
 msgid "* Key Agreement use enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:868
+#: ../src/ca-cli-callbacks.c:877
 #, c-format
 msgid "* Key Agreement use disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:871
+#: ../src/ca-cli-callbacks.c:880
 #, c-format
 msgid "Certificate purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:874
+#: ../src/ca-cli-callbacks.c:883
 #, c-format
 msgid "* Email Protection purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:876
+#: ../src/ca-cli-callbacks.c:885
 #, c-format
 msgid "* Email Protection purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:880
+#: ../src/ca-cli-callbacks.c:889
 #, c-format
 msgid "* Code Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:882
+#: ../src/ca-cli-callbacks.c:891
 #, c-format
 msgid "* Code Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:886
+#: ../src/ca-cli-callbacks.c:895
 #, c-format
 msgid "* TLS Web Client purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:888
+#: ../src/ca-cli-callbacks.c:897
 #, c-format
 msgid "* TLS Web Client purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:892
+#: ../src/ca-cli-callbacks.c:901
 #, c-format
 msgid "* TLS Web Server purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:894
+#: ../src/ca-cli-callbacks.c:903
 #, c-format
 msgid "* TLS Web Server purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:898
+#: ../src/ca-cli-callbacks.c:907
 #, c-format
 msgid "* Time Stamping purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:900
+#: ../src/ca-cli-callbacks.c:909
 #, c-format
 msgid "* Time Stamping purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:904
+#: ../src/ca-cli-callbacks.c:913
 #, c-format
 msgid "* OCSP Signing purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:906
+#: ../src/ca-cli-callbacks.c:915
 #, c-format
 msgid "* OCSP Signing purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:910
+#: ../src/ca-cli-callbacks.c:919
 #, c-format
 msgid "* Any purpose enabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:912
+#: ../src/ca-cli-callbacks.c:921
 #, c-format
 msgid "* Any purpose disabled.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:936
+#: ../src/ca-cli-callbacks.c:945
 #, c-format
 msgid "You are about to sign the following Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:938
+#: ../src/ca-cli-callbacks.c:947
 #, c-format
 msgid "with the certificate corresponding to the next CA:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:941
+#: ../src/ca-cli-callbacks.c:950
 msgid ""
 "Introduce number of months before expiration of the new certificate (0 to "
 "cancel)"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:967 ../src/ca-cli-callbacks.c:1055
+#: ../src/ca-cli-callbacks.c:976 ../src/ca-cli-callbacks.c:1064
 #, c-format
 msgid ""
 "The new certificate will be created with the following uses and purposes:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:970
+#: ../src/ca-cli-callbacks.c:979
 msgid "Do you want to change any property of the new certificate? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:973
+#: ../src/ca-cli-callbacks.c:982
 msgid "* Enable Certification Authority use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:975
+#: ../src/ca-cli-callbacks.c:984
 #, c-format
 msgid "* Certification Authority use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:979
+#: ../src/ca-cli-callbacks.c:988
 msgid "* Enable CRL Signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:981
+#: ../src/ca-cli-callbacks.c:990
 #, c-format
 msgid "* CRL signing use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:985
+#: ../src/ca-cli-callbacks.c:994
 msgid "* Enable Digital Signature use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:987
+#: ../src/ca-cli-callbacks.c:996
 #, c-format
 msgid "* Digital Signature use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:991
+#: ../src/ca-cli-callbacks.c:1000
 msgid "Enable Data Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:993
+#: ../src/ca-cli-callbacks.c:1002
 #, c-format
 msgid "* Data Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:997
+#: ../src/ca-cli-callbacks.c:1006
 msgid "Enable Key Encipherment use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:999
+#: ../src/ca-cli-callbacks.c:1008
 #, c-format
 msgid "* Key Encipherment use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1003
+#: ../src/ca-cli-callbacks.c:1012
 msgid "Enable Non Repudiation use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1005
+#: ../src/ca-cli-callbacks.c:1014
 #, c-format
 msgid "* Non Repudiation use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1009
+#: ../src/ca-cli-callbacks.c:1018
 msgid "Enable Key Agreement use? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1011
+#: ../src/ca-cli-callbacks.c:1020
 #, c-format
 msgid "* Key Agreement use disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1015
+#: ../src/ca-cli-callbacks.c:1024
 msgid "Enable Email Protection purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1017
+#: ../src/ca-cli-callbacks.c:1026
 #, c-format
 msgid "* Email Protection purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1021
+#: ../src/ca-cli-callbacks.c:1030
 msgid "Enable Code Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1023
+#: ../src/ca-cli-callbacks.c:1032
 #, c-format
 msgid "* Code Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1027
+#: ../src/ca-cli-callbacks.c:1036
 msgid "Enable TLS Web Client purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1029
+#: ../src/ca-cli-callbacks.c:1038
 #, c-format
 msgid "* TLS Web Client purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1033
+#: ../src/ca-cli-callbacks.c:1042
 msgid "Enable TLS Web Server purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1035
+#: ../src/ca-cli-callbacks.c:1044
 #, c-format
 msgid "* TLS Web Server purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1039
+#: ../src/ca-cli-callbacks.c:1048
 msgid "Enable Time Stamping purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1041
+#: ../src/ca-cli-callbacks.c:1050
 #, c-format
 msgid "* Time Stamping purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1045
+#: ../src/ca-cli-callbacks.c:1054
 msgid "Enable OCSP Signing purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1046
+#: ../src/ca-cli-callbacks.c:1055
 #, c-format
 msgid "* OCSP Signing purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1050
+#: ../src/ca-cli-callbacks.c:1059
 msgid "Enable any purpose? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1052
+#: ../src/ca-cli-callbacks.c:1061
 #, c-format
 msgid "* Any purpose disabled by policy\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid ""
 "All the mandatory data for the certificate generation has been gathered."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1060
+#: ../src/ca-cli-callbacks.c:1069
 msgid "Do you want to proceed with the signing? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1066
+#: ../src/ca-cli-callbacks.c:1075
 #, c-format
 msgid "Certificate signed.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This Certificate Signing Request will be deleted."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1088
+#: ../src/ca-cli-callbacks.c:1097
 msgid "This operation cannot be undone. Are you sure? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1094
+#: ../src/ca-cli-callbacks.c:1103
 #, c-format
 msgid "Certificate Signing Request deleted.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1119
+#: ../src/ca-cli-callbacks.c:1128
 #, c-format
 msgid "CRL generated successfully into file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1136
+#: ../src/ca-cli-callbacks.c:1145
 msgid "The bit-length of the prime number must be whole multiple of 1024"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1145
+#: ../src/ca-cli-callbacks.c:1154
 #, c-format
 msgid "Diffie-Hellman parameters created and saved successfully in file '%s'\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Currently, the database is not password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1157
+#: ../src/ca-cli-callbacks.c:1166
 msgid "Do you want to password protect it? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1158
+#: ../src/ca-cli-callbacks.c:1167
 msgid ""
 "OK. You need to supply a password for protecting the private keys in the\n"
 "database, so nobody else but authorized people can use them. This password\n"
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1161
+#: ../src/ca-cli-callbacks.c:1170
 msgid "Insert password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1162 ../src/ca-cli-callbacks.c:1232
+#: ../src/ca-cli-callbacks.c:1171 ../src/ca-cli-callbacks.c:1241
 msgid "The introduced passwords are distinct."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1173
+#: ../src/ca-cli-callbacks.c:1182
 #, c-format
 msgid "Password established successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1180
+#: ../src/ca-cli-callbacks.c:1189
 #, c-format
 msgid "Nothing done.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Currently, the database IS password-protected."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1184
+#: ../src/ca-cli-callbacks.c:1193
 msgid "Do you want to remove this password protection? Yes/[No] "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1188
+#: ../src/ca-cli-callbacks.c:1197
 #, c-format
 msgid ""
 "For removing the password-protection, the current database password\n"
 "must be supplied.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1189 ../src/ca-cli-callbacks.c:1217
+#: ../src/ca-cli-callbacks.c:1198 ../src/ca-cli-callbacks.c:1226
 msgid "Please, insert the current database password (Empty to cancel): "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1196 ../src/ca-cli-callbacks.c:1224
+#: ../src/ca-cli-callbacks.c:1205 ../src/ca-cli-callbacks.c:1233
 msgid ""
 "The current password you have entered\n"
 "doesn't match with the actual current database password."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1201
+#: ../src/ca-cli-callbacks.c:1210
 msgid ""
 "Error while removing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1206
+#: ../src/ca-cli-callbacks.c:1215
 #, c-format
 msgid "Password removed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1216
+#: ../src/ca-cli-callbacks.c:1225
 #, c-format
 msgid ""
 "You must supply the current database password before changing the password.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1228
+#: ../src/ca-cli-callbacks.c:1237
 msgid ""
 "OK. Now you must supply a new password for protecting the private keys in "
 "the\n"
@@ -1669,275 +1669,275 @@ msgid ""
 "will be asked any time gnoMint will make use of any private key in database."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password:"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1231
+#: ../src/ca-cli-callbacks.c:1240
 msgid "Insert new password (confirm):"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1240
+#: ../src/ca-cli-callbacks.c:1249
 msgid ""
 "Error while changing database password. \n"
 "The operation was cancelled."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1246
+#: ../src/ca-cli-callbacks.c:1255
 #, c-format
 msgid "Password changed successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1264
+#: ../src/ca-cli-callbacks.c:1273
 msgid "Problem when importing the given file."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1267
+#: ../src/ca-cli-callbacks.c:1276
 #, c-format
 msgid "File imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1283
+#: ../src/ca-cli-callbacks.c:1292
 #, c-format
 msgid "Directory imported successfully.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1316
+#: ../src/ca-cli-callbacks.c:1325
 #, c-format
 msgid "Certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1320
+#: ../src/ca-cli-callbacks.c:1329
 #, c-format
 msgid "\tSerial number: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1330
-#: ../src/ca-cli-callbacks.c:1389
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1339
+#: ../src/ca-cli-callbacks.c:1398
 #, c-format
 msgid "\tDistinguished Name: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1324 ../src/ca-cli-callbacks.c:1325
-#: ../src/ca-cli-callbacks.c:1330 ../src/ca-cli-callbacks.c:1331
+#: ../src/ca-cli-callbacks.c:1333 ../src/ca-cli-callbacks.c:1334
+#: ../src/ca-cli-callbacks.c:1339 ../src/ca-cli-callbacks.c:1340
 msgid "None."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1325 ../src/ca-cli-callbacks.c:1331
-#: ../src/ca-cli-callbacks.c:1393
+#: ../src/ca-cli-callbacks.c:1334 ../src/ca-cli-callbacks.c:1340
+#: ../src/ca-cli-callbacks.c:1402
 #, c-format
 msgid "\tUnique ID: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1329
+#: ../src/ca-cli-callbacks.c:1338
 #, c-format
 msgid "Issuer:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1352
+#: ../src/ca-cli-callbacks.c:1361
 #, c-format
 msgid "Fingerprints:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1353
+#: ../src/ca-cli-callbacks.c:1362
 #, c-format
 msgid "\tSHA1 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1354
+#: ../src/ca-cli-callbacks.c:1363
 #, c-format
 msgid "\tMD5 fingerprint: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1355
+#: ../src/ca-cli-callbacks.c:1364
 #, fuzzy, c-format
 msgid "\tSHA256 fingerprint: %s\n"
 msgstr "SHA1-fingeravtryck"
 
-#: ../src/ca-cli-callbacks.c:1386
+#: ../src/ca-cli-callbacks.c:1395
 #, c-format
 msgid "Certificate Signing Request:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1463
+#: ../src/ca-cli-callbacks.c:1472
 msgid "Generated certs inherit Country from CA                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1464
+#: ../src/ca-cli-callbacks.c:1473
 msgid "Generated certs inherit State from CA                             "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1465
+#: ../src/ca-cli-callbacks.c:1474
 msgid "Generated certs inherit Locality from CA                          "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1466
+#: ../src/ca-cli-callbacks.c:1475
 msgid "Generated certs inherit Organization from CA                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1467
+#: ../src/ca-cli-callbacks.c:1476
 msgid "Generated certs inherit Organizational Unit from CA               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1468
+#: ../src/ca-cli-callbacks.c:1477
 msgid "Country in generated certs must be the same than in CA            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1469
+#: ../src/ca-cli-callbacks.c:1478
 msgid "State in generated certs must be the same than in CA              "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1470
+#: ../src/ca-cli-callbacks.c:1479
 msgid "Locality in generated certs must be the same than in CA           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1471
+#: ../src/ca-cli-callbacks.c:1480
 msgid "Organization in generated certs must be the same than in CA       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1472
+#: ../src/ca-cli-callbacks.c:1481
 msgid "Organizational Unit in generated certs must be the same than in CA"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1473
+#: ../src/ca-cli-callbacks.c:1482
 msgid "Maximum number of hours between CRL updates                       "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1474
+#: ../src/ca-cli-callbacks.c:1483
 msgid "CRL distribution point (URL where CRL is published)               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1475
+#: ../src/ca-cli-callbacks.c:1484
 msgid "Maximum number of months before expiration of new certs           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1476
+#: ../src/ca-cli-callbacks.c:1485
 msgid "CA use enabled in generated certs                                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1477
+#: ../src/ca-cli-callbacks.c:1486
 msgid "CRL Sign use enabled in generated certs                           "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1478
+#: ../src/ca-cli-callbacks.c:1487
 msgid "Non reputation use enabled in generated certs                     "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1479
+#: ../src/ca-cli-callbacks.c:1488
 msgid "Digital signature use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1480
+#: ../src/ca-cli-callbacks.c:1489
 msgid "Key encipherment use enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1481
+#: ../src/ca-cli-callbacks.c:1490
 msgid "Key agreement use enabled in generated certs                      "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1482
+#: ../src/ca-cli-callbacks.c:1491
 msgid "Data encipherment use enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1483
+#: ../src/ca-cli-callbacks.c:1492
 msgid "TLS web server purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1484
+#: ../src/ca-cli-callbacks.c:1493
 msgid "TLS web client purpose enabled in generated certs                 "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1485
+#: ../src/ca-cli-callbacks.c:1494
 msgid "Time stamping purpose enabled in generated certs                  "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1486
+#: ../src/ca-cli-callbacks.c:1495
 msgid "Code signing server purpose enabled in generated certs            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1487
+#: ../src/ca-cli-callbacks.c:1496
 msgid "Email protection purpose enabled in generated certs               "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1488
+#: ../src/ca-cli-callbacks.c:1497
 msgid "OCSP signing purpose enabled in generated certs                   "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1489
+#: ../src/ca-cli-callbacks.c:1498
 msgid "Any purpose enabled in generated certs                            "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1503
+#: ../src/ca-cli-callbacks.c:1512
 #, c-format
 msgid "Showing policies of the following certificate:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1505
+#: ../src/ca-cli-callbacks.c:1514
 #, c-format
 msgid ""
 "\n"
 "Policies:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1507
+#: ../src/ca-cli-callbacks.c:1516
 #, c-format
 msgid "Id.\tDescription\t\t\t\t\t\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1533
+#: ../src/ca-cli-callbacks.c:1542
 msgid "The given policy id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1545
+#: ../src/ca-cli-callbacks.c:1554
 #, c-format
 msgid ""
 "You are about to assign to the policy\n"
 "'%s' the new value '%s'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1549 ../src/ca-cli-callbacks.c:1593
+#: ../src/ca-cli-callbacks.c:1558 ../src/ca-cli-callbacks.c:1602
 msgid "Are you sure? Yes/[No] : "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1554
+#: ../src/ca-cli-callbacks.c:1563
 #, c-format
 msgid "Policy set correctly to '%s'.\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1568
+#: ../src/ca-cli-callbacks.c:1577
 #, c-format
 msgid "gnoMint-cli current preferences:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1570
+#: ../src/ca-cli-callbacks.c:1579
 #, c-format
 msgid "Id.\tName\t\t\tValue\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1571
+#: ../src/ca-cli-callbacks.c:1580
 #, c-format
 msgid "0\tGnome keyring support\t%d\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1583
+#: ../src/ca-cli-callbacks.c:1592
 msgid "The given preference id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1589
+#: ../src/ca-cli-callbacks.c:1598
 #, c-format
 msgid ""
 "You are about to assign to the preference 'Gnome keyring support' the new "
 "value '%d'."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1611
+#: ../src/ca-cli-callbacks.c:1620
 #, c-format
 msgid ""
 "%s version %s\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1612
+#: ../src/ca-cli-callbacks.c:1621
 #, c-format
 msgid ""
 "\n"
@@ -1946,7 +1946,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1613 ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1622 ../src/ca-cli-callbacks.c:1623
 #: ../src/main.c:544
 msgid "translator-credits"
 msgstr ""
@@ -1954,14 +1954,14 @@ msgstr ""
 "  Daniel Nylander https://launchpad.net/~yeager\n"
 "  Marcus E https://launchpad.net/~marcus+e"
 
-#: ../src/ca-cli-callbacks.c:1614
+#: ../src/ca-cli-callbacks.c:1623
 #, c-format
 msgid ""
 "Translators:\n"
 "%s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1621
+#: ../src/ca-cli-callbacks.c:1630
 msgid ""
 "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\n"
 "APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\n"
@@ -1979,7 +1979,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1639
+#: ../src/ca-cli-callbacks.c:1648
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -1996,197 +1996,197 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1654
+#: ../src/ca-cli-callbacks.c:1663
 #, c-format
 msgid "%s version %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1663
+#: ../src/ca-cli-callbacks.c:1672
 #, c-format
 msgid "Available commands:\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1664
+#: ../src/ca-cli-callbacks.c:1673
 #, c-format
 msgid "===================\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1674
+#: ../src/ca-cli-callbacks.c:1683
 #, c-format
 msgid "Exiting gnomint-cli...\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1715
+#: ../src/ca-cli-callbacks.c:1724
 msgid "The given CA id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1727
+#: ../src/ca-cli-callbacks.c:1736
 msgid "Certificate type must be 'web' or 'email'"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1733
+#: ../src/ca-cli-callbacks.c:1742
 msgid "Server name cannot be empty"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1737
+#: ../src/ca-cli-callbacks.c:1746
 #, fuzzy, c-format
 msgid "Creating %s certificate for: %s\n"
 msgstr "Skapar CA-rotcertifikat"
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "web server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1738
+#: ../src/ca-cli-callbacks.c:1747
 msgid "email server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1814
+#: ../src/ca-cli-callbacks.c:1823
 #, fuzzy, c-format
 msgid "Error: Key generation failed: %s\n"
 msgstr "Nyckelgenerering misslyckades"
 
-#: ../src/ca-cli-callbacks.c:1822
+#: ../src/ca-cli-callbacks.c:1831
 #, fuzzy, c-format
 msgid "Error: CSR generation failed: %s\n"
 msgstr "CSR-generering misslyckades"
 
-#: ../src/ca-cli-callbacks.c:1831
+#: ../src/ca-cli-callbacks.c:1840
 #, c-format
 msgid "Error: Failed to parse generated CSR\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1842
+#: ../src/ca-cli-callbacks.c:1851
 #, c-format
 msgid "Error: Failed to save CSR: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1856
+#: ../src/ca-cli-callbacks.c:1865
 msgid "CSR created with ID: %"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1880
+#: ../src/ca-cli-callbacks.c:1889
 #, c-format
 msgid "Error: Failed to sign certificate: %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1887
+#: ../src/ca-cli-callbacks.c:1896
 #, fuzzy, c-format
 msgid "Certificate generated successfully for: %s\n"
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 #, fuzzy, c-format
 msgid "Certificate type: %s\n"
 msgstr "_Certifikat"
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Web Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1888
+#: ../src/ca-cli-callbacks.c:1897
 msgid "Email Server"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1902
+#: ../src/ca-cli-callbacks.c:1911
 msgid "Usage: renewcert <cert-id>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1907 ../src/ca-cli-callbacks.c:1938
+#: ../src/ca-cli-callbacks.c:1916 ../src/ca-cli-callbacks.c:1947
 msgid "The given certificate id is not valid"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1911
+#: ../src/ca-cli-callbacks.c:1920
 msgid ""
 "gnoMint will issue a new certificate with the same subject and SAN as this "
 "one, signed by the same CA, with a fresh keypair. The old certificate stays "
 "in place."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1914
+#: ../src/ca-cli-callbacks.c:1923
 msgid "Renew? [Yes]/No "
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1925
+#: ../src/ca-cli-callbacks.c:1934
 #, fuzzy
 msgid "Certificate renewed. New certificate id: %"
 msgstr "Certifikatgenerering misslyckades"
 
-#: ../src/ca-cli-callbacks.c:1933
+#: ../src/ca-cli-callbacks.c:1942
 msgid "Usage: exportchain <cert-id> <filename>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1944
+#: ../src/ca-cli-callbacks.c:1953
 msgid "Cannot build chain PEM for that certificate."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1949
+#: ../src/ca-cli-callbacks.c:1958
 #, fuzzy
 msgid "Cannot write chain file."
 msgstr "Lägg till ett autosignerat CA-certifikat"
 
-#: ../src/ca-cli-callbacks.c:1955
+#: ../src/ca-cli-callbacks.c:1964
 #, c-format
 msgid "Full chain (leaf → root) written to %s\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1962
+#: ../src/ca-cli-callbacks.c:1971
 msgid "Usage: revokemany <cert-id> [cert-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:1978
+#: ../src/ca-cli-callbacks.c:1987
 #, fuzzy, c-format
 msgid "%d certificate revoked.\n"
 msgid_plural "%d certificates revoked.\n"
 msgstr[0] "Exportera certifikat"
 msgstr[1] "Exportera certifikat"
 
-#: ../src/ca-cli-callbacks.c:1986
+#: ../src/ca-cli-callbacks.c:1995
 msgid "Usage: deletemany <csr-id> [csr-id ...]"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2002
+#: ../src/ca-cli-callbacks.c:2011
 #, c-format
 msgid "%d CSR deleted.\n"
 msgid_plural "%d CSRs deleted.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2062
+#: ../src/ca-cli-callbacks.c:2071
 msgid "Usage: search <pattern>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2069
+#: ../src/ca-cli-callbacks.c:2078
 #, c-format
 msgid "Matches (id\tserial\tsubject):\n"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2072
+#: ../src/ca-cli-callbacks.c:2081
 #, c-format
 msgid "%d match.\n"
 msgid_plural "%d matches.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca-cli-callbacks.c:2096
+#: ../src/ca-cli-callbacks.c:2105
 #, fuzzy, c-format
 msgid "'%s' is not a certificate id in this database."
 msgstr "_Öppna certifikatdatabas"
 
-#: ../src/ca-cli-callbacks.c:2104
+#: ../src/ca-cli-callbacks.c:2113
 #, c-format
 msgid "Cannot read PEM for cert id %s."
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2122
+#: ../src/ca-cli-callbacks.c:2131
 msgid "Usage: diff <cert-id-or-path> <cert-id-or-path>"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2138
+#: ../src/ca-cli-callbacks.c:2147
 msgid "Field"
 msgstr ""
 
-#: ../src/ca-cli-callbacks.c:2151
+#: ../src/ca-cli-callbacks.c:2160
 #, c-format
 msgid ""
 "\n"
@@ -2615,7 +2615,7 @@ msgstr "CSR kunde inte sparas"
 msgid "CSR generated successfully"
 msgstr "CSR-generering lyckades"
 
-#: ../src/csr_properties.c:77 ../src/new_cert.c:273 ../src/new_cert.c:280
+#: ../src/csr_properties.c:77 ../src/new_cert.c:279
 msgid "None"
 msgstr ""
 
@@ -2625,22 +2625,22 @@ msgid ""
 "in a external file.</b>"
 msgstr ""
 
-#: ../src/dialog.c:103
+#: ../src/dialog.c:108
 #, c-format
 msgid ""
 "\n"
 "The password must have, at least, %d characters\n"
 msgstr ""
 
-#: ../src/dialog.c:127
+#: ../src/dialog.c:132
 msgid "List of affirmative answers, separated with #|Yes#yes#Y#y"
 msgstr ""
 
-#: ../src/dialog.c:128
+#: ../src/dialog.c:133
 msgid "List of negative answers, separated with #|No#no#N#n"
 msgstr ""
 
-#: ../src/dialog.c:396
+#: ../src/dialog.c:401
 msgid "To do. Feature not implemented yet."
 msgstr ""
 
@@ -2932,37 +2932,37 @@ msgstr "Bitlängd för privat nyckel:"
 msgid "ECDSA curve:"
 msgstr ""
 
-#: ../src/new_cert.c:350
+#: ../src/new_cert.c:377
 msgid ""
 "The policy of this CA obligue the country field of the certificates to be "
 "the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:356
+#: ../src/new_cert.c:383
 msgid ""
 "The policy of this CA obligue the state/province field of the certificates "
 "to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:362
+#: ../src/new_cert.c:389
 msgid ""
 "The policy of this CA obligue the locality/city field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:368
+#: ../src/new_cert.c:395
 msgid ""
 "The policy of this CA obligue the organization field of the certificates to "
 "be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:374
+#: ../src/new_cert.c:401
 msgid ""
 "The policy of this CA obligue the organizational unit field of the "
 "certificates to be the same as the one in the CA cert."
 msgstr ""
 
-#: ../src/new_cert.c:831
+#: ../src/new_cert.c:876
 msgid ""
 "The expiration date of the new certificate is after the expiration date of "
 "the CA certificate.\n"
@@ -2971,7 +2971,7 @@ msgid ""
 "will be created with the same expiration date as the CA certificate."
 msgstr ""
 
-#: ../src/new_cert.c:847
+#: ../src/new_cert.c:892
 msgid "Error while signing CSR."
 msgstr ""
 

--- a/src/new_cert.c
+++ b/src/new_cert.c
@@ -34,10 +34,16 @@
 #include "pkey_manage.h"
 #include "preferences-gui.h"
 #include "new_cert.h"
+#ifndef GNOMINTCLI
+#  include "san_manager.h"
+#endif
 
 #ifndef GNOMINTCLI
 GtkBuilder * new_cert_window_gtkb = NULL;
 GtkTreeStore * new_cert_ca_list_model = NULL;
+#ifndef GNOMINTCLI
+GtkWidget *new_cert_san_manager = NULL;  /* SAN editor for issue #40 */
+#endif
 
 
 enum {NEW_CERT_CA_MODEL_COLUMN_ID=0,
@@ -273,12 +279,33 @@ void new_cert_window_display(const guint64 csr_id, const gchar *csr_pem, const g
 		gtk_label_set_text (GTK_LABEL(object), _("None"));
 	}
 
-	object = gtk_builder_get_object (new_cert_window_gtkb, "san_label");
-	if (csr_info->subject_alt_name && csr_info->subject_alt_name[0]) {
-		gtk_label_set_text (GTK_LABEL(object), csr_info->subject_alt_name);
-	} else {
-		gtk_label_set_text (GTK_LABEL(object), _("None"));
+#ifndef GNOMINTCLI
+	/* SAN editor (issue #40): replace the read-only san_label with a
+	 * live san_manager_widget pre-populated from the CSR. The
+	 * commit handler (on_new_cert_next2_clicked) reads
+	 * san_manager_get_string back into cert_creation_data so the
+	 * issued certificate carries whatever the CA operator chose,
+	 * not just the CSR's request. CLI doesn't have a SAN editor —
+	 * the CLI signing path keeps the CSR's SAN verbatim. */
+	{
+		GtkBuilder *san_builder = gtk_builder_new ();
+		gchar *san_ui = g_build_filename (PACKAGE_DATA_DIR, "gnomint",
+		                                   "san_manager_widget.ui", NULL);
+		gtk_builder_add_from_file (san_builder, san_ui, NULL);
+		g_free (san_ui);
+		new_cert_san_manager = san_manager_create (san_builder,
+		                                            "san_manager_vbox");
+		if (new_cert_san_manager) {
+			GtkWidget *box = GTK_WIDGET (gtk_builder_get_object (
+			    new_cert_window_gtkb, "san_alignment"));
+			gtk_container_add (GTK_CONTAINER (box), new_cert_san_manager);
+			gtk_widget_show_all (new_cert_san_manager);
+			if (csr_info->subject_alt_name && csr_info->subject_alt_name[0])
+				san_manager_set_string (new_cert_san_manager,
+				                        csr_info->subject_alt_name);
+		}
 	}
+#endif
 	
         object = gtk_builder_get_object (new_cert_window_gtkb, "signing_ca_treeview");
         __new_cert_populate_ca_treeview (GTK_TREE_VIEW(object));
@@ -764,7 +791,25 @@ G_MODULE_EXPORT void on_new_cert_commit_clicked (GtkButton *widg,
 	cert_creation_data->crl_distribution_point = ca_file_policy_get (ca_id, "CRL_DISTRIBUTION_POINT");
 
 	// SANs will be copied from the CSR by default
+#ifndef GNOMINTCLI
+	/* SAN editor (issue #40): read the (possibly-edited) SAN list back
+	 * from the manager widget. The empty string also means none, and
+	 * we normalise to NULL so the downstream tls_generate_certificate
+	 * path takes the no-SAN branch. */
+	if (new_cert_san_manager) {
+		gchar *edited_san = san_manager_get_string (new_cert_san_manager);
+		if (edited_san && *edited_san) {
+			cert_creation_data->subject_alt_name = edited_san;
+		} else {
+			g_free (edited_san);
+			cert_creation_data->subject_alt_name = NULL;
+		}
+	} else {
+		cert_creation_data->subject_alt_name = NULL;
+	}
+#else
 	cert_creation_data->subject_alt_name = NULL;
+#endif
 
 	strerror = new_cert_sign_csr (csr_id, ca_id, cert_creation_data);
 

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -761,6 +761,81 @@ out:
 }
 
 /* ------------------------------------------------------------------ */
+/*  Scenario 6b: SAN editor is present in the sign-CSR dialog (#40)   */
+/* ------------------------------------------------------------------ */
+
+extern GtkBuilder *new_cert_window_gtkb;
+extern GtkWidget  *new_cert_san_manager;
+
+static int
+scenario_sign_csr_has_san_editor (void)
+{
+    int rc = 1;
+    fprintf (stderr, "==> scenario: sign-CSR has SAN editor (issue #40)\n");
+    if (!test_init_main_window () || !fixture_setup ())
+        return 1;
+    if (!ca_open (g_strdup (fixture_path), FALSE)) {
+        fail_test ("san-editor", "ca_open(%s) failed", fixture_path);
+        goto out;
+    }
+    if (!select_row_by_id ("1", 1)) {
+        fail_test ("san-editor", "fixture CSR id=1 missing");
+        goto out;
+    }
+
+    /* Open the dialog WITHOUT auto-dismissing — the dismiss timer
+     * could destroy it before we get to inspect san_alignment.
+     * ca_on_sign1_activate calls new_cert_window_display which builds
+     * the dialog synchronously, attaches the SAN editor, and shows
+     * it. We check immediately, then tear it down by hand. */
+    ca_on_sign1_activate (NULL, NULL);
+
+    if (!new_cert_window_gtkb) {
+        fail_test ("san-editor", "new_cert_window_gtkb is NULL after sign");
+        goto out;
+    }
+
+    /* The san_alignment container must exist and have a child (the
+     * san_manager_widget added at runtime). */
+    GObject *container = gtk_builder_get_object (new_cert_window_gtkb,
+                                                  "san_alignment");
+    if (!container || !GTK_IS_CONTAINER (container)) {
+        fail_test ("san-editor", "san_alignment widget missing from .ui");
+        goto out;
+    }
+    GList *kids = gtk_container_get_children (GTK_CONTAINER (container));
+    int n_kids = g_list_length (kids);
+    g_list_free (kids);
+    if (n_kids == 0) {
+        fail_test ("san-editor",
+                   "san_alignment is empty — SAN editor wasn't attached");
+        goto out;
+    }
+    fprintf (stderr, "    san_alignment has %d child(ren); editor live\n",
+             n_kids);
+
+    if (!new_cert_san_manager) {
+        fail_test ("san-editor", "new_cert_san_manager global is NULL");
+        goto out;
+    }
+
+    /* Tear the dialog down manually so the next scenario starts clean. */
+    GObject *win = gtk_builder_get_object (new_cert_window_gtkb,
+                                            "new_cert_window");
+    if (win && GTK_IS_WIDGET (win))
+        gtk_widget_destroy (GTK_WIDGET (win));
+    drain_events ();
+
+    int crits = critical_messages_check_and_reset ("san-editor");
+    rc = (crits == 0) ? 0 : 1;
+
+out:
+    ca_file_close ();
+    fixture_teardown ();
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Scenario 7 (Phase 2B): revoke cert                                */
 /* ------------------------------------------------------------------ */
 
@@ -1869,6 +1944,7 @@ main (int argc, char **argv)
         scenario_view_properties_full ();
         scenario_extract_private_key ();
         scenario_sign_csr ();
+        scenario_sign_csr_has_san_editor ();
         scenario_revoke_cert ();
         scenario_wizard_window ();
         scenario_keylength_selector ();


### PR DESCRIPTION
## Summary
Closes #40. Signing a CSR was the only one of the three certificate-creation flows that didn't let the CA operator edit the Subject Alternative Names. SANs were shown read-only and copied verbatim into the issued certificate. A CA is supposed to control what it actually signs.

## What changed
- **\`gui/new_cert_window.ui\`** — replaces the read-only \`san_label\` GtkLabel with a \`san_alignment\` GtkBox container (same pattern as \`new_ca_window.ui\` / \`new_req_window.ui\`).
- **\`src/new_cert.c\`** — at dialog-open time loads \`san_manager_widget.ui\`, creates the SAN manager widget, packs it into \`san_alignment\`, and pre-populates from \`csr_info->subject_alt_name\` so the operator starts with the request's SANs visible. At signing time reads \`san_manager_get_string\` back into \`cert_creation_data->subject_alt_name\` (empty string → NULL so the no-SAN code path still works).
- The SAN editor is GUI-only; the embedding is wrapped in \`#ifndef GNOMINTCLI\`. The CLI \`sign\` command keeps the CSR's SAN verbatim (separate scope if needed).

## Test plan
- [x] \`make\` clean
- [x] \`make -C tests check\` — 14 of 14 PASS, including the new \`scenario_sign_csr_has_san_editor\` which opens the dialog and asserts the SAN editor is attached + accessible
- [ ] Manual: select a CSR, click Sign, advance to the subject panel, confirm the SAN list is editable