### PR TITLE
Release gnoMint 1.5.0 "Belt and Braces"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,109 @@
+* Version 1.5.0 "Belt and Braces" (2026.05.24)
+
+Six weeks after Lazarus, gnoMint 1.5.0 closes the running-a-CA-over-
+years loop (warning → filter → renew → diff) and finishes pulling the
+gnomint-cli interface to parity with the GUI. Every state-mutating
+command in ca_commands[] now has shell-test coverage; the test suite
+went from 5 suites to 14, all green.
+
+- FEATURE: ECDSA and Ed25519 key support (#49). New ECDSA generator
+  selects between NIST P-256, P-384 and P-521 from key_bitlength;
+  new Ed25519 generator ignores key length (fixed by the curve).
+  Both algorithms are available from the New-CA wizard, the New-CSR
+  wizard, and gnomint-cli's addca/addcsr prompts.
+
+- FEATURE: Algorithm-aware key-size selector. The bit-length input
+  in the New-CA and New-CSR wizards swaps to match the chosen
+  algorithm: spinbutton for RSA/DSA, P-256/P-384/P-521 dropdown for
+  ECDSA, hidden entirely for Ed25519 (curve size is fixed). The CLI
+  prompts do the same.
+
+- FEATURE: Certificate renewal (#50). Right-click → "Renew with
+  fresh key" reissues a certificate with the same subject and SAN,
+  signed by the same CA, with a freshly-generated keypair. The old
+  cert stays in the database — standard "issue new, deploy, revoke
+  old" pattern. CLI verb: renewcert <cert-id>.
+
+- FEATURE: Search / filter box (#53). A GtkSearchEntry above the
+  tree view filters certificates and CSRs as you type, matching on
+  subject or serial substring (case-insensitive). Ctrl+F focuses
+  the entry. CAs are always shown so the tree path to each match
+  stays visible. CLI verb: search <pattern>.
+
+- FEATURE: Side-by-side certificate diff (#55). Right-click a cert →
+  "Compare with PEM file…" opens a 3-column dialog (field, left,
+  right) showing every X.509 property; differing rows are
+  highlighted in amber. CLI verb: diff <cert-id-or-path>
+  <cert-id-or-path> (either argument can be a DB id or a path to a
+  PEM file).
+
+- FEATURE: Startup expiry banner (#56). Opening a database surfaces
+  a GtkInfoBar above the tree counting any certificates whose
+  effective expiration is inside the warning window (default 30
+  days, configurable via expire-warning-days). The banner's "Show
+  them" action filters the tree to only the expiring rows; closing
+  the banner restores the full view. gnomint-cli prints the same
+  notice on stderr at startup.
+
+- FEATURE: Editable SAN list when signing a CSR (#40). The sign-CSR
+  dialog now embeds the full SAN manager widget, pre-populated from
+  the CSR's request. A CA operator can add, remove, or override SAN
+  entries before signing — restoring the authority a CA is supposed
+  to have.
+
+- FEATURE: GitHub Pages site under docs/. A new Jekyll site (landing
+  page, features overview, install guide, task-oriented user manual,
+  tutorial, release history) lives in the docs/ tree and is served
+  from https://davefx.github.io/gnoMint/ once Pages is enabled in
+  repo settings. The same content is browsable offline as Markdown.
+
+- FEATURE: Full user manual (#57). docs/manual.md covers every
+  workflow: quick start, concepts, bootstrapping a CA, issuing
+  certificates, wizards, importing CSRs, renewing/revoking/CRLs,
+  exporting, bulk operations, search/filter, comparing certificates,
+  expiry warnings, importing OpenSSL CA layouts, the CLI, and a
+  troubleshooting section.
+
+- FEATURE: CLI parity pass. gnomint-cli gained renewcert, exportchain,
+  revokemany, deletemany, search, diff, and the per-algorithm prompt
+  flow. Every GUI menu entry now has a matching CLI verb. The CLI
+  also prints the expiry-window notice on database open.
+
+- FEATURE: Comprehensive CLI test coverage. Every state-mutating
+  command in ca_commands[] is now tested by at least one shell or
+  python-pty script. New test files: check_cli_info.sh,
+  check_cli_lifecycle.sh, check_cli_keys.sh, check_cli_banner.sh,
+  check_cli_import.sh, check_cli_importdir.sh, check_cli_dhgen.sh,
+  check_cli_passphrase.py. The pty-driven script in particular
+  exercises extractcertpkey, extractcsrpkey, and changepassword
+  end-to-end — the commands that read passphrases via getpass().
+
+- BUGFIX: ECDSA prompt no longer aborts. addca and addcsr pre-set
+  key_bitlength to 2048 before the algorithm prompt, then the ECDSA
+  branch called dialog_ask_for_number(min=256, max=521, default=2048)
+  and tripped an assertion. The default is now clamped to a valid
+  curve size before the prompt fires.
+
+- BUGFIX: gnomint-cli importfile no longer segfaults. The shared
+  import path called dialog_refresh_list() on success;
+  dialog_refresh_list() dereferenced a NULL function pointer because
+  the CLI never registers a refresh callback (the GUI does).
+  Added a null check.
+
+- BUGFIX: Copyright bumped from 2006-2016 to 2006-2026 and dead
+  sourceforge URLs replaced with GitHub repo links throughout. The
+  legacy gnomint.sourceforge.net site is gone; its content has been
+  archived into docs/.
+
+- POLISH: GTK 3 screenshots throughout the docs site, captured live
+  from the build (main window with a sample CA hierarchy, all four
+  key-algorithm wizard states, the new-CA / new-CSR / export / import
+  / preferences dialogs).
+
+This release is database-compatible with 1.4.0 — no migration step
+needed.
+
+
 * Version 1.4.0 "Lazarus" (2026.05.19)
 
 After a decade-long hiatus since 1.3.0, gnoMint returns. This

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.69])
 
-AC_INIT([gnoMint],[1.4.0],[<davefx@gmail.com>],[gnomint])
+AC_INIT([gnoMint],[1.5.0],[<davefx@gmail.com>],[gnomint])
 
 PACKAGE_COPYRIGHT="(c) 2006-2026 David Marín Carreño <davefx@gmail.com>"
 PACKAGE_WEBSITE="https://github.com/davefx/gnoMint"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -15,6 +15,51 @@ file.
 
 ---
 
+## 1.5.0 — "Belt and Braces" (2026-05-24)
+
+Six weeks after Lazarus. Closes the running-a-CA-over-years loop
+(warning → filter → renew → diff) and brings `gnomint-cli` to full
+parity with the GUI. Every state-mutating CLI command is now covered
+by an automated test.
+
+Highlights:
+
+- **ECDSA / Ed25519 key support** ([#49](https://github.com/davefx/gnoMint/issues/49))
+  in both wizards and the CLI prompts.
+- **Algorithm-aware key-size selector** — spinbutton for RSA/DSA,
+  curve dropdown for ECDSA, hidden for Ed25519.
+- **Certificate renewal** ([#50](https://github.com/davefx/gnoMint/issues/50)):
+  right-click → *Renew with fresh key*. CLI: `renewcert <id>`.
+- **Search / filter box** ([#53](https://github.com/davefx/gnoMint/issues/53))
+  above the tree view; Ctrl+F focuses it. CLI: `search <pattern>`.
+- **Side-by-side certificate diff** ([#55](https://github.com/davefx/gnoMint/issues/55)):
+  right-click → *Compare with PEM file…*. CLI: `diff <id|path> <id|path>`.
+- **Startup expiry banner** ([#56](https://github.com/davefx/gnoMint/issues/56))
+  with a *Show them* action that filters the tree to the expiring
+  certs. CLI: stderr notice on `ca_open`.
+- **Editable SAN list when signing a CSR** ([#40](https://github.com/davefx/gnoMint/issues/40)):
+  the sign-CSR dialog now embeds the full SAN editor.
+- **GitHub Pages site** under `docs/` — landing, features, install,
+  manual, tutorial, release history, all with current GTK 3
+  screenshots.
+- **Full user manual** ([#57](https://github.com/davefx/gnoMint/issues/57))
+  covering every workflow, the CLI, and a troubleshooting section.
+- **CLI parity**: `renewcert`, `exportchain`, `revokemany`,
+  `deletemany`, `search`, `diff` all available from `gnomint-cli`.
+- **Comprehensive test coverage**: 5 suites → 14 suites, all green.
+  pty-driven Python script for the getpass-using commands
+  (`extractcertpkey`, `extractcsrpkey`, `changepassword`).
+
+Bug fixes:
+
+- ECDSA prompt no longer asserts in `addca`/`addcsr`.
+- `gnomint-cli importfile` no longer segfaults.
+- Copyright updated to 2006-2026; dead sourceforge URLs replaced.
+
+Database-compatible with 1.4.0 — no migration needed.
+
+---
+
 ## 1.4.0 — "Lazarus" (2026-05-19)
 
 After a decade-long hiatus since 1.3.0, gnoMint returns. This release

--- a/gui/gnomint.appdata.xml.in
+++ b/gui/gnomint.appdata.xml.in
@@ -53,6 +53,7 @@
   
   <!-- Update this section with each new release -->
   <releases>
+    <release version="1.5.0" date="2026-05-24"/>
     <release version="1.4.0" date="2026-05-19"/>
     <release version="1.3.0" date="2016-01-01"/>
   </releases>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -28,6 +28,8 @@ gui/san_manager_widget.ui
 gui/wizard_window.ui
 mime/gnomint.xml.in
 src/ca.c
+src/cert_diff.c
+src/cert_renewal.c
 src/ca-cli.c
 src/ca-cli-callbacks.c
 src/ca_creation.c

--- a/tests/check_cli_parity.sh
+++ b/tests/check_cli_parity.sh
@@ -23,7 +23,13 @@ trap 'rm -rf "$TMPDIR"' EXIT
 DB="$TMPDIR/cli-parity.gnomint"
 CHAIN="$TMPDIR/chain.pem"
 
+# Force a writable copy. Under `make distcheck` the dist tarball ships
+# the fixture mode 0444 (autotools convention); plain cp inherits that
+# mode, and gnomint-cli's first-open migration silently fails on the
+# read-only DB so subsequent commands abort with "Cannot find last
+# assigned serial number".
 cp "$FIXTURE" "$DB"
+chmod 644 "$DB"
 
 LC_ALL=C "$CLI" "$DB" >"$TMPDIR/out.txt" 2>&1 <<EOF
 renewcert 2


### PR DESCRIPTION
## Summary

- Bump version to 1.5.0 in `configure.ac`
- Full NEWS entry covering all features, bug fixes, and polish since 1.4.0
- AppData release tag for 1.5.0
- `docs/releases.md` entry with highlights and bug fix list
- Fix two `make distcheck` issues: add `cert_diff.c` and `cert_renewal.c` to `po/POTFILES.in`, chmod 644 fixture DB in `check_cli_parity.sh`

`make distcheck` passes: `gnomint-1.5.0 archives ready for distribution`.

## Test plan

- [x] `make distcheck` passed
- [x] 14/14 test suites green
- [x] Tarball built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)