### PR TITLE
security: random serials, AES-256 key encryption, secret wiping

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,31 @@
+* Version 1.6.5 "Tempered Anvil" (unreleased)
+
+Security hardening.
+
+- SECURITY: Certificate serial numbers are now cryptographically random
+  (128 bits of CSPRNG entropy, per CA/Browser Forum Baseline Requirements
+  7.1) instead of a predictable sequential counter. Existing certificates
+  keep their serials, and no database migration is needed. Serials now
+  appear as longer random hex values (e.g. 40:A4:6A:...); the certificate's
+  list "Id" is a separate small number and is unaffected.
+
+- SECURITY: Private keys are now encrypted at rest with PBES2
+  (PBKDF2-SHA256 + AES-256-CBC) instead of the legacy PKCS#12 3DES. This is
+  backward compatible — keys written by older gnoMint versions still open,
+  because GnuTLS auto-detects the encryption scheme. Forward compatibility:
+  opening a new database's keys in another build requires GnuTLS 3.x (or
+  OpenSSL); every gnoMint of the last decade qualifies — Debian's gnomint
+  links GnuTLS >= 3.7.2.
+
+- SECURITY: Passwords are now wiped from memory with a non-elidable routine
+  instead of a memset() the compiler may optimise away.
+
+- Hardening: parameterised the remaining ca_policies name lookups, and
+  replaced a fixed-size sprintf with snprintf.
+
+Database-compatible with 1.4.0 — no migration needed.
+
+
 * Version 1.6.4 "Tempered Anvil" (2026.06.12)
 
 i386 / Year-2038 correctness.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,6 +118,7 @@ gnomint_cli_LDADD = \
 
 EXTRA_DIST = \
 	gnomint-upgrade-db \
+	secure_wipe.h \
 	ca_creation.h \
 	ca_file.h \
 	ca.h \

--- a/src/ca_file.c
+++ b/src/ca_file.c
@@ -1209,40 +1209,39 @@ gint ca_file_get_number_of_csrs ()
 
 void ca_file_get_next_serial (UInt160 *serial, guint64 ca_id)
 {
-	gchar *serialstr = NULL;
 	gchar **row = NULL;
+	gboolean check_dups = FALSE;
+	gboolean collision;
 
-	row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE name='ca_last_assigned_serial' AND ca_id=%"
-                                      GNOMINT_GUINT64_FORMAT";", ca_id);
-        if (row) {
-		uint160_read_escaped (serial, row[0], strlen (row[0]));
-		g_strfreev (row);
-	} else {
-		g_error (_("Cannot find last assigned serial number"));
-	}
-	
-
-        row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE "
+	/* Generate a cryptographically random serial (128 bits of CSPRNG entropy,
+	 * per CA/Browser Forum BR 7.1) instead of a predictable sequential
+	 * counter. The legacy 'ca_last_assigned_serial' policy row is left intact
+	 * for database backward-compatibility but is no longer used to derive new
+	 * serials — no schema change, and old databases open unchanged. */
+	row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE "
 				      "name='ca_must_check_serial_dups' AND ca_id=%"GNOMINT_GUINT64_FORMAT";",
                                       ca_id);
-        if (row) {
-                if (atoi(row[0])) {
-                        while (row) {
-                                uint160_inc (serial);
-                                g_strfreev (row);
-                                serialstr = uint160_strdup_printf (serial);
-                                row = __ca_file_get_single_row (ca_db, "SELECT id FROM certificates WHERE serial='%q' AND parent_id=%"GNOMINT_GUINT64_FORMAT";", 
-                                                              serialstr, ca_id);
-                                g_free (serialstr);                                
-                        }
-                } else {
-                        uint160_inc (serial);
-                        g_strfreev (row);
-                }
-        } else {
-                uint160_inc (serial);
-        }
+	if (row) {
+		check_dups = (atoi (row[0]) != 0);
+		g_strfreev (row);
+	}
 
+	do {
+		collision = FALSE;
+		tls_generate_random_serial (serial);
+
+		if (check_dups) {
+			gchar *serialstr = uint160_strdup_printf (serial);
+			gchar **dup = __ca_file_get_single_row (ca_db,
+			    "SELECT id FROM certificates WHERE serial='%q' AND parent_id=%"GNOMINT_GUINT64_FORMAT";",
+			    serialstr, ca_id);
+			g_free (serialstr);
+			if (dup) {
+				collision = TRUE;
+				g_strfreev (dup);
+			}
+		}
+	} while (collision);
 
 	return;
 }
@@ -2800,7 +2799,7 @@ gboolean ca_file_mark_pkey_as_extracted_for_id (CaFileElementType type, const gc
 
 gchar * ca_file_policy_get (guint64 ca_id, gchar *property_name)
 {
-	gchar **row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE name='%s' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
+	gchar **row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE name='%q' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
 					      property_name, ca_id);
 
 	gchar * res;
@@ -2822,7 +2821,7 @@ gboolean ca_file_policy_set (guint64 ca_id, gchar *property_name, const gchar * 
 	gchar *error = NULL;
 	gchar *sql = NULL;
 
-	aux = __ca_file_get_single_row (ca_db, "SELECT id, ca_id, name, value FROM ca_policies WHERE name='%s' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
+	aux = __ca_file_get_single_row (ca_db, "SELECT id, ca_id, name, value FROM ca_policies WHERE name='%q' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
 				      property_name, ca_id);
 
 	if (! aux) {
@@ -2835,7 +2834,7 @@ gboolean ca_file_policy_set (guint64 ca_id, gchar *property_name, const gchar * 
 		}
 	} else {
 		g_strfreev (aux);
-		sql = sqlite3_mprintf ("UPDATE ca_policies SET value='%q' WHERE ca_id=%"GNOMINT_GUINT64_FORMAT" AND name='%s';",
+		sql = sqlite3_mprintf ("UPDATE ca_policies SET value='%q' WHERE ca_id=%"GNOMINT_GUINT64_FORMAT" AND name='%q';",
 				       value, ca_id, property_name);
 		if (sqlite3_exec (ca_db, sql, NULL, NULL, &error)) {
 			fprintf (stderr, "%s\n", error);
@@ -2852,7 +2851,7 @@ gboolean ca_file_policy_set (guint64 ca_id, gchar *property_name, const gchar * 
 
 gint ca_file_policy_get_int (guint64 ca_id, gchar *property_name)
 {
-	gchar **row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE name='%s' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
+	gchar **row = __ca_file_get_single_row (ca_db, "SELECT value FROM ca_policies WHERE name='%q' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
 					      property_name, ca_id);
 
 	gint res;
@@ -2873,7 +2872,7 @@ gboolean ca_file_policy_set_int (guint64 ca_id, gchar *property_name, gint value
 	gchar *error = NULL;
 	gchar *sql = NULL;
 
-	aux = __ca_file_get_single_row (ca_db, "SELECT id, ca_id, name, value FROM ca_policies WHERE name='%s' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
+	aux = __ca_file_get_single_row (ca_db, "SELECT id, ca_id, name, value FROM ca_policies WHERE name='%q' AND ca_id=%"GNOMINT_GUINT64_FORMAT" ;", 
 				      property_name, ca_id);
 
 	if (! aux) {
@@ -2886,7 +2885,7 @@ gboolean ca_file_policy_set_int (guint64 ca_id, gchar *property_name, gint value
 		}
 	} else {
 		g_strfreev (aux);
-		sql = sqlite3_mprintf ("UPDATE ca_policies SET value='%d' WHERE ca_id=%"GNOMINT_GUINT64_FORMAT" AND name='%s';",
+		sql = sqlite3_mprintf ("UPDATE ca_policies SET value='%d' WHERE ca_id=%"GNOMINT_GUINT64_FORMAT" AND name='%q';",
 				       value, ca_id, property_name);
 		if (sqlite3_exec (ca_db, sql, NULL, NULL, &error)) {
 			fprintf (stderr, "%s\n", error);

--- a/src/certificate_properties.c
+++ b/src/certificate_properties.c
@@ -464,10 +464,10 @@ gchar * __certificate_properties_dump_key_usage(guint key_usage)
 void __certificate_properties_fill_cert_version(GnomintPropNode *parent, gnutls_x509_crt_t *certificate)
 {
 	gint result;
-	gchar value[4];
+	gchar value[16];
 
 	result = gnutls_x509_crt_get_version(*certificate);
-	sprintf(value, "v%d", result);
+	snprintf(value, sizeof(value), "v%d", result);
 
 	GnomintPropNode *child = gnomint_prop_node_new(_("Version"), value);
 	g_list_store_append(gnomint_prop_node_get_children(parent), child);

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <string.h>
 #include "dialog.h"
+#include "secure_wipe.h"
 
 
 #ifdef WIN32
@@ -109,6 +110,7 @@ gchar * dialog_get_password (gchar *info_message,
 
 	do {
 		if (res) {
+			gnomint_secure_wipe (res, strlen (res));
 			g_free (res);
 			res = NULL;
 		}
@@ -120,21 +122,22 @@ gchar * dialog_get_password (gchar *info_message,
 
 		res = g_strdup (password);
 		if (strlen (res) < minimum_length) {
-			fprintf (stderr, _("\nThe password must have, at least, %d characters\n"), minimum_length); 
+			gnomint_secure_wipe (password, strlen (password));
+			fprintf (stderr, _("\nThe password must have, at least, %d characters\n"), minimum_length);
 			continue;
 		}
-		memset (password, 0, strlen (res));
+		gnomint_secure_wipe (password, strlen (password));
 
 		password2 = getpass(confirm_message);
 
 		if (strcmp (res, password2)) {
 			fprintf (stderr, "\n%s\n", distinct_error_message);
-			memset (password, 0, strlen (password2));		
+			gnomint_secure_wipe (password2, strlen (password2));
 		}
 
 	} while (strlen (res) < minimum_length || strcmp (res, password2) );
 
-	memset (password, 0, strlen (password2));		
+	gnomint_secure_wipe (password2, strlen (password2));
 
 	return res;
 }
@@ -355,6 +358,7 @@ _dialog_get_password_response (GtkDialog *dialog,
 	passwordagain = gtk_editable_get_text (GTK_EDITABLE (widget));
 
 	if (strcmp (password, passwordagain)) {
+		gnomint_secure_wipe (password, strlen (password));
 		g_free (password);
 		dialog_error (ctx->distinct_error_message);
 		/* Re-present the dialog so the user can try again */

--- a/src/secure_wipe.h
+++ b/src/secure_wipe.h
@@ -1,0 +1,39 @@
+//  gnoMint: a graphical interface for managing a certification authority
+//  Copyright (C) 2006-2026 David Marín Carreño <davefx@gmail.com>
+//
+//  This file is part of gnoMint.
+//
+//  gnoMint is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+
+#ifndef _GNOMINT_SECURE_WIPE_H_
+#define _GNOMINT_SECURE_WIPE_H_
+
+#include <stddef.h>
+
+// Overwrite a buffer holding sensitive data (a password or private key) with
+// zeros in a way the compiler may not optimise away.
+//
+// A plain memset() to a buffer that is about to be freed is "dead" and can be
+// removed by the optimiser, leaving the secret in heap/stack memory (and
+// potentially in swap). Writing through a volatile pointer prevents that
+// elision and is portable to every platform gnoMint targets, including MinGW
+// (where explicit_bzero() is unavailable).
+static inline void gnomint_secure_wipe (void *buffer, size_t length)
+{
+	volatile unsigned char *p = (volatile unsigned char *) buffer;
+
+	if (!buffer)
+		return;
+	while (length--)
+		*p++ = 0;
+}
+
+#endif // _GNOMINT_SECURE_WIPE_H_

--- a/src/tls.c
+++ b/src/tls.c
@@ -32,6 +32,7 @@
 #include "uint160.h"
 #include "time64_check.h"
 #include "tls.h"
+#include <gnutls/crypto.h>   /* gnutls_rnd() for random serial numbers */
 
 void tls_init ()
 {
@@ -327,7 +328,6 @@ gchar * tls_generate_pkcs8_encrypted_private_key (gchar *pem_private_key, gchar 
 {
 	gnutls_datum_t pem_datum;
 	gchar *pkcs8_private_key = NULL;
-	size_t pkcs8_private_key_len = 0;
 	gnutls_x509_privkey_t key;
 
 	pem_datum.data = (unsigned char *) pem_private_key;
@@ -343,17 +343,24 @@ gchar * tls_generate_pkcs8_encrypted_private_key (gchar *pem_private_key, gchar 
 		return NULL;
 	}
 
-	/* Calculate pkcs8 length */
-	pkcs8_private_key = NULL;
-	gnutls_x509_privkey_export_pkcs8 (key, GNUTLS_X509_FMT_PEM, passphrase, GNUTLS_PKCS_USE_PKCS12_3DES, pkcs8_private_key, &pkcs8_private_key_len);
-
-	/* Save the private key to a PEM format */
-	pkcs8_private_key = g_new0 (gchar, pkcs8_private_key_len);	
-	if (gnutls_x509_privkey_export_pkcs8 (key, GNUTLS_X509_FMT_PEM, passphrase, GNUTLS_PKCS_USE_PKCS12_3DES, pkcs8_private_key, &pkcs8_private_key_len) < 0) {
+	/* Encrypt with PBES2 + AES-256 (PBKDF2) for the key at rest. GnuTLS
+	 * auto-detects the scheme on import, so keys written by older versions
+	 * with PKCS12-3DES still decrypt.
+	 *
+	 * We use the allocating export2 API rather than the two-call size-query
+	 * pattern: PBES2 embeds a freshly random salt/IV whose DER length can
+	 * differ between the size-query call and the write call, so a buffer
+	 * sized from the first call can be too short for the second (GnuTLS then
+	 * returns GNUTLS_E_SHORT_MEMORY_BUFFER). */
+	gnutls_datum_t out = { NULL, 0 };
+	if (gnutls_x509_privkey_export2_pkcs8 (key, GNUTLS_X509_FMT_PEM, passphrase,
+	                                       GNUTLS_PKCS_USE_PBES2_AES_256, &out) < 0) {
 		gnutls_x509_privkey_deinit (key);
 		return NULL;
 	}
 
+	pkcs8_private_key = g_strndup ((const gchar *) out.data, out.size);
+	gnutls_free (out.data);
 	gnutls_x509_privkey_deinit (key);
 
 	return pkcs8_private_key;
@@ -475,14 +482,17 @@ gnutls_datum_t * tls_generate_pkcs12 (gchar *pem_cert, gchar *pem_private_key, g
 		return NULL;
 	}
 
-	/* Calculate pkcs8 length */
+	/* Encrypt the private key with PBES2 + AES-256 into DER. The size-query
+	 * call only estimates the length; PBES2 embeds a freshly random salt/IV
+	 * whose DER encoding can be a few bytes longer on the actual write, so we
+	 * pad the buffer generously. The write call then sets the true length. */
 	pkcs8_private_key = g_new0 (gchar, 1);
-	gnutls_x509_privkey_export_pkcs8 (key, GNUTLS_X509_FMT_DER, passphrase, GNUTLS_PKCS_USE_PKCS12_3DES, pkcs8_private_key, &pkcs8_private_key_len);
+	gnutls_x509_privkey_export_pkcs8 (key, GNUTLS_X509_FMT_DER, passphrase, GNUTLS_PKCS_USE_PBES2_AES_256, pkcs8_private_key, &pkcs8_private_key_len);
 	g_free (pkcs8_private_key);
 
-	/* Save the private key to a DER format */
-	pkcs8_private_key = g_new0 (gchar, pkcs8_private_key_len);	
-	if (gnutls_x509_privkey_export_pkcs8 (key, GNUTLS_X509_FMT_DER, passphrase, GNUTLS_PKCS_USE_PKCS12_3DES, pkcs8_private_key, &pkcs8_private_key_len) < 0) {
+	pkcs8_private_key_len += 256;
+	pkcs8_private_key = g_new0 (gchar, pkcs8_private_key_len);
+	if (gnutls_x509_privkey_export_pkcs8 (key, GNUTLS_X509_FMT_DER, passphrase, GNUTLS_PKCS_USE_PBES2_AES_256, pkcs8_private_key, &pkcs8_private_key_len) < 0) {
 		gnutls_x509_privkey_deinit (key);
 		gnutls_x509_crt_deinit (crt);
 		return NULL;
@@ -636,8 +646,25 @@ gnutls_datum_t * tls_generate_pkcs12 (gchar *pem_cert, gchar *pem_private_key, g
         return pkcs12_datum;
 }
 
+gboolean tls_generate_random_serial (UInt160 *serial)
+{
+	/* Per CA/Browser Forum Baseline Requirements 7.1: a serial number must
+	 * contain at least 64 bits of output from a CSPRNG. We use 128 bits and
+	 * force the top byte into 0x40-0x7F so the value is a positive DER
+	 * INTEGER and keeps its full length (no leading-zero shrinkage). This
+	 * replaces the previous predictable sequential serials. */
+	guchar bytes[16];
 
-gchar * tls_generate_self_signed_certificate (TlsCreationData * creation_data, 
+	if (gnutls_rnd (GNUTLS_RND_RANDOM, bytes, sizeof (bytes)) < 0)
+		return FALSE;
+
+	bytes[0] = (bytes[0] & 0x7F) | 0x40;
+	uint160_read (serial, bytes, sizeof (bytes));
+	return TRUE;
+}
+
+
+gchar * tls_generate_self_signed_certificate (TlsCreationData * creation_data,
 					      gnutls_x509_privkey_t *key,
 					      gchar ** certificate)
 {
@@ -649,7 +676,10 @@ gchar * tls_generate_self_signed_certificate (TlsCreationData * creation_data,
 	size_t serialsize = 0;
 	size_t certificate_len = 0;
 
-	uint160_assign (sn, G_GUINT64_CONSTANT(1));
+	if (! tls_generate_random_serial (sn)) {
+		uint160_free (sn);
+		return g_strdup_printf(_("Error when generating the serial number"));
+	}
 
 	if (gnutls_x509_crt_init (&crt) < 0) {
                 uint160_free (sn);

--- a/src/tls.h
+++ b/src/tls.h
@@ -206,6 +206,11 @@ TlsCert * tls_parse_cert_pem (const char * pem_certificate);
 gboolean tls_cert_pem_get_validity (const gchar *pem_certificate,
                                     gint64 *activation, gint64 *expiration);
 
+/* Fills `serial` with a cryptographically random serial number (128 bits of
+ * CSPRNG entropy, positive DER INTEGER) per CA/Browser Forum BR 7.1, replacing
+ * predictable sequential serials. Returns FALSE if the CSPRNG fails. */
+gboolean tls_generate_random_serial (UInt160 *serial);
+
 gboolean tls_is_ca_pem (const char * pem_certificate);
 void tls_cert_free (TlsCert *);
 


### PR DESCRIPTION
A security pass over the CA core. **No database migration is required** — old databases open unchanged, existing serials and 3DES-encrypted keys keep working (GnuTLS auto-detects the key-encryption scheme on import).

## Fixes
1. **Random serial numbers** (was predictable sequential: root = 1, then `uint160_inc`). New `tls_generate_random_serial()` draws **128 bits from `gnutls_rnd(GNUTLS_RND_RANDOM)`**, top byte forced positive — per CA/Browser Forum BR 7.1 (≥64 bits CSPRNG entropy). Keeps the optional dup-check; legacy `ca_last_assigned_serial` row left intact (no schema change).
2. **AES-256 key encryption at rest** (was PKCS12-3DES) → **PBES2 + PBKDF2(SHA-256) + AES-256-CBC**. Uses the allocating `export2_pkcs8` API (PBES2's random salt/IV makes the old two-call size-query pattern fail with `GNUTLS_E_SHORT_MEMORY_BUFFER`).
3. **Secure wiping** of password buffers — portable `gnomint_secure_wipe()` (volatile, non-elidable) instead of an optimisable `memset`.
4. **SQL hardening**: `name='%s'` → `name='%q'` (not exploitable — internal constants — but the correct idiom).
5. `sprintf` → `snprintf` for the version string.

## Verification
- Signing in an **existing** DB still works (old key decrypts, new cert gets a random 128-bit serial) — backward compatibility confirmed.
- Exported keys confirmed **`PBES2 + aes-256-cbc`** via `openssl asn1parse`.
- **ASan+UBSan** over the parsing/crypto/passphrase tests: **0 hits**.
- Full suite green on **amd64 and i386**.

Also clean from the recon (no action needed): no format-string bugs (dialog uses `%s`), no command injection, no insecure temp files, no `strcpy`/`strcat`/`gets`, SHA-512 signing.

Follow-ups noted for later: fuzz the import parser, review the `pkey_manage.c` DB-master AES layer, add a sanitizer CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)