### PR TITLE
Add 'Show them' action to expiry banner (completes #56)

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-04-05 14:02+0000\n"
 "Last-Translator: Sergio Oller <Unknown>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -132,15 +132,15 @@ msgstr "Gestiona CAs i certificats X.509, fàcilment i de forma gràfica"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Sol·licituds de signatura de certificats</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Sol·licituds de signatura de certificats</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -157,28 +157,39 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Persona certificada"
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Núm. de sèrie"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Activació"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Venciment"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Revocació"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,66 +200,70 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Exporta sol·licitud de signatura de certificat"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Hi ha hagut un error al exportar el certificat."
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 "Ha hagut un error al exportar la sol·licitud de signatura de certificat "
 "(CSR),"
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr "Sol·licitud de signatura de certificat exportada amb èxit."
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr "Exporta la clau privada xifrada"
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Clau privada exportada amb èxit."
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporta la clau privada sense xifrar"
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporta tot el certificat en un paquet PKCS#12"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Exporta sol·licitud de signatura de certificat (CSR) - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -256,7 +271,7 @@ msgstr ""
 "Seleccioneu quina part de la sol·licitud de signatura de certificat (CSR) "
 "voleu exportar:"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -264,7 +279,7 @@ msgstr ""
 "<i>Exporta la sol·licitud de signatura de certificat a un fitxer públic en "
 "format PEM</i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -274,70 +289,70 @@ msgstr ""
 "contrasenya. Aquest fitxer només ha de ser accessible pel titular de la "
 "sol·licitud de signatura del certificat.</i>"
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporta certificat"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Afegir certificat de la CA auto-signat"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exportat amb èxit."
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Entitat certificadora"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Esteu segur que voleu revocar aquest certificat?"
 msgstr[1] "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat revocat.\n"
 msgstr[1] "Certificat revocat.\n"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -348,12 +363,12 @@ msgstr[1] ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -363,71 +378,71 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Revoca el certificat seleccionat"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Afegir certificat de la CA auto-signat"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Esteu segur que voleu revocar aquest certificat?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -438,17 +453,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Esteu segur que voleu eliminar aquesta sol·licitud de signatura de "
 "certificat (CSR)?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr "Canvia la contrasenya de la CA - gnoMint"
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -456,56 +471,56 @@ msgstr ""
 "La contrasenya introduïda no es correspon amb la contrasenya real de la base "
 "de dades."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al canviar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr "Contrasenya canviada correctament"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al establir la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr "La contrasenya s'ha establert amb èxit"
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "S'ha produït un error al eliminar la contrasenya de la base de dades. S'ha "
 "cancel·lat la operació."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "La contrasenya s'ha eliminat amb èxit"
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Desa paràmetres Diffie-Hellman"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Paràmetres Diffie-Hellman desats correctament"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "Seleccioneu el fitxer PEM a importar"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "S'han produït problemes al importar el fitxer '%s'"
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr "Seleccioneu el directori a importar"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2009-11-08 15:27+0000\n"
 "Last-Translator: Kuvaly [LCT] <kuvaly@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -121,15 +121,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -137,7 +137,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -145,28 +145,39 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -177,153 +188,157 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 msgid "Export certificate chain"
 msgstr ""
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -333,68 +348,68 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 msgid "Cannot read PEM of the selected certificate."
 msgstr ""
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 msgid "Cannot read file."
 msgstr ""
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -405,64 +420,64 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-04-02 04:45+0000\n"
 "Last-Translator: Mario Blättermann <mariobl@freenet.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -132,15 +132,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Zertifikate</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Signaturanfragen für Zertifikate</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Signaturanfragen für Zertifikate</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -157,28 +157,39 @@ msgstr "%d.%m.%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d.%m.%Y %R GMT"
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Seriell"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Widerruf"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +200,68 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Signaturanfrage für Zertifikat exportieren"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Beim Export des Zertifikats ist ein Fehler aufgetreten."
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr "Signaturanfrage für Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Geheimer Schlüssel wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Geheimen Schlüssel en_tpacken"
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Gesamtes Zertifikat in einem PKCS#12-Paket exportieren"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Signaturanfrage exportieren - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,7 +269,7 @@ msgstr ""
 "Bitte wählen Sie den Teil der gespeicherten Siganturanfrage aus, den Sie "
 "exportieren wollen:"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -262,77 +277,77 @@ msgstr ""
 "<i>Signaturanfrage für Zertifikat in eine öffentliche Datei im PEM-Format "
 "exportieren.</i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Zertifikat exportieren"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Zertifikat wurde erfolgreich exportiert"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Zertifizierungsstelle"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 msgstr[1] "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Zertifikat wurde widerrufen.\n"
 msgstr[1] "Zertifikat wurde widerrufen.\n"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -343,12 +358,12 @@ msgstr[1] ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -358,71 +373,71 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Das ausgewählte Zertifikat widerrufen"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Initialisierung ist fehlgeschlagen: %s\n"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Sind Sie sicher, dass Sie dieses Zertifikat widerrufen wollen?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -433,17 +448,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Sind Sie sicher, dass Sie diese Signaturanfrage für ein Zertifikat "
 "widerrufen wollen?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr "Zertifizierungsstellen-Passwort ändern - gnoMint"
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -451,56 +466,56 @@ msgstr ""
 "Das von Ihnen eingegebene Passwort stimmt nicht mit dem derzeit für die "
 "Datenbank geltenden Passwort überein."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ändern des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr "Das Passwort wurde erfolgreich geändert"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Ermitteln des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr "Passwort wurde erfolgreich ermittelt"
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Fehler beim Löschen des Passworts der Datenbank. Der Vorgang wurde "
 "abgebrochen."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "Passwort wurde erfolgreich gelöscht"
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Diffie-Hellman-Parameter speichern"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-Parameter wurden erfolgreich gespeichert"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "PEM-Datei zum Importieren auswählen"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problem beim Importieren der Datei »%s«"
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr "Ordner zum Importieren auswählen"
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnoMint 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-08-11 12:11+0200\n"
 "Last-Translator: DiegoJ <diegojromerolopez@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -133,15 +133,15 @@ msgstr "Gestiona autoridades de certificación y certificados X.509"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificados</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Solicitudes de certificación</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -149,7 +149,7 @@ msgstr "<b>Solicitudes de certificación</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -157,28 +157,43 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %H:%M GMT"
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titular"
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Nº serie"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Activación"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Caducidad"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Revocación"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+"Mostrando solo el <b>%d certificado</b> que caduca en los próximos %d días. "
+"Cierre este aviso para volver a mostrar todo."
+msgstr[1] ""
+"Mostrando solo los <b>%d certificados</b> que caducan en los próximos %d "
+"días. Cierre este aviso para volver a mostrar todo."
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -193,65 +208,69 @@ msgstr[1] ""
 "<b>%d certificados</b> caducan en los próximos %d días. Haga clic con el "
 "botón derecho sobre cada uno para renovarlo con una clave nueva."
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr "_Mostrarlos"
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Exportar certificado"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 #, fuzzy
 msgid "_Cancel"
 msgstr "Francia"
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Exportar solicitud de certificación"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Ocurrió un error al exportar el certificado"
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr "Ocurrió un error al exportar la solicitud de certificación."
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Certificado exportado con éxito"
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr "Solicitud de certificación exportada correctamente"
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr "Exportar clave privada cifrada."
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Clave privada exportada con éxito"
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportar clave privada sin cifrar."
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportar todo el certificado en un paquete PKCS#12"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Exportar solicitud de certificación - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -259,7 +278,7 @@ msgstr ""
 "Seleccione qué parte almacenada de la solicitud de certificación desea "
 "exportar:"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -267,7 +286,7 @@ msgstr ""
 "<i>Exporta la solicitud de certificación a un fichero público en formato "
 "PEM</i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -277,43 +296,43 @@ msgstr ""
 "clave. Este fichero sólo debería ser accesible para el titular de la "
 "soliticud de certificación.</i>"
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 msgid "Please select a certificate to export its chain."
 msgstr "Por favor, seleccione un certificado para exportar su cadena."
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 msgid "Export certificate chain"
 msgstr "Exportar cadena de certificados"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr "No se pudo construir la cadena de certificados."
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr "Error al escribir la cadena: %s"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 msgid "Certificate chain exported successfully."
 msgstr "Cadena de certificados exportada con éxito."
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 msgid "Please select one or more certificates to revoke."
 msgstr "Por favor, seleccione uno o más certificados para revocar."
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "¿Está seguro de que desea revocar este certificado?"
 msgstr[1] "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 #, fuzzy
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
@@ -324,35 +343,35 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr "La revocación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificado revocado.\n"
 msgstr[1] "Certificado revocado.\n"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr "Por favor, seleccione una o más solicitudes para eliminar."
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 msgstr[1] "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr "La eliminación masiva terminó con errores. Primer error: %s"
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -368,7 +387,7 @@ msgstr ""
 "El certificado antiguo permanecerá en la base de datos — revóquelo "
 "manualmente cuando haya desplegado el nuevo."
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
@@ -376,53 +395,53 @@ msgstr ""
 "Certificado renovado. Se ha añadido un nuevo certificado con un par de "
 "claves nuevo a la base de datos, junto al original."
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] "Diferencias entre certificados — %d diferencia"
 msgstr[1] "Diferencias entre certificados — %d diferencias"
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Revocar el certificado seleccionado"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr "Comparar con un archivo PEM…"
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Error al escribir la cadena: %s"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -432,11 +451,11 @@ msgstr ""
 "como no válido. Así, se impedirá cualquier uso futuro del certificado "
 "(siempre y cuando se compruebe la CRL)"
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "¿Está seguro de que desea revocar este certificado de AC?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -454,15 +473,15 @@ msgstr ""
 "certificados generados con él, por lo que todos deberían regenerarse con un "
 "nuevo certificado de AC."
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "¿Está seguro de que desea borrar esta solicitud de certificación?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr "Cambiando contraseña de AC - gnoMint"
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -470,56 +489,56 @@ msgstr ""
 "La contraseña actual que ha introducido no coincide con la contraseña real "
 "de la base de datos."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al cambiar la contraseña de la base de datos. Se canceló la "
 "operación."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr "Contraseña cambiada con éxito"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al establecer la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr "Contraseña establecida con éxito"
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ocurrió un error al eliminar la contraseña de la base de datos. Se canceló "
 "la operación."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "Contraseña eliminada con éxito"
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Guardar parámetros Diffie-Hellman"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parámetros Diffie-Hellman guardados correctamente"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "Seleccione fichero PEM a importar"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Hubo problemas al importar el fichero '%s'"
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr "Seleccione directorio a importar"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2009-06-03 22:28+0000\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -128,15 +128,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -144,7 +144,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -152,28 +152,39 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -184,155 +195,159 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Peruttujen varmenteiden näkyvyys"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Varmennuspyyntöjen näkyvyys"
 msgstr[1] "Varmennuspyyntöjen näkyvyys"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -342,70 +357,70 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Peruttujen varmenteiden näkyvyys"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Virhe allekirjoitettaessa varmennetta"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -416,64 +431,64 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-06-01 20:04+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: French\n"
@@ -132,15 +132,15 @@ msgstr "Gérer des certificats et des CA X.509, facilement et graphiquement"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Demandes en signature de certificat</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Demandes en signature de certificat</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -157,28 +157,39 @@ msgstr "%d/%m/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%d/%m/%Y %R GMT"
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Titulaire"
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Numéro"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Activation"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Expiration"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Révocation"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +200,68 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Exporter une CSR"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Erreur pendant l'exportation du certificat."
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr "Erreur pendant l'exportation de la Requête de Signature de Certificat."
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr "CSR exporté avec succès."
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr "Exporter la clé privée chiffrée"
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Clé privée exportée avec succès"
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exporter la clé privée non chiffrée"
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exporter l'intégralité du certificat vers un paquet au format PKCS#12"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Exportation de Requête de Signature de Certificat - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,13 +269,13 @@ msgstr ""
 "Veuillez choisir la partie de la Requête de Signature de Certificat "
 "sauvegardée que vous souhaitez exporter :"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr "<i>Exporter la CSR vers un fichier public, au format PEM.</i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -270,71 +285,71 @@ msgstr ""
 "passe, au format PKCS#8. Ce fichier ne devrait être accessible que par le "
 "titulaire de la CSR.</i>"
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exporter un certificat"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Certificat Racine de l'Autorité de Certification"
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificat exporté avec succès."
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorité de Certification"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 msgstr[1] "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificat révoqué.\n"
 msgstr[1] "Certificat révoqué.\n"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -343,12 +358,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -358,71 +373,71 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Révoquer le certificat sélectionné"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "L'initialisation a échoué : %s\n"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Êtes-vous sûr de vouloir révoquer ce certificat ?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -433,16 +448,16 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Êtes-vous sûr de vouloir supprimer cette Requête de Signature de Certificat ?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr "Modifier le mot de passe de l'Autorité de Certification - gnoMint"
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -450,56 +465,56 @@ msgstr ""
 "Le mot de passe que vous venez d'entrer ne correspond pas au mot de passe "
 "actuel de la base de données."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la modification du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr "Mot de passe modifié avec succès."
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant l'affectationdu mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr "Mot de passe mis en place avec succès."
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Erreur pendant la suppression du mot de passe de la base de données. "
 "L'opération a été annulée."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "Mot de passe supprimé avec succès."
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Sauvegarder les paramètres Diffie-Hellman"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Les paramètres Diffie-Hellman ont été sauvegardés avec succès"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "Choisir le fichier PEM à importer"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Problème pendant l'importation du fichier '%s'"
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr "Sélectionner le répertoire à importer"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-07-09 11:50+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -132,15 +132,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificati</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Richieste di firma di certificato (CSR)</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -156,28 +156,39 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Revoca"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -188,64 +199,68 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Esporta la richiesta di firma di certificato (CSR)"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Errore durante l'esportazione del certificato."
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr "Errore durante l'esportazione del CSR."
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr "Richiesta di firma di certificato (CSR) esportata correttamente"
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr "Esporta la chiave privata criptata"
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Chiave privata esportata correttamente"
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Esporta chiave privata non criptata"
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Esporta l'intero certificato nel pacchetto PKCS#12"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Esporta CSR - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -253,7 +268,7 @@ msgstr ""
 "Si prega di scegliere quale parte della richiesta di firma di certificato "
 "(CSR) salvata si vuole esportare:"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -261,7 +276,7 @@ msgstr ""
 "<i>Esporta la richiesta di firma di certificato (CSR) in un file pubblico, "
 "in formato PEM.</i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -271,70 +286,70 @@ msgstr ""
 "Questo file deve essere accessibile solamente da parte del soggetto della "
 "richiesta di firma di certificato (CSR).</i>"
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Esporta certificato"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Aggiungi un certificato CA autofirmato"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certificato esportato correttamente"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Autorità di Certificazione"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Confermare la revoca di questo certificato?"
 msgstr[1] "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Certificato revocato.\n"
 msgstr[1] "Certificato revocato.\n"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -345,12 +360,12 @@ msgstr[1] ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -360,71 +375,71 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Revoca il certificato selezionato"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Aggiungi un certificato CA autofirmato"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Confermare la revoca di questo certificato?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -435,17 +450,17 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 "Confermare la cancellazione di questa richiesta di firma di certificato "
 "(CSR)?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -453,56 +468,56 @@ msgstr ""
 "La password attualmente inserita non corrisponde con la reale e corrente "
 "password del database."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la modifica della password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 "Errore nello stabilire la password del database. L'operazione è stata "
 "annullata."
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr "Password stabilita correttamente"
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Errore durante la rimozione della password del database. L'operazione è "
 "stata annullata."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "Password rimossa correttamente"
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Salva i parametri Diffie-Hellman"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Parametri Diffie-Hellman salvati correttamente"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "Selezionare il file PEM da importare"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-05-16 15:17+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -123,15 +123,15 @@ msgstr "Gerir aisidament e graficament de certificats X.509 e d'AC"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -139,7 +139,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -147,28 +147,39 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Subjècte"
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Periodic"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Activacion"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Expiracion"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Revocacion"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -179,154 +190,158 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Error inesperada"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "<b>Certificats</b>"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 msgid "Certificate chain exported successfully."
 msgstr ""
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "<b>Certificats</b>"
 msgstr[1] "<b>Certificats</b>"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -336,68 +351,68 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 msgid "Cannot read PEM of the selected certificate."
 msgstr ""
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 msgid "Cannot read file."
 msgstr ""
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -408,64 +423,64 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2009-06-03 22:30+0000\n"
 "Last-Translator: Enrico Nicoletto <liverig@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -130,15 +130,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -146,7 +146,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -154,28 +154,39 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -186,155 +197,159 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Visibilidade de certificados revogados"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, c-format
 msgid "Failed to write chain: %s"
 msgstr ""
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Visibilidade de pedidos de certificado"
 msgstr[1] "Visibilidade de pedidos de certificado"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -344,69 +359,69 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Visibilidade de certificados revogados"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 msgid "Cannot read file."
 msgstr ""
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -417,64 +432,64 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2009-10-12 03:55+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -132,15 +132,15 @@ msgstr "Управлять сертификатами X.509 и CA легко и 
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Сертификат</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Запрос на Подпись Сертификата</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -148,7 +148,7 @@ msgstr "<b>Запрос на Подпись Сертификата</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -157,28 +157,39 @@ msgstr "%m/%d/%Y %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%m/%d/%Y %R GMT"
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Заголовок"
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Серийный номер"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Активация"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Срок истечения"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Отзыв"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -189,64 +200,68 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Экспорт запроса на подпись сертификата"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Произошла ошибка во время экспорта сертификата."
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr "Произошла ошибка во время экспорта CSR."
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr "Запрос на подпись сертификата успешно экспортирован"
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr "Экспорт зашифрованного закрытого ключ"
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Закрытый ключ успешно экспортирован"
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Экспорт незашифрованного закрытого ключа"
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Экспорт всего сертификата в PKCS#12 пакет"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Экспорт CSR - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -254,7 +269,7 @@ msgstr ""
 "Пожалуйста, выберите какую часть сохранённого Запроса на Подпись Сертификата "
 "вы хотите экспортировать:"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -262,7 +277,7 @@ msgstr ""
 "<i>Экспорт Запроса на Подпись Сертификата в незашифрованный файл PEM формата."
 "</i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -271,83 +286,83 @@ msgstr ""
 "<i>Экспрорт сохранённого закрытого ключа в PKCS#8 файл защищённый паролем. "
 "Этот файл должен быть доступен владельцу Запроса на Подпись Сертификата.</i>"
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Неожиданная ошибка"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Экспорт сертификата"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 #, fuzzy
 msgid "Could not build certificate chain."
 msgstr "Корневой сертификат CA"
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Сертификат успешно экспортирован"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Центр сертификации"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Вы уверены, что хотите отозвать сертификат?"
 msgstr[1] "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Сертификат отозван.\n"
 msgstr[1] "Сертификат отозван.\n"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 msgstr[1] "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -357,71 +372,71 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Отозвать выбранные сертификаты"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Не удалось инициализировать: %s\n"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Вы уверены, что хотите отозвать сертификат?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -432,15 +447,15 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Вы уверены, что хотите улалить Запрос на Подпись Сертификата?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr "Изменить CA пароль - gnoMint"
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
@@ -448,50 +463,50 @@ msgstr ""
 "Текущий пароль, который вы ввели, не совпадает с текущим актуальным паролем "
 "базы."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr "Произошла  ошибка при смене пароля базы. Операция отменена."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr "Пароль изменён успешно"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr "Произошла ошибка при установке пароля базы. Операция отменена."
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr "Пароль установлен успешно"
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr "Произошла ошибка при удалении пароля базы. Операция отменена."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "Пароль удалён успешно."
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Сохранить Diffie-Hellman параметры"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Параметры Diffie-Hellman сохранены успешно"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "Выберите PEM файл для импорта"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Проблема при импорте файла '%s'"
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr "Выберите каталог для импорта"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-04-02 04:51+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -131,15 +131,15 @@ msgstr ""
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr ""
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr ""
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -147,7 +147,7 @@ msgstr ""
 msgid "%m/%d/%Y %R GMT"
 msgstr ""
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -155,28 +155,39 @@ msgstr ""
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr ""
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr ""
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr ""
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr ""
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr ""
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr ""
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -187,155 +198,159 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr ""
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr ""
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr ""
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr ""
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr ""
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 msgid "Export unencrypted private key"
 msgstr ""
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr ""
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
 msgstr ""
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
 msgstr ""
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
 "Request.</i>"
 msgstr ""
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr ""
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 msgid "Please select a certificate to export its chain."
 msgstr ""
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Vlastnosti žiadosti o vydanie certifikátu - gnoMint"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Pridať certifikát self-signed CA"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 msgid "Please select one or more certificates to revoke."
 msgstr ""
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Viditeľnosť žiadostí o certifikát"
 msgstr[1] "Viditeľnosť žiadostí o certifikát"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
 msgstr[0] "Pridať novú žiadosť o vydanie certifikátu"
 msgstr[1] "Pridať novú žiadosť o vydanie certifikátu"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -345,70 +360,70 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Viditeľnosť zrušených certifikátov"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Pridať certifikát self-signed CA"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr ""
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr ""
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -419,64 +434,64 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr ""
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr ""
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr ""
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr ""
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr ""
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr ""
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr ""
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr ""
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnomint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 14:20+0200\n"
+"POT-Creation-Date: 2026-05-24 14:26+0200\n"
 "PO-Revision-Date: 2010-07-09 11:48+0000\n"
 "Last-Translator: David Marín <Unknown>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -134,15 +134,15 @@ msgstr "Hantera X.509-certifikat och certifikatutfärdare, enkelt och grafiskt"
 msgid "certificate;x.509;encryption;"
 msgstr ""
 
-#: ../src/ca.c:305
+#: ../src/ca.c:316
 msgid "<b>Certificates</b>"
 msgstr "<b>Certifikat</b>"
 
-#: ../src/ca.c:460
+#: ../src/ca.c:485
 msgid "<b>Certificate Signing Requests</b>"
 msgstr "<b>Certifikatsigneringsbegäran</b>"
 
-#: ../src/ca.c:503 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
+#: ../src/ca.c:528 ../src/ca-cli-callbacks.c:174 ../src/ca-cli-callbacks.c:188
 #: ../src/ca-cli-callbacks.c:203 ../src/ca-cli-callbacks.c:716
 #: ../src/ca-cli-callbacks.c:725 ../src/ca-cli-callbacks.c:1345
 #: ../src/ca-cli-callbacks.c:1354 ../src/certificate_properties.c:178
@@ -150,7 +150,7 @@ msgstr "<b>Certifikatsigneringsbegäran</b>"
 msgid "%m/%d/%Y %R GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:506 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
+#: ../src/ca.c:531 ../src/ca-cli-callbacks.c:177 ../src/ca-cli-callbacks.c:191
 #: ../src/ca-cli-callbacks.c:206 ../src/ca-cli-callbacks.c:719
 #: ../src/ca-cli-callbacks.c:728 ../src/ca-cli-callbacks.c:1348
 #: ../src/ca-cli-callbacks.c:1357 ../src/certificate_properties.c:181
@@ -159,28 +159,39 @@ msgstr "%Y/%m/%d %R GMT"
 msgid "%m/%d/%Y %H:%M GMT"
 msgstr "%Y/%m/%d %R GMT"
 
-#: ../src/ca.c:657 ../src/certificate_properties.c:588 ../src/crl.c:184
+#: ../src/ca.c:682 ../src/certificate_properties.c:588 ../src/crl.c:184
 #: ../src/new_cert.c:198 ../src/new_req_window.c:192
 msgid "Subject"
 msgstr "Ämne"
 
-#: ../src/ca.c:693
+#: ../src/ca.c:718
 msgid "Serial"
 msgstr "Serienummer"
 
-#: ../src/ca.c:701
+#: ../src/ca.c:726
 msgid "Activation"
 msgstr "Aktivering"
 
-#: ../src/ca.c:711
+#: ../src/ca.c:736
 msgid "Expiration"
 msgstr "Utgång"
 
-#: ../src/ca.c:721
+#: ../src/ca.c:746
 msgid "Revocation"
 msgstr "Spärrning"
 
-#: ../src/ca.c:754
+#: ../src/ca.c:782
+#, c-format
+msgid ""
+"Showing only the <b>%d certificate</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgid_plural ""
+"Showing only the <b>%d certificates</b> expiring in the next %d days. Close "
+"this banner to show everything again."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/ca.c:793
 #, c-format
 msgid ""
 "<b>%d certificate</b> expires in the next %d days. Right-click it to renew "
@@ -191,64 +202,68 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1124
+#: ../src/ca.c:809
+msgid "_Show them"
+msgstr ""
+
+#: ../src/ca.c:1194
 msgid "Export certificate"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1127 ../src/ca.c:1134 ../src/ca.c:1236 ../src/ca.c:1287
-#: ../src/ca.c:1338 ../src/ca.c:1528 ../src/ca.c:1939 ../src/ca.c:2647
-#: ../src/ca.c:2753 ../src/ca.c:2787 ../src/crl.c:257 ../src/main.c:330
+#: ../src/ca.c:1197 ../src/ca.c:1204 ../src/ca.c:1306 ../src/ca.c:1357
+#: ../src/ca.c:1408 ../src/ca.c:1598 ../src/ca.c:2009 ../src/ca.c:2718
+#: ../src/ca.c:2824 ../src/ca.c:2858 ../src/crl.c:257 ../src/main.c:330
 #: ../src/main.c:402 ../src/main.c:490
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ca.c:1128 ../src/ca.c:1135 ../src/ca.c:1237 ../src/ca.c:1288
-#: ../src/ca.c:1339 ../src/ca.c:1529 ../src/ca.c:2648 ../src/crl.c:258
+#: ../src/ca.c:1198 ../src/ca.c:1205 ../src/ca.c:1307 ../src/ca.c:1358
+#: ../src/ca.c:1409 ../src/ca.c:1599 ../src/ca.c:2719 ../src/crl.c:258
 msgid "_Save"
 msgstr ""
 
-#: ../src/ca.c:1131
+#: ../src/ca.c:1201
 msgid "Export certificate signing request"
 msgstr "Exportera certificate signing request"
 
-#: ../src/ca.c:1146 ../src/ca.c:1182 ../src/ca.c:1192 ../src/export.c:278
+#: ../src/ca.c:1216 ../src/ca.c:1252 ../src/ca.c:1262 ../src/export.c:278
 msgid "There was an error while exporting certificate."
 msgstr "Det inträffade ett fel då certifikatet skulle exporteras."
 
-#: ../src/ca.c:1148 ../src/ca.c:1184 ../src/ca.c:1194
+#: ../src/ca.c:1218 ../src/ca.c:1254 ../src/ca.c:1264
 msgid "There was an error while exporting CSR."
 msgstr "Det inträffade ett fel då CSR skulle exporteras."
 
-#: ../src/ca.c:1207 ../src/ca.c:1373
+#: ../src/ca.c:1277 ../src/ca.c:1443
 msgid "Certificate exported successfully"
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1214
+#: ../src/ca.c:1284
 msgid "Certificate signing request exported successfully"
 msgstr ""
 
-#: ../src/ca.c:1233
+#: ../src/ca.c:1303
 msgid "Export crypted private key"
 msgstr "Exportera krypterad privat nyckel"
 
-#: ../src/ca.c:1262 ../src/ca.c:1314
+#: ../src/ca.c:1332 ../src/ca.c:1384
 msgid "Private key exported successfully"
 msgstr "Privat nyckel exporterades"
 
-#: ../src/ca.c:1284
+#: ../src/ca.c:1354
 #, fuzzy
 msgid "Export unencrypted private key"
 msgstr "Exportera okrypterad privat nyckel"
 
-#: ../src/ca.c:1335
+#: ../src/ca.c:1405
 msgid "Export whole certificate in PKCS#12 package"
 msgstr "Exportera helt certifikat i PKCS#12-paket"
 
-#: ../src/ca.c:1406
+#: ../src/ca.c:1476
 msgid "Export CSR - gnoMint"
 msgstr "Exportera CSR - gnoMint"
 
-#: ../src/ca.c:1411
+#: ../src/ca.c:1481
 msgid ""
 "Please, choose which part of the saved Certificate Signing Request you want "
 "to export:"
@@ -256,7 +271,7 @@ msgstr ""
 "Vänligen välj vilken del av den sparade Certificate Signing Request du vill "
 "exportera:"
 
-#: ../src/ca.c:1416
+#: ../src/ca.c:1486
 msgid ""
 "<i>Export the Certificate Signing Request to a public file, in PEM format.</"
 "i>"
@@ -264,7 +279,7 @@ msgstr ""
 "<i>Exportera Certificate Signing Request till en publik fil, i PEM-format.</"
 "i>"
 
-#: ../src/ca.c:1421
+#: ../src/ca.c:1491
 msgid ""
 "<i>Export the saved private key to a PKCS#8 password-protected file. This "
 "file should only be accessed by the subject of the Certificate Signing "
@@ -274,70 +289,70 @@ msgstr ""
 "fil. Filen bör endast kunna kommas åt av den till vilken Certificate Signing "
 "Request är utfärdat.</i>"
 
-#: ../src/ca.c:1485
+#: ../src/ca.c:1555
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: ../src/ca.c:1500
+#: ../src/ca.c:1570
 #, fuzzy
 msgid "Please select a certificate to export its chain."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1526
+#: ../src/ca.c:1596
 #, fuzzy
 msgid "Export certificate chain"
 msgstr "Exportera certifikat"
 
-#: ../src/ca.c:1549
+#: ../src/ca.c:1619
 msgid "Could not build certificate chain."
 msgstr ""
 
-#: ../src/ca.c:1557
+#: ../src/ca.c:1627
 #, fuzzy, c-format
 msgid "Failed to write chain: %s"
 msgstr "Lägg till ett autosignerat CA-certifikat"
 
-#: ../src/ca.c:1565
+#: ../src/ca.c:1635
 #, fuzzy
 msgid "Certificate chain exported successfully."
 msgstr "Certifikatet exporterades"
 
-#: ../src/ca.c:1633
+#: ../src/ca.c:1703
 #, fuzzy
 msgid "Please select one or more certificates to revoke."
 msgstr "Återkallar det valda certifikatet"
 
-#: ../src/ca.c:1639
+#: ../src/ca.c:1709
 #, fuzzy, c-format
 msgid "Are you sure you want to revoke %d certificate?"
 msgid_plural "Are you sure you want to revoke %d certificates?"
 msgstr[0] "Är du säker på att du vill spärra detta certifikat?"
 msgstr[1] "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1646
+#: ../src/ca.c:1716
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. CSRs in the selection (if any) are not affected; use \"Delete "
 "selected CSRs\" for those."
 msgstr ""
 
-#: ../src/ca.c:1664
+#: ../src/ca.c:1734
 #, c-format
 msgid "Bulk revoke completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1668
+#: ../src/ca.c:1738
 #, fuzzy, c-format
 msgid "%d certificate revoked."
 msgid_plural "%d certificates revoked."
 msgstr[0] "Exportera certifikat"
 msgstr[1] "Exportera certifikat"
 
-#: ../src/ca.c:1692
+#: ../src/ca.c:1762
 msgid "Please select one or more CSRs to delete."
 msgstr ""
 
-#: ../src/ca.c:1698
+#: ../src/ca.c:1768
 #, fuzzy, c-format
 msgid "Are you sure you want to delete %d Certificate Signing Request?"
 msgid_plural "Are you sure you want to delete %d Certificate Signing Requests?"
@@ -346,12 +361,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:1719
+#: ../src/ca.c:1789
 #, c-format
 msgid "Bulk delete completed with errors. First error: %s"
 msgstr ""
 
-#: ../src/ca.c:1782
+#: ../src/ca.c:1852
 msgid ""
 "<b>Renew this certificate?</b>\n"
 "\n"
@@ -361,71 +376,71 @@ msgid ""
 "have deployed the new one."
 msgstr ""
 
-#: ../src/ca.c:1800
+#: ../src/ca.c:1870
 msgid ""
 "Certificate renewed. A new certificate with a fresh keypair has been added "
 "to the database alongside the original."
 msgstr ""
 
-#: ../src/ca.c:1820
+#: ../src/ca.c:1890
 #, c-format
 msgid "Certificate diff — %d difference"
 msgid_plural "Certificate diff — %d differences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ca.c:1827
+#: ../src/ca.c:1897
 msgid "_Close"
 msgstr ""
 
-#: ../src/ca.c:1849
+#: ../src/ca.c:1919
 msgid "Left"
 msgstr ""
 
-#: ../src/ca.c:1853
+#: ../src/ca.c:1923
 msgid "Right"
 msgstr ""
 
-#: ../src/ca.c:1929
+#: ../src/ca.c:1999
 #, fuzzy
 msgid "Cannot read PEM of the selected certificate."
 msgstr "Återkalla det valda certifikatet"
 
-#: ../src/ca.c:1936
+#: ../src/ca.c:2006
 msgid "Compare with PEM file…"
 msgstr ""
 
-#: ../src/ca.c:1940 ../src/ca.c:2754 ../src/ca.c:2788 ../src/main.c:331
+#: ../src/ca.c:2010 ../src/ca.c:2825 ../src/ca.c:2859 ../src/main.c:331
 #: ../src/main.c:403 ../src/main.c:491
 msgid "_Open"
 msgstr ""
 
-#: ../src/ca.c:1954 ../src/ca-cli-callbacks.c:2120
+#: ../src/ca.c:2024 ../src/ca-cli-callbacks.c:2120
 #, fuzzy
 msgid "Cannot read file."
 msgstr "Lägg till ett autosignerat CA-certifikat"
 
-#: ../src/ca.c:1961
+#: ../src/ca.c:2031
 msgid "Selected"
 msgstr ""
 
-#: ../src/ca.c:1997
+#: ../src/ca.c:2067
 msgid "Are you sure you want to revoke this certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:1998
+#: ../src/ca.c:2068
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
 "as the CRL is checked)."
 msgstr ""
 
-#: ../src/ca.c:2006
+#: ../src/ca.c:2076
 #, fuzzy
 msgid "Are you sure you want to revoke this CA certificate?"
 msgstr "Är du säker på att du vill spärra detta certifikat?"
 
-#: ../src/ca.c:2007
+#: ../src/ca.c:2077
 msgid ""
 "Revoking a certificate will include it in the next CRL, marking it as "
 "invalid. This way, any future use of the certificate will be denied (as long "
@@ -436,68 +451,68 @@ msgid ""
 "certificate."
 msgstr ""
 
-#: ../src/ca.c:2050
+#: ../src/ca.c:2120
 msgid "Are you sure you want to delete this Certificate Signing Request?"
 msgstr "Är du säker på att du vill ta bort denna certifikatsigneringsbegäran?"
 
-#: ../src/ca.c:2425
+#: ../src/ca.c:2496
 msgid "Change CA password - gnoMint"
 msgstr "Ändra CA-lösenord - gnoMint"
 
-#: ../src/ca.c:2443
+#: ../src/ca.c:2514
 msgid ""
 "The current password you have entered  doesn't match with the actual current "
 "database password."
 msgstr ""
 "Det lösenord Du skrivit in är inte det som behövs för den valda databasen."
 
-#: ../src/ca.c:2458
+#: ../src/ca.c:2529
 msgid "Error while changing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle bytas. Operationen avbröts."
 
-#: ../src/ca.c:2467
+#: ../src/ca.c:2538
 msgid "Password changed successfully"
 msgstr "Lösenordet ändrades utan problem"
 
-#: ../src/ca.c:2477 ../src/ca-cli-callbacks.c:1178
+#: ../src/ca.c:2548 ../src/ca-cli-callbacks.c:1178
 msgid ""
 "Error while establishing database password. The operation was cancelled."
 msgstr ""
 
-#: ../src/ca.c:2487
+#: ../src/ca.c:2558
 msgid "Password established successfully"
 msgstr ""
 
-#: ../src/ca.c:2497
+#: ../src/ca.c:2568
 msgid "Error while removing database password. The operation was cancelled."
 msgstr ""
 "Ett fel inträffade då databasens lösenord skulle tas bort. Operationen "
 "avbröts."
 
-#: ../src/ca.c:2506
+#: ../src/ca.c:2577
 msgid "Password removed successfully"
 msgstr "Lösenordet togs bort"
 
-#: ../src/ca.c:2644
+#: ../src/ca.c:2715
 msgid "Save Diffie-Hellman parameters"
 msgstr "Spara Diffie-Hellman-parametrar"
 
-#: ../src/ca.c:2670
+#: ../src/ca.c:2741
 msgid "Diffie-Hellman parameters saved successfully"
 msgstr "Diffie-Hellman-parametrar sparades"
 
 #. Import single file
-#: ../src/ca.c:2750
+#: ../src/ca.c:2821
 msgid "Select PEM file to import"
 msgstr "Välj PEM-fil att importera"
 
-#: ../src/ca.c:2771
+#: ../src/ca.c:2842
 #, c-format
 msgid "Problem when importing '%s' file"
 msgstr "Ett problem inträffade vid importerandet av filen '%s'"
 
-#: ../src/ca.c:2784
+#: ../src/ca.c:2855
 msgid "Select directory to import"
 msgstr "Välj katalog att importera"
 

--- a/src/ca.c
+++ b/src/ca.c
@@ -151,6 +151,17 @@ static gint ca_expiring_soon_count = 0;
  * we don't show it again until the user re-opens the file. */
 static gboolean ca_expiry_infobar_dismissed = FALSE;
 
+/* "Show only expiring" filter mode (#56): when TRUE, the row-add
+ * function skips any non-amber leaf row. CAs are always shown so the
+ * tree hierarchy stays intact. Activated by the banner's "Show them"
+ * action button; reset when the banner is dismissed or a new file is
+ * opened. Non-static so the test scenario can flip it directly. */
+gboolean ca_view_only_expiring = FALSE;
+
+/* Custom GtkInfoBar response id for the banner's "Show them" button.
+ * Chosen well outside the GtkResponseType range so it can't collide. */
+#define CA_BANNER_RESPONSE_SHOW_THEM 100
+
 /* Active search text for the filter box (#53). When non-empty, leaf
  * certificates whose subject/serial doesn't contain this substring
  * (case-insensitive) are hidden from the tree. Owned by ca.c; freed
@@ -385,8 +396,22 @@ int __ca_refresh_model_add_certificate (void *pArg, int argc, char **argv, char 
 	    preferences_get_expire_warning_days ());
 
 	/* Count amber rows so we can drive the expiry banner (#56). */
-	if (row_foreground && g_strcmp0 (row_foreground, "#cc7700") == 0)
+	gboolean is_amber = (row_foreground &&
+	                     g_strcmp0 (row_foreground, "#cc7700") == 0);
+	if (is_amber)
 		ca_expiring_soon_count++;
+
+	/* "Show only expiring" mode (#56 "Show them"): hide non-amber
+	 * leaves. CAs are always shown so the tree path to an amber
+	 * leaf stays visible. */
+	if (ca_view_only_expiring &&
+	    argv[CA_FILE_CERT_COLUMN_IS_CA] &&
+	    atoi (argv[CA_FILE_CERT_COLUMN_IS_CA]) == 0 &&
+	    !is_amber) {
+		if (last_id_value) g_free (last_id_value);
+		if (last_parent_route_value) g_free (last_parent_route_value);
+		return 0;
+	}
 
         if (! argv[CA_FILE_CERT_COLUMN_REVOCATION])
                 gtk_tree_store_set (new_model, &iter,
@@ -750,15 +775,47 @@ gboolean ca_refresh_model_callback ()
 
 		if (bar && lbl && ca_expiring_soon_count > 0 &&
 		    !ca_expiry_infobar_dismissed && days > 0) {
-			gchar *msg = g_strdup_printf (
-			    ngettext ("<b>%d certificate</b> expires in the next %d days. "
-			              "Right-click it to renew with a fresh key.",
-			              "<b>%d certificates</b> expire in the next %d days. "
-			              "Right-click each one to renew with a fresh key.",
-			              ca_expiring_soon_count),
-			    ca_expiring_soon_count, days);
+			gchar *msg;
+			if (ca_view_only_expiring) {
+				msg = g_strdup_printf (
+				    ngettext (
+				        "Showing only the <b>%d certificate</b> expiring "
+				        "in the next %d days. Close this banner to show "
+				        "everything again.",
+				        "Showing only the <b>%d certificates</b> expiring "
+				        "in the next %d days. Close this banner to show "
+				        "everything again.",
+				        ca_expiring_soon_count),
+				    ca_expiring_soon_count, days);
+			} else {
+				msg = g_strdup_printf (
+				    ngettext (
+				        "<b>%d certificate</b> expires in the next %d days. "
+				        "Right-click it to renew with a fresh key.",
+				        "<b>%d certificates</b> expire in the next %d days. "
+				        "Right-click each one to renew with a fresh key.",
+				        ca_expiring_soon_count),
+				    ca_expiring_soon_count, days);
+			}
 			gtk_label_set_markup (lbl, msg);
 			g_free (msg);
+
+			/* Add the "Show them" action button on first show. The
+			 * GtkInfoBar widget itself owns the button once added; we
+			 * don't want to add it again on every refresh, so we
+			 * stash a flag on the widget. */
+			if (!g_object_get_data (G_OBJECT (bar), "show-them-added")) {
+				gtk_info_bar_add_button (GTK_INFO_BAR (bar),
+				                         _("_Show them"),
+				                         CA_BANNER_RESPONSE_SHOW_THEM);
+				g_object_set_data (G_OBJECT (bar), "show-them-added",
+				                   GINT_TO_POINTER (1));
+			}
+			/* Don't offer "Show them" if we're already in that mode. */
+			GtkWidget *button = gtk_info_bar_get_action_area (GTK_INFO_BAR (bar));
+			if (button) {
+				gtk_widget_set_sensitive (button, !ca_view_only_expiring);
+			}
 			gtk_widget_show (bar);
 		} else if (bar) {
 			gtk_widget_hide (bar);
@@ -809,8 +866,21 @@ ca_expiry_infobar_response (GtkInfoBar *bar,
                             gint        response,
                             gpointer    user_data G_GNUC_UNUSED)
 {
+	if (response == CA_BANNER_RESPONSE_SHOW_THEM) {
+		/* Enter "show only expiring" filter mode and refresh. The
+		 * banner stays visible (text changes to reflect the mode);
+		 * closing it both clears the filter and dismisses the banner. */
+		ca_view_only_expiring = TRUE;
+		ca_refresh_model_callback ();
+		return;
+	}
 	if (response == GTK_RESPONSE_CLOSE || response == -7 /* close button */) {
 		ca_expiry_infobar_dismissed = TRUE;
+		if (ca_view_only_expiring) {
+			/* Restore the full view too. */
+			ca_view_only_expiring = FALSE;
+			ca_refresh_model_callback ();
+		}
 		gtk_widget_hide (GTK_WIDGET (bar));
 	}
 }
@@ -2100,6 +2170,7 @@ gboolean ca_open (gchar *filename, gboolean create)
 
 	/* Re-arm the expiry banner for the freshly-opened file. */
 	ca_expiry_infobar_dismissed = FALSE;
+	ca_view_only_expiring = FALSE;
 
 	/* Reset the search filter so the new DB starts with everything
 	 * visible — both internally and in the entry widget. */

--- a/tests/check_workflows.c
+++ b/tests/check_workflows.c
@@ -1759,6 +1759,31 @@ scenario_expiry_banner (void)
     }
     fprintf (stderr, "    no-amber state: banner hidden OK\n");
 
+    /* "Show them" response handler (#56 follow-up): exercise the
+     * response handler directly. CA_BANNER_RESPONSE_SHOW_THEM == 100
+     * (defined in src/ca.c). After firing the response, the global
+     * ca_view_only_expiring should be TRUE. After firing the CLOSE
+     * response, it should be FALSE again. */
+    extern gboolean ca_view_only_expiring;
+    extern void ca_expiry_infobar_response (GtkInfoBar *bar, gint resp,
+                                            gpointer user_data);
+    ca_view_only_expiring = FALSE;
+    ca_expiry_infobar_response (GTK_INFO_BAR (bar), 100, NULL);
+    if (!ca_view_only_expiring) {
+        fail_test ("expiry-banner",
+                   "Show-them response didn't set ca_view_only_expiring");
+        goto out;
+    }
+    fprintf (stderr, "    Show-them response → only-expiring mode OK\n");
+
+    ca_expiry_infobar_response (GTK_INFO_BAR (bar), GTK_RESPONSE_CLOSE, NULL);
+    if (ca_view_only_expiring) {
+        fail_test ("expiry-banner",
+                   "Close response didn't clear ca_view_only_expiring");
+        goto out;
+    }
+    fprintf (stderr, "    Close response → only-expiring cleared OK\n");
+
     rc = 0;
 
 out:


### PR DESCRIPTION
## Summary
PR #65 shipped the expiry banner's count + display, but issue #56 also asks for a **"Show them"** action that filters the tree to *only* the expiring certs. This PR adds that.

## What changed
- **\`gtk_info_bar_add_button\`** at runtime adds a "_Show them" action button (response id \`100\`) the first time the banner shows. Idempotent.
- **New flag \`ca_view_only_expiring\`** — when TRUE, the row-add function in \`ca_refresh_model_callback\` skips any non-CA leaf that isn't amber. CAs are always shown so the path to each amber leaf stays visible.
- **Response handler** now branches on the new id: "Show them" → flip flag + refresh; CLOSE → clear flag + restore full view + dismiss banner.
- **Banner text adapts** — the mode-active text reads *"Showing only the N certificates expiring in the next D days. Close this banner to show everything again."* — a clear path back. The button is greyed out once already in the mode.
- **\`ca_open\`** clears the flag so a new file starts clean.

## Test plan
- [x] \`make\` clean
- [x] \`make -C tests check\` — 14 of 14 PASS. \`scenario_expiry_banner\` now asserts:
  - banner hidden when no amber rows
  - firing response 100 sets \`ca_view_only_expiring\`
  - firing CLOSE clears it

## Closes
- #56