### PR TITLE
Add Flatpak packaging and update install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -21,8 +21,26 @@ sudo apt install gnomint
 sudo dnf install gnomint
 ```
 
-For the latest release (1.4.0 "Lazarus" and newer), you'll likely want
-to build from source.
+For the latest release (1.5.0 "Belt and Braces" and newer), you'll
+likely want to install via Flatpak or build from source.
+
+---
+
+## Flatpak
+
+The easiest way to run the latest gnoMint on any Linux distribution:
+
+```bash
+# Build and install from the repo manifest
+flatpak-builder --install --user build-flatpak \
+    net.sourceforge.gnomint.yml
+
+# Run
+flatpak run net.sourceforge.gnomint
+```
+
+The Flatpak bundles GnuTLS, libgcrypt, and all other dependencies
+inside the sandbox. It uses the GNOME 48 runtime for GTK 4.
 
 ---
 
@@ -32,13 +50,12 @@ to build from source.
 
 gnoMint links against:
 
-- **GTK 3** (≥ 3.18)
-- **GLib / GIO** (≥ 2.40)
-- **GnuTLS** (≥ 3.4)
+- **GTK 4** (≥ 4.6)
+- **GLib / GIO** (≥ 2.66)
+- **GnuTLS** (≥ 2.0; ≥ 2.7.4 for advanced features)
 - **libgcrypt**
 - **SQLite 3**
 - **GNU readline** (for `gnomint-cli`)
-- **gdk-pixbuf 2**
 
 Build-time tools:
 
@@ -51,8 +68,8 @@ On Debian/Ubuntu the full set installs with:
 ```bash
 sudo apt install \
     build-essential autoconf automake libtool intltool pkg-config \
-    libgtk-3-dev libglib2.0-dev libgnutls28-dev libgcrypt20-dev \
-    libsqlite3-dev libreadline-dev libgdk-pixbuf2.0-dev
+    libgtk-4-dev libglib2.0-dev libgnutls28-dev libgcrypt20-dev \
+    libsqlite3-dev libreadline-dev
 ```
 
 The same package list is used by gnoMint's CI workflow, so it stays in
@@ -73,7 +90,7 @@ From a release tarball, skip `autogen.sh` and start at `./configure`.
 
 The build produces two binaries:
 
-- `gnomint`     — the GTK 3 desktop application
+- `gnomint`     — the GTK 4 desktop application
 - `gnomint-cli` — the readline command-line interface
 
 Both are installed into `$prefix/bin` (default `/usr/local/bin`). UI
@@ -113,6 +130,6 @@ If `./configure` or `make` fails, please file a bug at
 including:
 
 - distribution + version (`lsb_release -a` or contents of `/etc/os-release`)
-- output of `pkg-config --modversion gtk+-3.0 gnutls glib-2.0 sqlite3`
+- output of `pkg-config --modversion gtk4 gnutls glib-2.0 sqlite3`
 - the failing line from `./configure` (or `config.log` if it bailed out)
 - the gnoMint version (release tarball name or `git describe`)

--- a/net.sourceforge.gnomint.yml
+++ b/net.sourceforge.gnomint.yml
@@ -69,6 +69,10 @@ modules:
     buildsystem: autotools
     post-install:
       - glib-compile-schemas /app/share/glib-2.0/schemas/
+      - mv /app/share/applications/gnomint.desktop /app/share/applications/net.sourceforge.gnomint.desktop || true
+      - mv /app/share/appdata/gnomint.appdata.xml /app/share/appdata/net.sourceforge.gnomint.appdata.xml || true
+      - mkdir -p /app/share/metainfo && cp /app/share/appdata/net.sourceforge.gnomint.appdata.xml /app/share/metainfo/ || true
+      - mv /app/share/mime/packages/gnomint.xml /app/share/mime/packages/net.sourceforge.gnomint.xml || true
     sources:
       - type: git
         url: https://github.com/davefx/gnoMint.git

--- a/net.sourceforge.gnomint.yml
+++ b/net.sourceforge.gnomint.yml
@@ -1,0 +1,75 @@
+app-id: net.sourceforge.gnomint
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: gnomint
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=home
+  - --metadata=X-DConf=migrate-path=/org/gnome/gnomint/
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/man
+  - /share/info
+  - /share/gtk-doc
+  - '*.la'
+  - '*.a'
+
+modules:
+  - name: libgpg-error
+    buildsystem: autotools
+    config-opts:
+      - --disable-doc
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.51.tar.bz2
+        sha256: be0f1b2db6b93eed55369cdf79f19f72750c8c7c39fc20b577e724545427e6b2
+
+  - name: libgcrypt
+    buildsystem: autotools
+    config-opts:
+      - --disable-doc
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.11.0.tar.bz2
+        sha256: 09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c
+
+  - name: gnutls
+    buildsystem: autotools
+    config-opts:
+      - --disable-doc
+      - --disable-static
+      - --disable-tests
+      - --disable-tools
+      - --disable-guile
+      - --with-included-libtasn1
+      - --with-included-unistring
+      - --without-p11-kit
+    sources:
+      - type: archive
+        url: https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.8.tar.xz
+        sha256: ac4f020e583880b51380ed226e59033244bc536cad2623f2e26f5afa2939d8fb
+
+  - name: intltool
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: gnomint
+    buildsystem: autotools
+    post-install:
+      - glib-compile-schemas /app/share/glib-2.0/schemas/
+    sources:
+      - type: git
+        url: https://github.com/davefx/gnoMint.git
+        branch: master


### PR DESCRIPTION
## Summary

- **Flatpak manifest** (`net.sourceforge.gnomint.yml`): targets GNOME 48 runtime, bundles libgpg-error + libgcrypt + GnuTLS + intltool as dependencies. Post-install renames desktop/appdata/mime files to use app-id prefix for proper Flatpak export.
- **Install docs** updated for GTK 4 (dependencies, package names, build instructions) with new Flatpak section.

Build tested locally with `flatpak-builder --disable-rofiles-fuse` — produces working `gnomint` and `gnomint-cli` binaries.

## Test plan

- [x] `flatpak-builder` completes successfully
- [x] Both `gnomint` and `gnomint-cli` present in `build-flatpak/files/bin/`
- [x] All dependencies (libgpg-error, libgcrypt, gnutls, intltool) build inside the sandbox
- [x] Cleanup removes headers and static libs

🤖 Generated with [Claude Code](https://claude.com/claude-code)