### PR TITLE
Windows: hide the console window behind the GUI (-mwindows)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,16 +149,22 @@ LIBS=$old_LIBS
 
 AC_SUBST(READLINE_LIBS)
 
-# On Windows (MinGW), inet_pton/inet_ntop live in ws2_32
+# On Windows (MinGW), inet_pton/inet_ntop live in ws2_32.
+# Also link the GUI (only) with -mwindows so it gets the "Windows GUI"
+# PE subsystem and Windows does not open a console window behind it when
+# launched from the Start menu. gnomint-cli must stay a console program.
 case "$host_os" in
   mingw*|msys*|cygwin*)
     WINSOCK_LIBS="-lws2_32"
+    GUI_SUBSYSTEM_LDFLAGS="-mwindows"
     ;;
   *)
     WINSOCK_LIBS=""
+    GUI_SUBSYSTEM_LDFLAGS=""
     ;;
 esac
 AC_SUBST(WINSOCK_LIBS)
+AC_SUBST(GUI_SUBSYSTEM_LDFLAGS)
 
 PKG_CHECK_MODULES(GNOMINTCLI, 
 	glib-2.0 >= $GLIB_REQUIRED \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,7 +66,8 @@ gnomint_LDADD = \
 	$(LTLIBINTL)
 
 gnomint_LDFLAGS = \
-	-export-dynamic
+	-export-dynamic \
+	$(GUI_SUBSYSTEM_LDFLAGS)
 
 
 


### PR DESCRIPTION
Launching gnoMint from the Windows Start menu popped up a console window behind the GUI, because `gnomint.exe` was built as a console-subsystem binary (no `-mwindows`).

Link the **GUI only** with `-mwindows` so it gets the "Windows GUI" PE subsystem and Windows attaches no console. `gnomint-cli` stays a console program (it needs the console for its readline shell). The flag is set per-host in `configure.ac` (`mingw*|msys*|cygwin*` only) and applied via `$(GUI_SUBSYSTEM_LDFLAGS)` on the `gnomint` target, so the Linux/macOS builds are unchanged.

Verification: CI will build the MSI; I'll confirm via `objdump -p` that `gnomint.exe`'s subsystem is "Windows GUI" while `gnomint-cli.exe` stays "console", and re-run under Wine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)