### PR TITLE
docs: correct stale GTK 3 references and the Y2K38 description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Layered roughly bottom-up:
 
 ## Conventions worth knowing
 
-- **Y2K38**: `configure.ac` defines `_TIME_BITS=64` and `_FILE_OFFSET_BITS=64` so `time_t` is 64-bit even on 32-bit hosts. Certificate validity periods reach well past 2038. Don't introduce `int`/`long` truncation when handling `time_t`; the codebase explicitly supports far-future expirations.
+- **Y2K38**: gnoMint relies on the platform's native 64-bit `time_t`. `configure.ac` defines `_FILE_OFFSET_BITS=64` but deliberately does **not** force `_TIME_BITS=64` — that glibc ABI switch must match every linked library, and forcing it only in gnoMint corrupted the GnuTLS ABI on i386 (issue #86). A conditional static assertion in `src/time64_check.h` checks 64-bit `time_t` only where it is the ABI. On 32-bit-`time_t` platforms (i386) gnoMint warns and clamps new CA expiry to 2038 and still displays stored post-2038 dates. Certificate validity periods reach well past 2038; don't introduce `int`/`long` truncation when handling `time_t`.
 - **Default DB location**: `gnomint-cli` stores the default CA DB at `$XDG_DATA_HOME/gnomint/default.gnomint` (typically `~/.local/share/gnomint/default.gnomint`) and migrates from the legacy `~/.gnomint/default.gnomint` on first run. The GUI uses the same convention.
 - **i18n**: gettext via `intltool`; supported locales are listed as `ALL_LINGUAS` in `configure.ac`. Translations live in `po/`. New user-visible strings should be wrapped in `_()`.
 - **MIME type**: registered as `application/x-gnomint` (see `mime/`); used for the GUI's recent-files filter.

--- a/README
+++ b/README
@@ -42,7 +42,7 @@ Two binaries
 
 The build produces two binaries from a shared source tree:
 
-    gnomint       The GTK 3 desktop application.
+    gnomint       The GTK 4 desktop application.
     gnomint-cli   A readline CLI with the same capabilities. Use it
                   in cron jobs, CI pipelines, and anywhere a script
                   is more convenient than clicking.

--- a/README
+++ b/README
@@ -50,18 +50,28 @@ The build produces two binaries from a shared source tree:
 Year 2038 (Y2K38) Support
 -------------------------
 
-gnoMint is designed to handle certificates with expiration dates beyond
-January 19, 2038 (the Year 2038 problem). The application uses 64-bit
-time_t values to ensure proper handling of dates far into the future.
+gnoMint handles certificates whose validity extends past the Year 2038
+boundary (2038-01-19 03:14:07 UTC, where a signed 32-bit time_t
+overflows), so CAs and certificates with multi-decade lifetimes work
+correctly.
 
-The following measures have been implemented:
-- Compile-time flags (_TIME_BITS=64, _FILE_OFFSET_BITS=64) to ensure
-  64-bit time_t even on 32-bit systems
-- Static assertions to verify time_t is 64-bit at compile time
-- Support for certificate expiration dates well beyond 2038
+How it works:
+- gnoMint relies on the platform's native 64-bit time_t. It defines
+  _FILE_OFFSET_BITS=64 but deliberately does NOT force _TIME_BITS=64:
+  that is a glibc ABI switch which must match every linked library, and
+  forcing it only in gnoMint corrupted the GnuTLS ABI (see issue #86).
+  Modern targets — amd64, and 32-bit ports such as armhf — already
+  provide a 64-bit time_t through the toolchain.
+- A conditional compile-time assertion (src/time64_check.h) verifies
+  time_t really is 64-bit wherever 64-bit time_t is the ABI.
+- On legacy 32-bit-time_t platforms such as i386, where the distribution
+  keeps time_t at 32 bits for binary compatibility, gnoMint does not
+  force a mismatched ABI. Instead it warns and clamps a new CA's
+  expiration to the 2038 limit, while still correctly displaying any
+  post-2038 dates already stored in a database.
 
-This ensures gnoMint can safely create and manage certificates with
-validity periods extending decades into the future.
+On any platform with a 64-bit time_t, gnoMint can safely issue and
+manage certificates with validity periods reaching decades past 2038.
 
 Issues and patches
 ------------------

--- a/docs/features.md
+++ b/docs/features.md
@@ -130,11 +130,17 @@ GSettings) lets you collapse expired branches out of the tree.
 ## Y2K38 safety
 
 Certificate validity periods routinely run 10, 20 or 30 years out, well
-past the 2038 wraparound point for 32-bit `time_t`. gnoMint forces
-`_TIME_BITS=64` and `_FILE_OFFSET_BITS=64` at configure time, includes a
-compile-time static assertion that `sizeof(time_t) == 8`, and ships a
-standalone `test_y2k38` harness. You can confidently issue 50-year
-certificates without underflow surprises.
+past the 2038 wraparound point for 32-bit `time_t`. gnoMint relies on the
+platform's native 64-bit `time_t`: it sets `_FILE_OFFSET_BITS=64` but
+deliberately does **not** force `_TIME_BITS=64`, a glibc ABI switch that
+must match every linked library — forcing it only in gnoMint corrupted
+the GnuTLS ABI on i386 (issue #86). A conditional compile-time assertion
+in `src/time64_check.h` verifies `sizeof(time_t) == 8` wherever 64-bit
+`time_t` is the ABI, and a standalone `test_y2k38` harness exercises the
+logic. On any platform with a 64-bit `time_t` you can confidently issue
+50-year certificates; on legacy 32-bit-`time_t` platforms such as i386,
+gnoMint warns and clamps a new certificate's expiry to the 2038 limit
+while still displaying post-2038 dates already stored in a database.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ a matching readline CLI for scripting and CI.
 
 ![gnoMint main window]({{ site.baseurl }}/assets/screenshots/main-window.png)
 
-gnoMint is a GTK 3 application (with a parallel `gnomint-cli` readline
+gnoMint is a GTK 4 application (with a parallel `gnomint-cli` readline
 front-end) that lets you bootstrap a Certificate Authority, issue and
 revoke certificates, manage CSRs, publish CRLs, and import/export keys
 and PKCS#12 bundles — all stored in a self-contained SQLite database
@@ -32,7 +32,7 @@ file you can carry around or back up like any other document.
 | **Key algorithms** | RSA, DSA, ECDSA (P-256/P-384/P-521), Ed25519 |
 | **Standards** | X.509, PKCS#8, PKCS#10 CSRs, PKCS#12 bundles, X.509 CRLs |
 | **Extensions** | Subject Alternative Names (SAN), Extended Key Usage, Basic Constraints |
-| **Interfaces** | GTK 3 desktop GUI and `gnomint-cli` readline shell |
+| **Interfaces** | GTK 4 desktop GUI and `gnomint-cli` readline shell |
 | **Workflows** | New CA, sign CSR, revoke, renew, bulk-revoke, full-chain export |
 | **Lifetime safety** | 64-bit `time_t` everywhere — Y2K38-safe certificates |
 


### PR DESCRIPTION
Documentation accuracy fixes. Two inaccuracies were each repeated across several files.

## GTK version (GTK 4 since 1.6.0, docs said "GTK 3")
- `README` — "The GTK 4 desktop application"
- `docs/index.md` — intro line and the "At a glance" table
- Left `docs/releases.md` as-is: its "current GTK 3 screenshots" line is inside the 1.4.0 release history (pre-GTK-4-migration), so it's historically accurate.

## Y2K38 description (described the opposite of the code)
`README`, `CLAUDE.md`, and `docs/features.md` all claimed gnoMint forces `_TIME_BITS=64` and asserts a 64-bit `time_t` unconditionally. In fact:
- `configure.ac` defines only `_FILE_OFFSET_BITS=64` and **deliberately does not** force `_TIME_BITS=64` — forcing it only in gnoMint corrupted the GnuTLS ABI on i386 (issue #86).
- The `src/time64_check.h` static assertion is **conditional** (`#if _TIME_BITS == 64`).
- On 32-bit-`time_t` platforms (i386), gnoMint **warns and clamps** new CA expiry to the 2038 limit (`ca-cli-callbacks.c`) and still displays stored post-2038 dates.

All three corrected to match the implementation.

Docs-only change (no code, no build impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)